### PR TITLE
fix(quickstart): always pull latest images

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -24,7 +24,9 @@ La majoria d'eines de gestió de socis són plataformes SaaS cares o programari 
 Proveu Memship amb una sola comanda — sense necessitat de clonar el repositori:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/marcandreuf/memship/main/docker-compose.quickstart.yml -o docker-compose.yml && PORT=8081 docker compose up -d
+curl -fsSL https://raw.githubusercontent.com/marcandreuf/memship/main/docker-compose.quickstart.yml -o docker-compose.yml
+docker compose pull        # descarrega les últimes imatges publicades
+PORT=8081 docker compose up -d
 ```
 
 A continuació, executeu la configuració inicial:

--- a/README.es.md
+++ b/README.es.md
@@ -24,7 +24,9 @@ La mayoría de herramientas de gestión de socios son plataformas SaaS caras o s
 Prueba Memship con un solo comando, sin necesidad de clonar el repositorio:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/marcandreuf/memship/main/docker-compose.quickstart.yml -o docker-compose.yml && PORT=8081 docker compose up -d
+curl -fsSL https://raw.githubusercontent.com/marcandreuf/memship/main/docker-compose.quickstart.yml -o docker-compose.yml
+docker compose pull        # descarga las últimas imágenes publicadas
+PORT=8081 docker compose up -d
 ```
 
 A continuación, ejecuta la configuración inicial:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Most membership tools are either expensive SaaS platforms or outdated legacy sof
 Try memship with a single command — no cloning required:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/marcandreuf/memship/main/docker-compose.quickstart.yml -o docker-compose.yml && PORT=8081 docker compose up -d
+curl -fsSL https://raw.githubusercontent.com/marcandreuf/memship/main/docker-compose.quickstart.yml -o docker-compose.yml
+docker compose pull        # fetch the latest published images
+PORT=8081 docker compose up -d
 ```
 
 Then run the initial setup:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -40,6 +40,7 @@ services:
 
   demo-memship-api:
     image: ghcr.io/marcandreuf/memship-backend:latest
+    pull_policy: always
     container_name: demo-memship-api
     expose:
       - "8000"
@@ -60,6 +61,7 @@ services:
 
   demo-memship-frontend:
     image: ghcr.io/marcandreuf/memship-frontend:latest
+    pull_policy: always
     container_name: demo-memship-frontend
     expose:
       - "3000"


### PR DESCRIPTION
Follow-up to the v1.0.0 release, found while running the quick-start end-to-end on a clean checkout.

A stale locally-cached `ghcr.io/…:latest` backend image made `docker compose up` boot an old image (pre-`--demo`), so the quick-start seed fell into the interactive path instead of the `--demo` dataset.

- `docker-compose.quickstart.yml`: add `pull_policy: always` to the `demo-memship-api` and `demo-memship-frontend` services.
- READMEs (en/es/ca): add a `docker compose pull` step to the Quick Start before `up -d`.

So a fresh checkout always runs the published release image. Docs/infra only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)