### PR TITLE
fix(celery): register scheduled tasks and complete worker mapper registry

### DIFF
--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -9,6 +9,11 @@ celery = Celery(
     "memship",
     broker=settings.CELERY_BROKER_URL,
     backend=settings.CELERY_BROKER_URL,
+    include=[
+        "app.tasks.billing_tasks",
+        "app.tasks.communication_tasks",
+        "app.tasks.email_tasks",
+    ],
 )
 
 celery.conf.update(
@@ -36,5 +41,7 @@ celery.conf.beat_schedule = {
     },
 }
 
-# Auto-discover tasks in app.tasks package
-celery.autodiscover_tasks(["app.tasks"])
+# Load every model so the SQLAlchemy mapper registry is fully configured in the
+# worker/beat processes, which don't import the full API. Without this, string-based
+# relationships (e.g. Receipt -> Registration) fail to resolve at query time.
+import app.db.models_registry  # noqa: E402,F401

--- a/backend/app/db/models_registry.py
+++ b/backend/app/db/models_registry.py
@@ -1,0 +1,16 @@
+"""Import every model module so the SQLAlchemy mapper registry is complete.
+
+Processes that don't load the full API (e.g. the Celery worker/beat) must import
+this module before running any query, otherwise string-based relationships such as
+``Receipt`` -> ``Registration`` fail to resolve during mapper configuration.
+"""
+
+from app.domains.activities import models as activities_models  # noqa: F401
+from app.domains.audit import models as audit_models  # noqa: F401
+from app.domains.auth import models as auth_models  # noqa: F401
+from app.domains.billing import models as billing_models  # noqa: F401
+from app.domains.communications import models as communications_models  # noqa: F401
+from app.domains.members import models as members_models  # noqa: F401
+from app.domains.organizations import models as organizations_models  # noqa: F401
+from app.domains.persons import models as persons_models  # noqa: F401
+from app.domains.reminders import models as reminders_models  # noqa: F401


### PR DESCRIPTION
## Problem

Investigating an unresponsive-VM incident surfaced a recurring worker error in the celery logs:

```
ERROR/MainProcess Received unregistered task of type
'app.tasks.billing_tasks.scheduled_billing_run'.
KeyError: 'app.tasks.billing_tasks.scheduled_billing_run'
```

The scheduled billing run (and payment reminders) were **never executing** — beat dispatched them but the worker rejected them as unregistered.

## Root cause (two stacked bugs)

**1. Worker registered zero tasks.** `celery_app.py` used `autodiscover_tasks(["app.tasks"])`, which appends the default `related_name='tasks'` and thus looks for a non-existent `app.tasks.tasks` module. The API process only worked by luck (each caller lazily imports its task at call time); the separate worker imported nothing.

**2. Incomplete mapper in the worker (latent, hidden behind #1).** Once tasks reached the worker, they failed with `failed to locate a name 'Registration'` — the worker doesn't import the full API, so the SQLAlchemy mapper was incomplete and the string-based `Receipt -> Registration` relationship couldn't resolve. This would have broken scheduled billing regardless of #1.

## Fix

- Replace the broken `autodiscover_tasks` with an explicit `include=[...]` of the three task modules — the canonical, deterministic way to register worker tasks.
- Add `app/db/models_registry.py` importing every model module, loaded once from the celery app so worker/beat processes configure the full mapper registry.

## Verification (live, in the running stack)

- Worker `[tasks]` banner now lists all 8 tasks including `scheduled_billing_run`.
- `scheduled_billing_run` dispatched → **succeeded**: `{'runs': 0, 'receipts_generated': 0}`
- `scheduled_payment_reminders` dispatched → **succeeded**: `{'overdue_marked': 0, 'reminders_sent': 0, 'failures': 0}`
  (No-ops because billing isn't feature-enabled on the dev org — the correct result.)
- Full backend suite: **764 passed**.

> Note: unrelated to the VM freeze that started the investigation — that was an external Proxmox-host event (the VM was idle when it died). These were pre-existing latent bugs the investigation happened to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)