### PR TITLE
ci: add Redis service to integration job (fixes ~9min runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      # Celery broker. Several endpoints fire a fire-and-forget task.delay() in
+      # the request path; without a reachable broker each call blocks ~19s on a
+      # connection retry before the error is swallowed, inflating the suite from
+      # ~1min to ~9min. CELERY_BROKER_URL defaults to redis://localhost:6379/0.
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

The **Integration Tests** CI job was taking **~9 minutes**; the same suite runs in **~12s locally**. Root cause: the job only provisions a `postgres` service — **no Redis broker**.

Several endpoints fire a fire-and-forget Celery `task.delay()` in the request path (registration emails, announcement send, receipt emails). It's wrapped in try/except so a missing broker is "handled" — but each call first blocks **~19s** on a broker connection retry before the exception is swallowed. Across the many tests that hit such a path, on 2 xdist workers, that adds up to ~9 minutes of idle waiting. Locally it's fast only because `memship-redis` is running.

## Fix

Add a `redis:7-alpine` service to the `integration` job. `.delay()` then enqueues instantly (no worker consumes the tasks; they're discarded when the job ends). `CELERY_BROKER_URL` already defaults to `redis://localhost:6379/0`, so no env change is needed.

## Evidence

Same test, only the broker differs:

| Broker | Time |
|---|---|
| Dead (no Redis, like CI today) | **19.37s** |
| Live (Redis up, like local) | **0.33s** |

Expected effect: integration job drops from ~9min back toward ~1–2min.

## Notes
- No version bump — `VERSION` stays `0.4.5`.
- Alternative considered: Celery eager mode in tests (no service needed) — rejected to keep task execution semantics production-faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
