### PR TITLE
feat(communications): v0.5.1 sent view + recipient tracking

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -27,7 +27,11 @@ from app.domains.billing.models import (  # noqa: F401
     Receipt,
     WebhookEvent,
 )
-from app.domains.communications.models import Announcement, Notification  # noqa: F401
+from app.domains.communications.models import (  # noqa: F401
+    Announcement,
+    AnnouncementRecipient,
+    Notification,
+)
 
 config = context.config
 

--- a/backend/alembic/versions/e1f2a3b4c5d6_add_announcement_recipients.py
+++ b/backend/alembic/versions/e1f2a3b4c5d6_add_announcement_recipients.py
@@ -1,0 +1,44 @@
+"""add_announcement_recipients_table
+
+Revision ID: e1f2a3b4c5d6
+Revises: d8e9f0a1b2c3
+Create Date: 2026-07-02 10:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e1f2a3b4c5d6'
+down_revision: Union[str, None] = 'd8e9f0a1b2c3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'announcement_recipients',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('announcement_id', sa.Integer(), nullable=False),
+        sa.Column('member_id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('emailed', sa.Boolean(), nullable=False),
+        sa.Column('in_app', sa.Boolean(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['announcement_id'], ['announcements.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['member_id'], ['members.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'ix_announcement_recipients_announcement',
+        'announcement_recipients',
+        ['announcement_id'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_announcement_recipients_announcement', table_name='announcement_recipients')
+    op.drop_table('announcement_recipients')

--- a/backend/app/api/v1/endpoints/communications.py
+++ b/backend/app/api/v1/endpoints/communications.py
@@ -17,6 +17,8 @@ from app.domains.communications.schemas import (
     AnnouncementUpdate,
     MarkReadRequest,
     NotificationResponse,
+    RecipientResponse,
+    RecipientStatsResponse,
 )
 from app.domains.communications.service import (
     AnnouncementNotDraft,
@@ -141,6 +143,46 @@ def audience_preview(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Announcement not found")
     members = service.resolve_audience(db, ann.target_type, ann.target_id)
     return {"count": len(members)}
+
+
+@router.get("/{announcement_id}/recipients")
+def list_recipients(
+    announcement_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+):
+    """Paginated recipient list for a sent announcement (name, channel, seen)."""
+    ann = service.get_announcement(db, announcement_id)
+    if ann is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Announcement not found")
+    rows, meta = paginate(service.list_recipients(db, announcement_id), page, per_page)
+    items = [
+        RecipientResponse(
+            member_id=r.member_id,
+            name=f"{r.first_name} {r.last_name}".strip(),
+            email=r.email,
+            emailed=r.emailed,
+            in_app=r.in_app,
+            seen_at=r.read_at,
+        ).model_dump()
+        for r in rows
+    ]
+    return {"items": items, "meta": meta.model_dump()}
+
+
+@router.get("/{announcement_id}/stats")
+def recipient_stats(
+    announcement_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """Aggregate delivery stats (recipients / emailed / seen) for the sent view."""
+    ann = service.get_announcement(db, announcement_id)
+    if ann is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Announcement not found")
+    return RecipientStatsResponse(**service.recipient_stats(db, announcement_id)).model_dump()
 
 
 # --- Member: received announcements + in-app notifications ---

--- a/backend/app/domains/communications/models.py
+++ b/backend/app/domains/communications/models.py
@@ -73,3 +73,34 @@ class Notification(Base):
     excerpt = Column(String(280))  # short body preview for the list
     read_at = Column(DateTime(timezone=True))  # NULL = unread
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class AnnouncementRecipient(Base):
+    """Per-recipient delivery snapshot, written at send.
+
+    One row per member the announcement was sent to — the faithful record of the
+    audience at send time (membership changes afterwards must not alter it).
+    ``user_id`` is set only when the member has an account; it joins back to
+    ``notifications`` (source_type='announcement', source_id) for the read state
+    that drives the admin "Seen" badge. ``emailed`` mirrors the email opt-out.
+    """
+
+    __tablename__ = "announcement_recipients"
+    __table_args__ = (
+        Index("ix_announcement_recipients_announcement", "announcement_id"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    announcement_id = Column(
+        Integer,
+        ForeignKey("announcements.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    member_id = Column(
+        Integer, ForeignKey("members.id", ondelete="CASCADE"), nullable=False
+    )
+    # NULL when the member has no user account (email-only recipient).
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"))
+    emailed = Column(Boolean, nullable=False, default=False)  # email actually sent
+    in_app = Column(Boolean, nullable=False, default=False)  # notification row created
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/domains/communications/schemas.py
+++ b/backend/app/domains/communications/schemas.py
@@ -69,3 +69,19 @@ class NotificationResponse(BaseModel):
 class MarkReadRequest(BaseModel):
     ids: list[int] | None = None
     all: bool = False
+
+
+class RecipientResponse(BaseModel):
+    member_id: int
+    name: str
+    email: str | None = None
+    emailed: bool
+    in_app: bool
+    seen_at: datetime | None = None  # in-app read timestamp; None for email-only
+
+
+class RecipientStatsResponse(BaseModel):
+    recipient_count: int
+    emailed_count: int
+    seen_count: int
+    sent_by: str | None = None

--- a/backend/app/domains/communications/service.py
+++ b/backend/app/domains/communications/service.py
@@ -8,11 +8,16 @@ caller (endpoint / task) owns the transaction.
 
 from datetime import datetime, timezone
 
+from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from app.domains.auth.models import User
 from app.domains.communications.markdown import excerpt as build_excerpt
-from app.domains.communications.models import Announcement, Notification
+from app.domains.communications.models import (
+    Announcement,
+    AnnouncementRecipient,
+    Notification,
+)
 from app.domains.communications.schemas import (
     AnnouncementCreate,
     AnnouncementUpdate,
@@ -131,6 +136,33 @@ def send_announcement(
 
     ann.recipient_count = len(members)
     excerpt = build_excerpt(ann.body)
+
+    # Per-recipient delivery snapshot — the faithful audience record at send time.
+    # One query fetches persons to compute the email-reachability flag.
+    person_ids = [m.person_id for m in members]
+    persons = (
+        {p.id: p for p in db.query(Person).filter(Person.id.in_(person_ids)).all()}
+        if person_ids
+        else {}
+    )
+    for m in members:
+        prefs = m.communication_preferences or {}
+        person = persons.get(m.person_id)
+        emailed = (
+            prefs.get("email") is not False
+            and person is not None
+            and bool(person.email)
+        )
+        db.add(
+            AnnouncementRecipient(
+                announcement_id=ann.id,
+                member_id=m.id,
+                user_id=m.user_id,
+                emailed=emailed,
+                in_app=m.user_id is not None,
+            )
+        )
+
     # In-app notifications require a user account (email is the universal channel).
     user_ids = {m.user_id for m in members if m.user_id}
     for uid in user_ids:
@@ -164,6 +196,77 @@ def list_announcements(db: Session):
 
 def get_announcement(db: Session, announcement_id: int) -> Announcement | None:
     return _get_active(db, announcement_id)
+
+
+def _seen_join(announcement_id: int):
+    """Join condition linking a recipient's user to its announcement notification."""
+    return and_(
+        Notification.user_id == AnnouncementRecipient.user_id,
+        Notification.source_type == "announcement",
+        Notification.source_id == announcement_id,
+    )
+
+
+def list_recipients(db: Session, announcement_id: int):
+    """Recipient snapshot joined to member/person and the in-app read state.
+
+    Returns a query of rows (member_id, first_name, last_name, email, emailed,
+    in_app, read_at) ordered by name. ``read_at`` is the "Seen" timestamp and is
+    NULL for email-only recipients (no user account → no notification). Caller
+    paginates.
+    """
+    return (
+        db.query(
+            AnnouncementRecipient.member_id,
+            Person.first_name,
+            Person.last_name,
+            Person.email,
+            AnnouncementRecipient.emailed,
+            AnnouncementRecipient.in_app,
+            Notification.read_at,
+        )
+        .join(Member, Member.id == AnnouncementRecipient.member_id)
+        .join(Person, Person.id == Member.person_id)
+        .outerjoin(Notification, _seen_join(announcement_id))
+        .filter(AnnouncementRecipient.announcement_id == announcement_id)
+        .order_by(Person.last_name, Person.first_name, AnnouncementRecipient.member_id)
+    )
+
+
+def recipient_stats(db: Session, announcement_id: int) -> dict:
+    """Aggregate delivery stats for the sent view header/details tab."""
+    base = db.query(AnnouncementRecipient).filter(
+        AnnouncementRecipient.announcement_id == announcement_id
+    )
+    recipient_count = base.count()
+    emailed_count = base.filter(AnnouncementRecipient.emailed.is_(True)).count()
+    seen_count = (
+        db.query(AnnouncementRecipient)
+        .join(Notification, _seen_join(announcement_id))
+        .filter(
+            AnnouncementRecipient.announcement_id == announcement_id,
+            Notification.read_at.isnot(None),
+        )
+        .count()
+    )
+    return {
+        "recipient_count": recipient_count,
+        "emailed_count": emailed_count,
+        "seen_count": seen_count,
+        "sent_by": _announcement_author_name(db, announcement_id),
+    }
+
+
+def _announcement_author_name(db: Session, announcement_id: int) -> str | None:
+    """Display name of the admin who sent the announcement (via user→person)."""
+    row = (
+        db.query(Person.first_name, Person.last_name)
+        .join(User, User.person_id == Person.id)
+        .join(Announcement, Announcement.created_by_user_id == User.id)
+        .filter(Announcement.id == announcement_id)
+        .first()
+    )
+    return f"{row.first_name} {row.last_name}".strip() if row else None
 
 
 def member_announcements(db: Session, user: User) -> list[Announcement]:

--- a/backend/tests/integration/api/v1/test_communications.py
+++ b/backend/tests/integration/api/v1/test_communications.py
@@ -8,7 +8,11 @@ from app.core.security.jwt import create_access_token
 from app.core.security.password import hash_password
 from app.domains.auth.models import User
 from app.domains.communications import service
-from app.domains.communications.models import Announcement, Notification
+from app.domains.communications.models import (
+    Announcement,
+    AnnouncementRecipient,
+    Notification,
+)
 from app.domains.members.models import Group, Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
@@ -429,3 +433,144 @@ class TestNotifications:
         items = resp.json()
         assert len(items) == 1
         assert items[0]["subject"] == "News"
+
+
+# --- Recipient snapshot + sent view (v0.5.1) ---
+
+
+class TestRecipients:
+    def test_send_creates_recipient_snapshot(self, client, db):
+        admin = _create_user(db, "admin", "rs-a")
+        _ensure_org(db)
+        with_acct = _create_member(db, "rs-acct", with_user=True)
+        email_only = _create_member(db, "rs-email", with_user=False)
+        opted_out = _create_member(db, "rs-optout", with_user=True, opted_out=True)
+        ann = _draft(db, admin, target_type="all")
+        client.post(f"/api/v1/announcements/{ann.id}/send", cookies=_auth_cookie(admin))
+
+        recips = {
+            r.member_id: r
+            for r in db.query(AnnouncementRecipient).filter(
+                AnnouncementRecipient.announcement_id == ann.id
+            )
+        }
+        assert set(recips) == {with_acct.id, email_only.id, opted_out.id}
+        # Member with account: emailed + in-app.
+        assert recips[with_acct.id].emailed is True
+        assert recips[with_acct.id].in_app is True
+        # Email-only member: emailed, not in-app, no user_id.
+        assert recips[email_only.id].emailed is True
+        assert recips[email_only.id].in_app is False
+        assert recips[email_only.id].user_id is None
+        # Opted-out member: not emailed, but still in-app (has account).
+        assert recips[opted_out.id].emailed is False
+        assert recips[opted_out.id].in_app is True
+
+    def test_recipients_endpoint_lists_and_paginates(self, client, db):
+        admin = _create_user(db, "admin", "rl-a")
+        _ensure_org(db)
+        for i in range(3):
+            _create_member(db, f"rl{i}", with_user=(i % 2 == 0))
+        ann = _draft(db, admin, target_type="all")
+        client.post(f"/api/v1/announcements/{ann.id}/send", cookies=_auth_cookie(admin))
+
+        resp = client.get(
+            f"/api/v1/announcements/{ann.id}/recipients?page=1&per_page=2",
+            cookies=_auth_cookie(admin),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["meta"]["total"] == 3
+        assert body["meta"]["total_pages"] == 2
+        assert len(body["items"]) == 2
+        item = body["items"][0]
+        assert {"member_id", "name", "email", "emailed", "in_app", "seen_at"} <= item.keys()
+        # Not yet opened by anyone.
+        assert all(i["seen_at"] is None for i in body["items"])
+
+    def test_recipient_seen_reflects_read_at(self, client, db):
+        admin = _create_user(db, "admin", "rsn-a")
+        _ensure_org(db)
+        member = _create_member(db, "rsn1", with_user=True)
+        ann = _draft(db, admin, target_type="all")
+        client.post(f"/api/v1/announcements/{ann.id}/send", cookies=_auth_cookie(admin))
+
+        # Member opens it — marks the notification read.
+        member_user = db.query(User).filter(User.id == member.user_id).first()
+        client.post(
+            "/api/v1/me/notifications/mark-read",
+            json={"all": True},
+            cookies=_auth_cookie(member_user),
+        )
+
+        resp = client.get(
+            f"/api/v1/announcements/{ann.id}/recipients",
+            cookies=_auth_cookie(admin),
+        )
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["member_id"] == member.id
+        assert item["seen_at"] is not None
+
+    def test_email_only_recipient_never_seen(self, client, db):
+        admin = _create_user(db, "admin", "reo-a")
+        _ensure_org(db)
+        _create_member(db, "reo1", with_user=False)
+        ann = _draft(db, admin, target_type="all")
+        client.post(f"/api/v1/announcements/{ann.id}/send", cookies=_auth_cookie(admin))
+
+        resp = client.get(
+            f"/api/v1/announcements/{ann.id}/recipients",
+            cookies=_auth_cookie(admin),
+        )
+        item = resp.json()["items"][0]
+        assert item["in_app"] is False
+        assert item["seen_at"] is None
+
+    def test_stats_counts(self, client, db):
+        admin = _create_user(db, "admin", "st-a")
+        _ensure_org(db)
+        seen_member = _create_member(db, "st-seen", with_user=True)
+        _create_member(db, "st-unseen", with_user=True)
+        _create_member(db, "st-email", with_user=False)
+        _create_member(db, "st-optout", with_user=True, opted_out=True)
+        ann = _draft(db, admin, target_type="all")
+        client.post(f"/api/v1/announcements/{ann.id}/send", cookies=_auth_cookie(admin))
+
+        seen_user = db.query(User).filter(User.id == seen_member.user_id).first()
+        client.post(
+            "/api/v1/me/notifications/mark-read",
+            json={"all": True},
+            cookies=_auth_cookie(seen_user),
+        )
+
+        resp = client.get(
+            f"/api/v1/announcements/{ann.id}/stats", cookies=_auth_cookie(admin)
+        )
+        assert resp.status_code == 200
+        stats = resp.json()
+        assert stats["recipient_count"] == 4
+        assert stats["emailed_count"] == 3  # all but the opted-out member
+        assert stats["seen_count"] == 1
+        assert stats["sent_by"] == "Test User"  # from _create_user
+
+    def test_recipients_forbidden_for_member(self, client, db):
+        admin = _create_user(db, "admin", "rf-a")
+        member_user = _create_user(db, "member", "rf-m")
+        _ensure_org(db)
+        _create_member(db, "rf1", with_user=True)
+        ann = _draft(db, admin, target_type="all")
+        client.post(f"/api/v1/announcements/{ann.id}/send", cookies=_auth_cookie(admin))
+        resp = client.get(
+            f"/api/v1/announcements/{ann.id}/recipients",
+            cookies=_auth_cookie(member_user),
+        )
+        assert resp.status_code == 403
+
+    def test_recipients_404_for_missing(self, client, db):
+        admin = _create_user(db, "admin", "r404")
+        _ensure_org(db)
+        resp = client.get(
+            "/api/v1/announcements/999999/recipients", cookies=_auth_cookie(admin)
+        )
+        assert resp.status_code == 404

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -50,7 +50,11 @@ from app.domains.activities.models import (  # noqa: F401
 from app.domains.billing.models import (  # noqa: F401
     BillingRun, Concept, PaymentProvider, Receipt, Remittance, SepaMandate, WebhookEvent,
 )
-from app.domains.communications.models import Announcement, Notification  # noqa: F401
+from app.domains.communications.models import (  # noqa: F401
+    Announcement,
+    AnnouncementRecipient,
+    Notification,
+)
 
 # Use test database
 TEST_DATABASE_URL = os.getenv("DATABASE_TEST_URL", settings.DATABASE_TEST_URL)

--- a/e2e/cypress/e2e/communications/communications.cy.ts
+++ b/e2e/cypress/e2e/communications/communications.cy.ts
@@ -1,10 +1,12 @@
 // =============================================================================
-// Communications (v0.5.0) — admin compose/send, member notifications, RBAC
+// Communications (v0.5.0 + v0.5.1) — admin compose/send, member notifications,
+// RBAC, and the sent view (content header + details/recipients tabs).
 // =============================================================================
 
 const SUBJECT = "E2E Broadcast Announcement";
+const SUBJECT_DIRECT = "E2E Direct Send Announcement";
 
-describe("Communications (v0.5.0)", () => {
+describe("Communications (v0.5.0 + v0.5.1)", () => {
   before(() => {
     // Enable the module (persists in org settings) so nav, bell, and the
     // member announcements page are available for the rest of the suite.
@@ -46,9 +48,32 @@ describe("Communications (v0.5.0)", () => {
       cy.contains("button", "Send").click();
     });
 
-    // Back to history, listed as sent.
-    cy.url().should("match", /\/communications$/);
-    cy.contains("td", SUBJECT).should("be.visible");
+    // Lands on the sent view (content header + tabs), not the compose form.
+    cy.url().should("match", /\/communications\/\d+$/);
+    cy.contains(/recipients/i).should("be.visible");
+    cy.contains("button", "Save draft").should("not.exist");
+  });
+
+  it("composes and sends in one action from the new form (v0.5.1)", () => {
+    cy.loginAsAdmin();
+    cy.visit("/en/communications/new");
+
+    cy.get('input[maxlength="200"]').type(SUBJECT_DIRECT);
+    cy.get("textarea").type("Direct one-shot send — no intermediate draft step.");
+    // Send is available immediately on the new form (no prior Save draft).
+    cy.contains("button", "Send").click();
+    cy.get('[role="dialog"]').within(() => {
+      cy.contains(/send announcement\?/i).should("be.visible");
+      cy.contains("button", "Send").click();
+    });
+
+    // Created + sent in one go → sent view.
+    cy.url().should("match", /\/communications\/\d+$/);
+    cy.contains(/recipients/i).should("be.visible");
+
+    // And it shows up as sent in the history.
+    cy.visit("/en/communications");
+    cy.contains("td", SUBJECT_DIRECT).should("be.visible");
     cy.contains("Sent").should("be.visible");
   });
 
@@ -79,12 +104,23 @@ describe("Communications (v0.5.0)", () => {
     cy.url().should("include", "/dashboard");
   });
 
-  it("renders a sent announcement read-only (no Save draft / Send)", () => {
+  it("shows the sent view: content header, details, and a lazy recipients tab (v0.5.1)", () => {
     cy.loginAsAdmin();
     cy.visit("/en/communications");
     cy.contains("td", SUBJECT).click();
     cy.url().should("match", /\/communications\/\d+$/);
+
+    // Sent view, not the compose form.
     cy.contains("button", "Save draft").should("not.exist");
-    cy.contains("Sent").should("be.visible");
+    // Content header summary line.
+    cy.contains(/recipients/i).should("be.visible");
+    // Details tab is the default; shows delivery metadata.
+    cy.contains(/Sent by/i).should("be.visible");
+
+    // Recipients tab loads on demand and lists the audience in a paginated table
+    // with a Seen column (read state per recipient).
+    cy.contains('[role="tab"]', "Recipients").click();
+    cy.get("table tbody tr").should("have.length.greaterThan", 0);
+    cy.contains("th", "Seen").should("be.visible");
   });
 });

--- a/frontend/app/[locale]/(portal)/communications/[id]/page.tsx
+++ b/frontend/app/[locale]/(portal)/communications/[id]/page.tsx
@@ -6,6 +6,7 @@ import { DetailHeader } from "@/components/entity/detail-header";
 import { DetailSkeleton } from "@/components/ui/skeletons";
 import { useAuth } from "@/features/auth/hooks/use-auth";
 import { AnnouncementForm } from "@/features/communications/components/announcement-form";
+import { SentAnnouncementView } from "@/features/communications/components/sent-announcement-view";
 import { useAnnouncement } from "@/features/communications/hooks/use-announcements";
 
 export default function AnnouncementDetailPage({
@@ -46,7 +47,11 @@ export default function AnnouncementDetailPage({
         ]}
         title={announcement.subject}
       />
-      <AnnouncementForm announcement={announcement} />
+      {announcement.status === "sent" ? (
+        <SentAnnouncementView announcement={announcement} />
+      ) : (
+        <AnnouncementForm announcement={announcement} />
+      )}
     </div>
   );
 }

--- a/frontend/app/api/announcements/[id]/recipients/route.ts
+++ b/frontend/app/api/announcements/[id]/recipients/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8003";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const cookie = request.headers.get("cookie") || "";
+  const search = request.nextUrl.search;
+  const res = await fetch(
+    `${API_BASE_URL}/api/v1/announcements/${id}/recipients${search}`,
+    { headers: { Cookie: cookie } }
+  );
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/frontend/app/api/announcements/[id]/stats/route.ts
+++ b/frontend/app/api/announcements/[id]/stats/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8003";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const cookie = request.headers.get("cookie") || "";
+  const res = await fetch(`${API_BASE_URL}/api/v1/announcements/${id}/stats`, {
+    headers: { Cookie: cookie },
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/frontend/components/entity/entity-tabs.tsx
+++ b/frontend/components/entity/entity-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -14,13 +14,32 @@ interface EntityTab {
 interface EntityTabsProps {
   tabs: EntityTab[];
   defaultTab?: string;
+  /**
+   * When true, a tab's content is mounted only after the tab is first
+   * activated (and stays mounted afterwards). Use for tabs whose content
+   * triggers on-demand data fetching that shouldn't fire on page load.
+   */
+  lazy?: boolean;
 }
 
-export function EntityTabs({ tabs, defaultTab }: EntityTabsProps) {
+export function EntityTabs({ tabs, defaultTab, lazy = false }: EntityTabsProps) {
+  const initial = defaultTab || tabs[0]?.id;
+  // Track which tabs have been opened so lazy content mounts once and persists.
+  const [visited, setVisited] = useState<Set<string>>(
+    () => new Set(initial ? [initial] : [])
+  );
+
   if (tabs.length === 0) return null;
 
   return (
-    <Tabs defaultValue={defaultTab || tabs[0].id}>
+    <Tabs
+      defaultValue={initial}
+      onValueChange={(value) =>
+        setVisited((prev) =>
+          prev.has(value) ? prev : new Set(prev).add(value)
+        )
+      }
+    >
       <TabsList>
         {tabs.map((tab) => (
           <TabsTrigger key={tab.id} value={tab.id}>
@@ -35,7 +54,7 @@ export function EntityTabs({ tabs, defaultTab }: EntityTabsProps) {
       </TabsList>
       {tabs.map((tab) => (
         <TabsContent key={tab.id} value={tab.id}>
-          {tab.content}
+          {lazy && !visited.has(tab.id) ? null : tab.content}
         </TabsContent>
       ))}
     </Tabs>

--- a/frontend/components/entity/pagination.tsx
+++ b/frontend/components/entity/pagination.tsx
@@ -32,16 +32,14 @@ export function Pagination({
       </p>
       <div className="flex gap-2">
         <Button
-          variant="outline"
-          size="sm"
+          size="xs"
           disabled={page <= 1}
           onClick={() => onPageChange(page - 1)}
         >
           {t("common.previous")}
         </Button>
         <Button
-          variant="outline"
-          size="sm"
+          size="xs"
           disabled={page >= totalPages}
           onClick={() => onPageChange(page + 1)}
         >

--- a/frontend/features/communications/components/announcement-form.tsx
+++ b/frontend/features/communications/components/announcement-form.tsx
@@ -102,14 +102,26 @@ export function AnnouncementForm({
   }
 
   async function handleSend() {
-    if (!announcement) return;
+    // For a new announcement, create the draft first, then send it — one action
+    // that ends in "sent". For an existing draft, send it directly.
+    let id = announcement?.id ?? null;
     try {
-      await sendMutation.mutateAsync(announcement.id);
+      if (id === null) {
+        const created = await createMutation.mutateAsync(buildPayload());
+        id = created.id;
+      }
+      await sendMutation.mutateAsync(id);
       toast.success(t("communications.compose.sentToast"));
       setConfirmOpen(false);
-      router.push("/communications");
+      router.push(`/communications/${id}`);
     } catch (error) {
       toast.error(getErrorMessage(error));
+      setConfirmOpen(false);
+      // A just-created draft persisted even though the send failed (e.g. empty
+      // audience) — take the user to it so they can fix targeting and retry.
+      if (id !== null && !announcement) {
+        router.push(`/communications/${id}`);
+      }
     }
   }
 
@@ -267,6 +279,7 @@ export function AnnouncementForm({
       ) : (
         <div className="flex items-center gap-2">
           <Button
+            variant="outline"
             onClick={handleSave}
             disabled={!canSave || createMutation.isPending || updateMutation.isPending}
           >
@@ -274,15 +287,12 @@ export function AnnouncementForm({
               ? t("common.loading")
               : t("communications.compose.saveDraft")}
           </Button>
-          {announcement && (
-            <Button
-              variant="secondary"
-              disabled={!canSave}
-              onClick={() => setConfirmOpen(true)}
-            >
-              {t("communications.compose.send")}
-            </Button>
-          )}
+          <Button
+            disabled={!canSave || createMutation.isPending || sendMutation.isPending}
+            onClick={() => setConfirmOpen(true)}
+          >
+            {t("communications.compose.send")}
+          </Button>
         </div>
       )}
 
@@ -292,16 +302,21 @@ export function AnnouncementForm({
             <DialogTitle>{t("communications.compose.confirmSendTitle")}</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            {t("communications.compose.confirmSendBody", {
-              count: audience?.count ?? 0,
-            })}
+            {announcement
+              ? t("communications.compose.confirmSendBody", {
+                  count: audience?.count ?? 0,
+                })
+              : t("communications.compose.confirmSendBodyNew")}
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>
               {t("common.cancel")}
             </Button>
-            <Button onClick={handleSend} disabled={sendMutation.isPending}>
-              {sendMutation.isPending
+            <Button
+              onClick={handleSend}
+              disabled={createMutation.isPending || sendMutation.isPending}
+            >
+              {createMutation.isPending || sendMutation.isPending
                 ? t("common.loading")
                 : t("communications.compose.send")}
             </Button>

--- a/frontend/features/communications/components/recipients-tab.tsx
+++ b/frontend/features/communications/components/recipients-tab.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import { TabContentSkeleton } from "@/components/ui/skeletons";
+import { Pagination } from "@/components/entity/pagination";
+import { useFormatters } from "@/hooks/use-formatters";
+import { useAnnouncementRecipients } from "../hooks/use-announcements";
+
+export function RecipientsTab({ announcementId }: { announcementId: number }) {
+  const t = useTranslations();
+  const { formatDateTime } = useFormatters();
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useAnnouncementRecipients(announcementId, page);
+
+  if (isLoading) return <TabContentSkeleton />;
+
+  const items = data?.items ?? [];
+  const meta = data?.meta;
+
+  if (!items.length) {
+    return (
+      <p className="text-sm text-muted-foreground py-4">
+        {t("communications.view.noRecipients")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4 table-compact">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{t("communications.view.recipientName")}</TableHead>
+            <TableHead>{t("communications.view.recipientEmail")}</TableHead>
+            <TableHead>{t("communications.view.channel")}</TableHead>
+            <TableHead>{t("communications.view.seen")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((r) => (
+            <TableRow key={r.member_id}>
+              <TableCell className="font-medium">{r.name}</TableCell>
+              <TableCell className="text-sm text-muted-foreground">
+                {r.email || "—"}
+              </TableCell>
+              <TableCell>
+                <div className="flex gap-1">
+                  {r.emailed && (
+                    <Badge variant="outline">
+                      {t("communications.view.channelEmail")}
+                    </Badge>
+                  )}
+                  {r.in_app && (
+                    <Badge variant="outline">
+                      {t("communications.view.channelInApp")}
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell>
+                {r.seen_at ? (
+                  <Badge className="bg-emerald-600 hover:bg-emerald-600">
+                    {t("communications.view.seenAt", {
+                      date: formatDateTime(r.seen_at),
+                    })}
+                  </Badge>
+                ) : r.in_app ? (
+                  <Badge variant="secondary">
+                    {t("communications.view.notSeen")}
+                  </Badge>
+                ) : (
+                  <span className="text-sm text-muted-foreground">—</span>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {meta && (
+        <Pagination
+          page={meta.page}
+          totalPages={meta.total_pages}
+          total={meta.total}
+          perPage={meta.per_page}
+          onPageChange={setPage}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/features/communications/components/sent-announcement-view.tsx
+++ b/frontend/features/communications/components/sent-announcement-view.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Card, CardContent, CardHeader, CardTitle,
+} from "@/components/ui/card";
+import { DetailSection } from "@/components/entity/detail-section";
+import { EntityTabs } from "@/components/entity/entity-tabs";
+import { Markdown } from "@/lib/markdown";
+import { useFormatters } from "@/hooks/use-formatters";
+import { useGroups } from "@/features/groups/hooks/use-groups";
+import { useMembershipTypes } from "@/features/members/hooks/use-members";
+import { useAnnouncementStats } from "../hooks/use-announcements";
+import { RecipientsTab } from "./recipients-tab";
+import type { AnnouncementData } from "../services/announcements-api";
+
+export function SentAnnouncementView({
+  announcement,
+}: {
+  announcement: AnnouncementData;
+}) {
+  const t = useTranslations();
+  const { formatDateTime } = useFormatters();
+  const { data: stats } = useAnnouncementStats(announcement.id);
+  const { data: groups } = useGroups();
+  const { data: membershipTypes } = useMembershipTypes();
+
+  function targetLabel() {
+    if (announcement.target_type === "all") return t("communications.target.all");
+    if (announcement.target_type === "group") {
+      const g = (groups ?? []).find((x) => x.id === announcement.target_id);
+      return `${t("communications.target.group")}: ${g?.name ?? "—"}`;
+    }
+    const mt = (membershipTypes ?? []).find((x) => x.id === announcement.target_id);
+    return `${t("communications.target.membership_type")}: ${mt?.name ?? "—"}`;
+  }
+
+  const recipientCount = stats?.recipient_count ?? announcement.recipient_count ?? 0;
+  const seenCount = stats?.seen_count ?? 0;
+
+  return (
+    <div className="space-y-4 max-w-4xl">
+      {/* Content header — subject + rendered body + summary line */}
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="text-lg">{announcement.subject}</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            {t("communications.view.summary", {
+              date: announcement.sent_at ? formatDateTime(announcement.sent_at) : "—",
+              recipients: recipientCount,
+              seen: seenCount,
+            })}
+          </p>
+        </CardHeader>
+        <CardContent className="px-4 pb-4 pt-0">
+          <Markdown
+            content={announcement.body}
+            className="text-sm prose-sm [&_p]:my-1 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_a]:text-primary [&_a]:underline"
+          />
+        </CardContent>
+      </Card>
+
+      <EntityTabs
+        lazy
+        tabs={[
+          {
+            id: "details",
+            label: t("communications.view.detailsTab"),
+            content: (
+              <Card>
+                <CardContent className="p-4">
+                  <DetailSection
+                    columns={2}
+                    fields={[
+                      { label: t("communications.view.sentAt"), value: announcement.sent_at ? formatDateTime(announcement.sent_at) : "—" },
+                      { label: t("communications.view.sentBy"), value: stats?.sent_by ?? "—" },
+                      { label: t("communications.view.target"), value: targetLabel() },
+                      { label: t("communications.view.recipientCount"), value: recipientCount },
+                      { label: t("communications.view.emailedCount"), value: stats?.emailed_count ?? "—" },
+                      { label: t("communications.view.seenCount"), value: seenCount },
+                      { label: t("communications.view.createdAt"), value: announcement.created_at ? formatDateTime(announcement.created_at) : "—" },
+                    ]}
+                  />
+                </CardContent>
+              </Card>
+            ),
+          },
+          {
+            id: "recipients",
+            label: t("communications.view.recipientsTab"),
+            badge: recipientCount,
+            content: <RecipientsTab announcementId={announcement.id} />,
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/frontend/features/communications/hooks/use-announcements.ts
+++ b/frontend/features/communications/hooks/use-announcements.ts
@@ -6,6 +6,8 @@ import {
   getAnnouncement,
   getAnnouncements,
   getAudiencePreview,
+  getRecipients,
+  getRecipientStats,
   sendAnnouncement,
   updateAnnouncement,
   type AnnouncementFilters,
@@ -59,6 +61,27 @@ export function useAudiencePreview(id: number, enabled = true) {
   return useQuery({
     queryKey: ["announcements", id, "audience"],
     queryFn: () => getAudiencePreview(id),
+    enabled: enabled && Number.isFinite(id) && id > 0,
+  });
+}
+
+export function useAnnouncementRecipients(
+  id: number,
+  page: number,
+  perPage = 10,
+  enabled = true
+) {
+  return useQuery({
+    queryKey: ["announcements", id, "recipients", page, perPage],
+    queryFn: () => getRecipients(id, page, perPage),
+    enabled: enabled && Number.isFinite(id) && id > 0,
+  });
+}
+
+export function useAnnouncementStats(id: number, enabled = true) {
+  return useQuery({
+    queryKey: ["announcements", id, "stats"],
+    queryFn: () => getRecipientStats(id),
     enabled: enabled && Number.isFinite(id) && id > 0,
   });
 }

--- a/frontend/features/communications/services/announcements-api.ts
+++ b/frontend/features/communications/services/announcements-api.ts
@@ -75,3 +75,39 @@ export async function sendAnnouncement(id: number): Promise<AnnouncementData> {
 export async function getAudiencePreview(id: number): Promise<{ count: number }> {
   return apiClient(`/announcements/${id}/audience-preview`);
 }
+
+export interface RecipientData {
+  member_id: number;
+  name: string;
+  email: string | null;
+  emailed: boolean;
+  in_app: boolean;
+  seen_at: string | null;
+}
+
+export interface PaginatedRecipients {
+  items: RecipientData[];
+  meta: { page: number; per_page: number; total: number; total_pages: number };
+}
+
+export interface RecipientStats {
+  recipient_count: number;
+  emailed_count: number;
+  seen_count: number;
+  sent_by: string | null;
+}
+
+export async function getRecipients(
+  id: number,
+  page = 1,
+  perPage = 20
+): Promise<PaginatedRecipients> {
+  const params = new URLSearchParams();
+  params.set("page", String(page));
+  params.set("per_page", String(perPage));
+  return apiClient(`/announcements/${id}/recipients?${params.toString()}`);
+}
+
+export async function getRecipientStats(id: number): Promise<RecipientStats> {
+  return apiClient(`/announcements/${id}/stats`);
+}

--- a/frontend/locales/ca/communications.json
+++ b/frontend/locales/ca/communications.json
@@ -48,8 +48,30 @@
       "send": "Envia",
       "confirmSendTitle": "Enviar l'anunci?",
       "confirmSendBody": "S'enviarà per correu a {count} membres i se'ls notificarà a l'app. Un anunci enviat no es pot editar.",
+      "confirmSendBodyNew": "Es desarà i s'enviarà immediatament l'anunci a l'audiència seleccionada, per correu i amb notificació a l'app. Un anunci enviat no es pot editar.",
       "sentToast": "Anunci enviat",
       "sentRecipients": "Enviat a {count} membres"
+    },
+    "view": {
+      "summary": "Enviat {date} · {recipients} destinataris · {seen} vistos",
+      "detailsTab": "Detalls",
+      "recipientsTab": "Destinataris",
+      "sentAt": "Enviat el",
+      "sentBy": "Enviat per",
+      "target": "Audiència",
+      "recipientCount": "Destinataris",
+      "emailedCount": "Per correu",
+      "seenCount": "Vistos",
+      "createdAt": "Creat el",
+      "noRecipients": "No hi ha destinataris registrats per a aquest anunci.",
+      "recipientName": "Membre",
+      "recipientEmail": "Correu",
+      "channel": "Canal",
+      "channelEmail": "Correu",
+      "channelInApp": "A l'app",
+      "seen": "Vist",
+      "seenAt": "Vist {date}",
+      "notSeen": "No vist"
     }
   }
 }

--- a/frontend/locales/en/communications.json
+++ b/frontend/locales/en/communications.json
@@ -48,8 +48,30 @@
       "send": "Send",
       "confirmSendTitle": "Send announcement?",
       "confirmSendBody": "This will email {count} members and notify them in the app. A sent announcement cannot be edited.",
+      "confirmSendBodyNew": "This will save and immediately send the announcement to the selected audience — emailing them and notifying them in the app. A sent announcement cannot be edited.",
       "sentToast": "Announcement sent",
       "sentRecipients": "Sent to {count} members"
+    },
+    "view": {
+      "summary": "Sent {date} · {recipients} recipients · {seen} seen",
+      "detailsTab": "Details",
+      "recipientsTab": "Recipients",
+      "sentAt": "Sent at",
+      "sentBy": "Sent by",
+      "target": "Audience",
+      "recipientCount": "Recipients",
+      "emailedCount": "Emailed",
+      "seenCount": "Seen",
+      "createdAt": "Created at",
+      "noRecipients": "No recipients recorded for this announcement.",
+      "recipientName": "Member",
+      "recipientEmail": "Email",
+      "channel": "Channel",
+      "channelEmail": "Email",
+      "channelInApp": "In-app",
+      "seen": "Seen",
+      "seenAt": "Seen {date}",
+      "notSeen": "Not seen"
     }
   }
 }

--- a/frontend/locales/es/communications.json
+++ b/frontend/locales/es/communications.json
@@ -48,8 +48,30 @@
       "send": "Enviar",
       "confirmSendTitle": "¿Enviar anuncio?",
       "confirmSendBody": "Se enviará por correo a {count} miembros y se les notificará en la app. Un anuncio enviado no se puede editar.",
+      "confirmSendBodyNew": "Se guardará y enviará inmediatamente el anuncio a la audiencia seleccionada, por correo y con notificación en la app. Un anuncio enviado no se puede editar.",
       "sentToast": "Anuncio enviado",
       "sentRecipients": "Enviado a {count} miembros"
+    },
+    "view": {
+      "summary": "Enviado {date} · {recipients} destinatarios · {seen} vistos",
+      "detailsTab": "Detalles",
+      "recipientsTab": "Destinatarios",
+      "sentAt": "Enviado el",
+      "sentBy": "Enviado por",
+      "target": "Audiencia",
+      "recipientCount": "Destinatarios",
+      "emailedCount": "Por correo",
+      "seenCount": "Vistos",
+      "createdAt": "Creado el",
+      "noRecipients": "No hay destinatarios registrados para este anuncio.",
+      "recipientName": "Miembro",
+      "recipientEmail": "Correo",
+      "channel": "Canal",
+      "channelEmail": "Correo",
+      "channelInApp": "En la app",
+      "seen": "Visto",
+      "seenAt": "Visto {date}",
+      "notSeen": "No visto"
     }
   }
 }


### PR DESCRIPTION
## v0.5.1 — Communications Sent View & Recipient Tracking

Patch enhancement to v0.5.0. Turns the sent-announcement page from a read-only reuse of the compose form into a proper **sent view**, and adds a faithful per-recipient delivery record.

### What changed

**Sent view** (`/communications/{id}` when `status = sent`)
- Content header: subject + rendered markdown body + summary (`Sent {date} · N recipients · M seen`)
- `EntityTabs`:
  - **Details** — sent at, sent by (author), audience target, recipient / emailed / seen counts, created at
  - **Recipients** — **lazy** (fetched only when opened), paginated **10/page**, with channel badges (email / in-app) and a green **"Seen {date}"** badge (in-app read state)

**Recipient tracking**
- New `announcement_recipients` table (#26, migration `e1f2a3b4c5d6`) — snapshots the audience at Send (`member_id`, `user_id?`, `emailed`, `in_app`), so later membership changes never alter who an announcement was sent to. Includes email-only members (no account).
- `send_announcement()` writes recipient rows from the already-resolved audience.
- New endpoints: `GET /announcements/{id}/recipients` (paginated) + `GET /announcements/{id}/stats` (recipient/emailed/seen counts + author name).
- **"Seen"** is derived from `notifications.read_at` — in-app only; email opens are not tracked (email-only recipients never show a Seen state, by design).

**UX**
- **Direct Send** from the new-announcement form — creates the draft then immediately sends it in one action (ends in `sent`); if the send fails, the just-created draft is preserved and the user is routed to it.
- `EntityTabs` gained an opt-in `lazy` prop (content mounts only on first open).
- Shared pagination Prev/Next restyled to the brand primary (no longer read as disabled).

### Tests
- **Backend:** 7 new integration tests (30 in `test_communications.py`); full suite **699 passed**. Migration roundtrips.
- **E2E:** 2 new Cypress tests (direct send, sent view + recipients tab); spec **7/7 green**.
- TSC + ESLint clean; ES/CA/EN i18n added.

### Notes
- No `VERSION` bump / tag in this branch — left to the release commit per the repo's version-hook workflow.
- Docs (schema #26, `IMPLEMENTATION-PLAN-v0.5.1-*`, `MANUAL-TEST-CHART-v0.5.1`, STATUS, ROADMAP) are prepared in `memship-definition` (separate repo, uncommitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
