### PR TITLE
ci: trigger CI + image build on frontend changes; add frontend checks

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -23,11 +23,48 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  version:
+  changes:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 2
+
+      - name: Detect changed images
+        id: filter
+        run: |
+          # Manual dispatch rebuilds everything.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED="$(git diff --name-only HEAD~1 HEAD)"
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          backend=false
+          frontend=false
+          # A VERSION bump (release) rebuilds both images.
+          if echo "$CHANGED" | grep -qE '^(backend/|VERSION$)'; then backend=true; fi
+          if echo "$CHANGED" | grep -qE '^(frontend/|VERSION$)'; then frontend=true; fi
+
+          echo "backend=$backend" >> "$GITHUB_OUTPUT"
+          echo "frontend=$frontend" >> "$GITHUB_OUTPUT"
+          echo "Build backend: $backend | Build frontend: $frontend"
+
+  version:
+    needs: changes
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -55,7 +92,8 @@ jobs:
           echo "Version: $VERSION"
 
   build-backend:
-    needs: version
+    needs: [changes, version]
+    if: ${{ needs.changes.outputs.backend == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -88,7 +126,8 @@ jobs:
           docker push $IMAGE:latest
 
   build-frontend:
-    needs: version
+    needs: [changes, version]
+    if: ${{ needs.changes.outputs.frontend == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -121,6 +160,7 @@ jobs:
 
   finalize:
     needs: [version, build-backend, build-frontend]
+    if: ${{ always() && (needs.build-backend.result == 'success' || needs.build-frontend.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Build Summary
@@ -129,8 +169,12 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Service | Image |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Backend | \`ghcr.io/${{ github.repository_owner }}/memship-backend:${{ needs.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend | \`ghcr.io/${{ github.repository_owner }}/memship-frontend:${{ needs.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ needs.build-backend.result }}" == "success" ]]; then
+            echo "| Backend | \`ghcr.io/${{ github.repository_owner }}/memship-backend:${{ needs.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [[ "${{ needs.build-frontend.result }}" == "success" ]]; then
+            echo "| Frontend | \`ghcr.io/${{ github.repository_owner }}/memship-frontend:${{ needs.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          fi
 
   ci-failed:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 # Continuous Integration
-# Runs backend tests on push to main and PRs
+# Runs backend tests and frontend checks on push to main and PRs.
+# Each suite only runs when its own paths changed (see the `changes` job).
 #
 name: CI
 
@@ -9,6 +10,7 @@ on:
       - main
     paths:
       - 'backend/**'
+      - 'frontend/**'
       - 'VERSION'
       - '.github/workflows/ci.yml'
   pull_request:
@@ -16,11 +18,37 @@ on:
       - main
     paths:
       - 'backend/**'
+      - 'frontend/**'
+      - 'VERSION'
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'VERSION'
+            frontend:
+              - 'frontend/**'
+              - 'VERSION'
+
   unit:
     name: Unit Tests
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -52,6 +80,8 @@ jobs:
 
   integration:
     name: Integration Tests
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
 
     services:
@@ -107,3 +137,32 @@ jobs:
           else
             echo "Tests failed." >> $GITHUB_STEP_SUMMARY
           fi
+
+  frontend:
+    name: Frontend Checks
+    needs: changes
+    if: ${{ needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable pnpm
+        run: corepack enable && corepack prepare pnpm@10.29.3 --activate
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        working-directory: frontend
+        run: pnpm lint
+
+      - name: Type check
+        working-directory: frontend
+        run: pnpm exec tsc --noEmit


### PR DESCRIPTION
## Summary

Fixes the gap found after merging #1: a **frontend-only change ran no CI and never rebuilt the frontend image**.

Root cause: `ci.yml` only triggered on `backend/**`/`VERSION` paths, and `build-images.yml` chains off CI via `workflow_run` — so frontend-only commits never started the pipeline, and the existing `build-frontend` job was unreachable.

## Changes

### `ci.yml`
- Trigger on `frontend/**` in addition to `backend/**` / `VERSION`.
- New `changes` job (`dorny/paths-filter`) → backend tests run only when backend changed; new **`frontend`** job (pnpm install → `lint` → `tsc --noEmit`) runs only when frontend changed. No wasted backend runs on frontend-only PRs.

### `build-images.yml`
- New `changes` job (git diff of the merged commit) so `build-backend` and `build-frontend` each rebuild **only when their own code changed**.
- A `VERSION` bump (release) or manual `workflow_dispatch` still rebuilds **both** images.
- `finalize` lists only the images actually built.
- This avoids redundant cross-image rebuilds (previously any CI success rebuilt both images).

## Behaviour matrix

| Change | CI runs | Images rebuilt |
|---|---|---|
| backend only | unit + integration | backend |
| frontend only | frontend (lint + tsc) | frontend |
| VERSION bump (release) | both suites | backend + frontend |
| manual dispatch | (n/a) | backend + frontend |

## Notes
- No version bump — `VERSION` stays `0.4.5`.
- Verified: both workflow YAMLs parse and the job graph is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
