### PR TITLE
docs(readme): add v1.0.1 to the roadmap (en/es/ca)

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -103,6 +103,7 @@ Obriu http://localhost:8081 i inicieu sessió amb les vostres credencials. Canvi
 | v0.7.1 | Millores del carnet — vista de carnet per a l'admin, foto de perfil del soci, redisseny del perfil | Fet |
 | v0.8.0 | ~~Convocatòries~~ — ajornat després de v1.0.0 (segons demanda) | Ajornat |
 | v1.0.0 | Estabilització i llançament — exportacions CSV, tauler financer, notes i recordatoris, resum anual, dades demo, polit de docs | Fet |
+| v1.0.1 | Pedaç — corregeix el registre de tasques programades de facturació/recordatoris a Celery; protecció de CI contra la sobreescriptura d'etiquetes d'imatge | Fet |
 
 Ajornat després de v1.0.0: GoCardless e-mandats, integració PayPal, flux d'Stripe Invoice, accions massives en rebuts, generador d'informes personalitzats, enquestes, biblioteca de documents del club, facturació familiar i altres variacions complexes de les anteriors. Llista completa d'ajornats a `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
 

--- a/README.es.md
+++ b/README.es.md
@@ -103,6 +103,7 @@ Abre http://localhost:8081 e inicia sesión con tus credenciales. Cambia `PORT=8
 | v0.7.1 | Mejoras del carnet — vista de carnet para el admin, foto de perfil del socio, rediseño del perfil | Hecho |
 | v0.8.0 | ~~Convocatorias~~ — aplazado tras v1.0.0 (según demanda) | Aplazado |
 | v1.0.0 | Estabilización y lanzamiento — exportaciones CSV, panel financiero, notas y recordatorios, resumen anual, datos demo, pulido de docs | Hecho |
+| v1.0.1 | Parche — corrige el registro de tareas programadas de facturación/recordatorios en Celery; protección de CI contra la sobrescritura de etiquetas de imagen | Hecho |
 
 Aplazado tras v1.0.0: GoCardless e-mandatos, integración PayPal, flujo de Stripe Invoice, acciones masivas en recibos, generador de informes personalizados, encuestas, biblioteca de documentos del club, facturación familiar y otras variaciones complejas de las anteriores. Lista completa de aplazados en `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Open http://localhost:8081 and log in with your credentials. Change `PORT=8081` 
 | v0.7.1 | Member card polish — admin card view on member page, member profile photo upload, profile page redesign | Done |
 | v0.8.0 | ~~Convocations~~ — deferred post-1.0 (build on demand) | Deferred |
 | v1.0.0 | Stabilization & Release — CSV exports, finance dashboard, notes & reminders, annual summary, demo seed, docs polish | Done |
+| v1.0.1 | Patch — fix Celery scheduled billing/reminder task registration; CI guard against image tag overwrite | Done |
 
 Deferred past v1.0.0: GoCardless e-mandates, PayPal integration, Stripe Invoice flow, bulk receipt actions, custom report builder, surveys, club document library, family group billing, and other complex variations of the above. See `memship-definition/docs/public/ROADMAP-v1.0.0.md` for the full deferred list.
 


### PR DESCRIPTION
The roadmap tables in all three locale READMEs stopped at `v1.0.0`. v1.0.1 has shipped (Celery scheduled-task registration fix + CI image-tag overwrite guard), so add the `v1.0.1` row to `README.md`, `README.es.md`, and `README.ca.md`.

Docs-only — outside the CI/Build-Images path filters, so no checks run and no images rebuild.

Also removes the friction where the release pre-commit hook warns "v1.0.1 not found in README roadmap" — the entry now exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)