### PR TITLE
fix(ui): activity detail layout, cover image tab, dashboard chart spa…

### DIFF
--- a/frontend/app/[locale]/(portal)/activities/[id]/page.tsx
+++ b/frontend/app/[locale]/(portal)/activities/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/features/activities/hooks/use-activities";
 import { useEligibility, useMyRegistrations } from "@/features/activities/hooks/use-registrations";
 import { ActivityDetailSection } from "@/features/activities/components/activity-detail-section";
+import { ActivityCoverImage } from "@/features/activities/components/activity-cover-image";
 import { ActivityEditForm } from "@/features/activities/components/activity-edit-form";
 import { ModalitiesTab } from "@/features/activities/components/modalities-tab";
 import { PricesTab } from "@/features/activities/components/prices-tab";
@@ -188,7 +189,7 @@ export default function ActivityDetailPage({
           onEdit={() => setIsEditing(true)}
           onCancel={() => setIsEditing(false)}
           canEdit={isAdmin}
-          readContent={<ActivityDetailSection activity={activity} showCoverImage />}
+          readContent={<ActivityDetailSection activity={activity} />}
           editContent={
             <ActivityEditForm
               activity={activity}
@@ -261,6 +262,11 @@ export default function ActivityDetailPage({
                   id: "attachments",
                   label: t("activities.attachments.title"),
                   content: <AttachmentTypesTab activityId={activityId} />,
+                },
+                {
+                  id: "coverImage",
+                  label: t("activities.coverImage.tab"),
+                  content: <ActivityCoverImage activity={activity} isAdmin />,
                 },
               ]
             : [

--- a/frontend/app/[locale]/(portal)/dashboard/page.tsx
+++ b/frontend/app/[locale]/(portal)/dashboard/page.tsx
@@ -65,6 +65,11 @@ interface ChartItem {
   color: string;
 }
 
+// Uniform chart height so paired charts in a grid row always match. A vertical
+// bar chart spreads its category bands evenly across this height, so sparse
+// charts (4 statuses) leave no trailing dead space.
+const CHART_HEIGHT = 5 * 32 + 8;
+
 function StatusBarChart({
   data,
   title,
@@ -89,7 +94,7 @@ function StatusBarChart({
             —
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height={5 * 32 + 8}>
+          <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
             <BarChart
               data={data}
               layout="vertical"
@@ -221,7 +226,7 @@ function NextBillingRunCard() {
   }
 
   return (
-    <Link href="/billing-runs">
+    <Link href="/billing-runs" className="block">
       <Card className="hover:bg-accent/50 transition-colors">
         <CardContent className="flex items-center gap-3 py-3 px-4">
           <CalendarClock className="size-5 shrink-0 text-muted-foreground" />

--- a/frontend/features/activities/components/activity-detail-section.tsx
+++ b/frontend/features/activities/components/activity-detail-section.tsx
@@ -2,7 +2,6 @@
 
 import { useTranslations } from "next-intl";
 import { DetailSection } from "@/components/entity/detail-section";
-import { ActivityCoverImage } from "./activity-cover-image";
 import type { ActivityData } from "../services/activities-api";
 
 function formatDate(iso: string) {
@@ -17,20 +16,19 @@ function formatDate(iso: string) {
 
 interface ActivityDetailSectionProps {
   activity: ActivityData;
-  showCoverImage?: boolean;
 }
 
-export function ActivityDetailSection({ activity, showCoverImage }: ActivityDetailSectionProps) {
+export function ActivityDetailSection({ activity }: ActivityDetailSectionProps) {
   const t = useTranslations();
 
   const fields = [
     { label: t("activities.name"), value: activity.name },
-    { label: t("activities.slug"), value: activity.slug, inline: true },
+    { label: t("activities.slug"), value: activity.slug },
     { label: t("activities.shortDescription"), value: activity.short_description },
-    { label: t("activities.startsAt"), value: formatDate(activity.starts_at), inline: true },
-    { label: t("activities.endsAt"), value: formatDate(activity.ends_at), inline: true },
-    { label: t("activities.registrationStartsAt"), value: formatDate(activity.registration_starts_at), inline: true },
-    { label: t("activities.registrationEndsAt"), value: formatDate(activity.registration_ends_at), inline: true },
+    { label: t("activities.startsAt"), value: formatDate(activity.starts_at) },
+    { label: t("activities.endsAt"), value: formatDate(activity.ends_at) },
+    { label: t("activities.registrationStartsAt"), value: formatDate(activity.registration_starts_at) },
+    { label: t("activities.registrationEndsAt"), value: formatDate(activity.registration_ends_at) },
     { label: t("activities.location"), value: activity.location },
     { label: t("activities.locationDetails"), value: activity.location_details },
     { label: t("activities.minParticipants"), value: activity.min_participants, inline: true },
@@ -43,19 +41,12 @@ export function ActivityDetailSection({ activity, showCoverImage }: ActivityDeta
   ];
 
   return (
-    <div className="flex gap-4">
-      <div className="flex-1 min-w-0">
-        <DetailSection fields={fields} columns={3} />
-        {activity.description && (
-          <div className="mt-2">
-            <dt className="text-xs text-muted-foreground">{t("activities.description")}</dt>
-            <dd className="mt-0.5 text-sm whitespace-pre-wrap">{activity.description}</dd>
-          </div>
-        )}
-      </div>
-      {showCoverImage && (
-        <div className="hidden lg:block w-64 shrink-0">
-          <ActivityCoverImage activity={activity} isAdmin />
+    <div className="min-w-0">
+      <DetailSection fields={fields} columns={3} />
+      {activity.description && (
+        <div className="mt-2">
+          <dt className="text-xs text-muted-foreground">{t("activities.description")}</dt>
+          <dd className="mt-0.5 text-sm whitespace-pre-wrap">{activity.description}</dd>
         </div>
       )}
     </div>

--- a/frontend/locales/ca/activities.json
+++ b/frontend/locales/ca/activities.json
@@ -129,6 +129,7 @@
     },
     "coverImage": {
       "title": "Imatge de portada",
+      "tab": "Imatge",
       "upload": "Canviar imatge",
       "remove": "Eliminar",
       "dragOrClick": "Fes clic per pujar una imatge de portada",

--- a/frontend/locales/en/activities.json
+++ b/frontend/locales/en/activities.json
@@ -129,6 +129,7 @@
     },
     "coverImage": {
       "title": "Cover Image",
+      "tab": "Image",
       "upload": "Change Image",
       "remove": "Remove",
       "dragOrClick": "Click to upload a cover image",

--- a/frontend/locales/es/activities.json
+++ b/frontend/locales/es/activities.json
@@ -129,6 +129,7 @@
     },
     "coverImage": {
       "title": "Imagen de portada",
+      "tab": "Imagen",
       "upload": "Cambiar imagen",
       "remove": "Eliminar",
       "dragOrClick": "Haz clic para subir una imagen de portada",


### PR DESCRIPTION

- Activity detail: render slug + date field values below their labels instead of inline-right (values exceed 5 chars), matching the rest of the section.
- Move the activity cover image from a side column into a dedicated admin-only "Image" tab; drop the showCoverImage prop. Add coverImage.tab i18n key (es/ca/en).
- Dashboard: use a uniform chart height so paired charts in a grid row always match, and make the "Next recurring billing" card link block-level so the column gap below it no longer collapses (was colliding with the Members/Activities row).