### PR TITLE
ci(build-images): don't overwrite an already-published version tag

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       force_rebuild:
-        description: 'Force rebuild even if version exists'
+        description: 'Force rebuild even if the version tag already exists in GHCR'
         required: false
         type: boolean
         default: false
@@ -98,6 +98,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # 'true' when a build actually ran; 'false' when skipped because the tag exists.
+      built: ${{ steps.guard.outputs.exists == 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -111,7 +114,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Protect released tags: never overwrite an existing $VERSION image. A backend
+      # change merged to main without a VERSION bump would otherwise silently re-push
+      # the current version tag (e.g. clobbering a shipped 1.0.0). Bump VERSION to
+      # publish, or re-run via workflow_dispatch with force_rebuild=true.
+      - name: Guard against overwriting a published version
+        id: guard
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/memship-backend
+          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild || 'false' }}
+        run: |
+          if [[ "$FORCE_REBUILD" != "true" ]] && docker buildx imagetools inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Image build skipped::$IMAGE:$VERSION already exists in GHCR. Bump VERSION to publish a new release, or re-run this workflow via workflow_dispatch with force_rebuild=true."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push Backend
+        if: ${{ steps.guard.outputs.exists == 'false' }}
         env:
           VERSION: ${{ needs.version.outputs.version }}
           IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/memship-backend
@@ -132,6 +154,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # 'true' when a build actually ran; 'false' when skipped because the tag exists.
+      built: ${{ steps.guard.outputs.exists == 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -145,7 +170,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Protect released tags — see the backend job's guard for rationale.
+      - name: Guard against overwriting a published version
+        id: guard
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/memship-frontend
+          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild || 'false' }}
+        run: |
+          if [[ "$FORCE_REBUILD" != "true" ]] && docker buildx imagetools inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Image build skipped::$IMAGE:$VERSION already exists in GHCR. Bump VERSION to publish a new release, or re-run this workflow via workflow_dispatch with force_rebuild=true."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push Frontend
+        if: ${{ steps.guard.outputs.exists == 'false' }}
         env:
           VERSION: ${{ needs.version.outputs.version }}
           IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/memship-frontend
@@ -165,15 +206,23 @@ jobs:
     steps:
       - name: Build Summary
         run: |
-          echo "### Docker Images Built" >> $GITHUB_STEP_SUMMARY
+          echo "### Docker Images" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Service | Image |" >> $GITHUB_STEP_SUMMARY
-          echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Service | Image | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-------|--------|" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ needs.build-backend.result }}" == "success" ]]; then
-            echo "| Backend | \`ghcr.io/${{ github.repository_owner }}/memship-backend:${{ needs.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+            if [[ "${{ needs.build-backend.outputs.built }}" == "true" ]]; then
+              echo "| Backend | \`ghcr.io/${{ github.repository_owner }}/memship-backend:${{ needs.version.outputs.version }}\` | published |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| Backend | \`ghcr.io/${{ github.repository_owner }}/memship-backend:${{ needs.version.outputs.version }}\` | skipped (tag already exists) |" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
           if [[ "${{ needs.build-frontend.result }}" == "success" ]]; then
-            echo "| Frontend | \`ghcr.io/${{ github.repository_owner }}/memship-frontend:${{ needs.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+            if [[ "${{ needs.build-frontend.outputs.built }}" == "true" ]]; then
+              echo "| Frontend | \`ghcr.io/${{ github.repository_owner }}/memship-frontend:${{ needs.version.outputs.version }}\` | published |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| Frontend | \`ghcr.io/${{ github.repository_owner }}/memship-frontend:${{ needs.version.outputs.version }}\` | skipped (tag already exists) |" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
 
   ci-failed:


### PR DESCRIPTION
## Problem

The `Build Images` workflow tags images straight from the `VERSION` file and pushes **unconditionally**:

```
-t $IMAGE:$VERSION -t $IMAGE:latest
docker push $IMAGE:$VERSION
docker push $IMAGE:latest
```

The `build-backend` job runs whenever `backend/` changed. So **any backend change merged to `main` without a `VERSION` bump re-pushes the current version tag**, silently overwriting a released image.

This already happened: `VERSION` is still `1.0.0`, and the celery fix (PR #10, backend change) triggered a Build Images run on 2026-07-14 that rebuilt and force-pushed `memship-backend:1.0.0` + `:latest` with post-release code. The `1.0.0` tag no longer matches the actual v1.0.0 release.

The `force_rebuild` dispatch input was even described as "Force rebuild even if version exists" — but no such existence check was ever wired up.

## Change

- Add a **guard step** to both `build-backend` and `build-frontend`: after GHCR login, check whether `$IMAGE:$VERSION` already exists via `docker buildx imagetools inspect`. If it does and `force_rebuild` is not set, **skip the build + push** and emit a `::warning::`.
- The build/push step is now gated on `steps.guard.outputs.exists == 'false'`.
- Each build job exposes a `built` output; `finalize` uses it to report **published** vs **skipped (tag already exists)** honestly.
- `workflow_dispatch` `force_rebuild=true` now actually bypasses the guard, matching its description.

Net effect: **the only way to publish a new image tag is to bump `VERSION`** (a release), which is the intended behavior. Released tags can no longer be silently clobbered.

## Validation

- `actionlint` (via `rhysd/actionlint` image): clean — only pre-existing `SC2086` *info*-level style notes on unchanged lines (`VERSION` is already regex-validated).
- YAML parses.

## Follow-up (separate PR)

Bump to **v1.0.1** to publish the celery fix under its own tag and stop polluting `1.0.0`. This hardening lands first so the 1.0.1 build runs under the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)