### PR TITLE
docs(readme): add post-1.0 core-gap roadmap (v1.1.0–v1.5.0)

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -104,8 +104,14 @@ Obriu http://localhost:8081 i inicieu sessió amb les vostres credencials. Canvi
 | v0.8.0 | ~~Convocatòries~~ — ajornat després de v1.0.0 (segons demanda) | Ajornat |
 | v1.0.0 | Estabilització i llançament — exportacions CSV, tauler financer, notes i recordatoris, resum anual, dades demo, polit de docs | Fet |
 | v1.0.1 | Pedaç — corregeix el registre de tasques programades de facturació/recordatoris a Celery; protecció de CI contra la sobreescriptura d'etiquetes d'imatge | Fet |
+| v1.1.0 | Camps de perfil personalitzats — dades de soci configurables per l'organització (text, número, data, selecció, …) amb validació per camp | Planificat |
+| v1.2.0 | Rols i permisos flexibles — multi-rol i permisos per rol més enllà dels 4 rols fixos | Planificat |
+| v1.3.0 | Integració SSO / identitat — inici de sessió amb l'IdP de l'organització (SAML/OIDC); mode proveïdor més endavant | Planificat |
+| v1.4.0 | Biblioteca de documents — estatuts, actes, formularis amb visibilitat per grup | Planificat |
+| v1.5.0 | Calendari d'esdeveniments + confirmació d'assistència — vista de calendari i seguiment de participació | Planificat |
+| (més endavant) | Mòduls opcionals per a superadmin — àlbums de fotos, fòrum, llibre de visites, directori d'enllaços, inventari/préstecs, ginys del portal | Planificat |
 
-Ajornat després de v1.0.0: GoCardless e-mandats, integració PayPal, flux d'Stripe Invoice, accions massives en rebuts, generador d'informes personalitzats, enquestes, biblioteca de documents del club, facturació familiar i altres variacions complexes de les anteriors. Llista completa d'ajornats a `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
+Ajornat després de v1.0.0: GoCardless e-mandats, integració PayPal, flux d'Stripe Invoice, accions massives en rebuts, generador d'informes personalitzats, enquestes, facturació familiar i altres variacions complexes de les anteriors. Llista completa d'ajornats a `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -104,8 +104,14 @@ Abre http://localhost:8081 e inicia sesión con tus credenciales. Cambia `PORT=8
 | v0.8.0 | ~~Convocatorias~~ — aplazado tras v1.0.0 (según demanda) | Aplazado |
 | v1.0.0 | Estabilización y lanzamiento — exportaciones CSV, panel financiero, notas y recordatorios, resumen anual, datos demo, pulido de docs | Hecho |
 | v1.0.1 | Parche — corrige el registro de tareas programadas de facturación/recordatorios en Celery; protección de CI contra la sobrescritura de etiquetas de imagen | Hecho |
+| v1.1.0 | Campos de perfil personalizados — datos de socio configurables por la organización (texto, número, fecha, selección, …) con validación por campo | Planificado |
+| v1.2.0 | Roles y permisos flexibles — multi-rol y permisos por rol más allá de los 4 roles fijos | Planificado |
+| v1.3.0 | Integración SSO / identidad — inicio de sesión con el IdP de la organización (SAML/OIDC); modo proveedor más adelante | Planificado |
+| v1.4.0 | Biblioteca de documentos — estatutos, actas, formularios con visibilidad por grupo | Planificado |
+| v1.5.0 | Calendario de eventos + confirmación de asistencia — vista de calendario y seguimiento de participación | Planificado |
+| (más adelante) | Módulos opcionales para superadmin — álbumes de fotos, foro, libro de visitas, directorio de enlaces, inventario/préstamos, widgets del portal | Planificado |
 
-Aplazado tras v1.0.0: GoCardless e-mandatos, integración PayPal, flujo de Stripe Invoice, acciones masivas en recibos, generador de informes personalizados, encuestas, biblioteca de documentos del club, facturación familiar y otras variaciones complejas de las anteriores. Lista completa de aplazados en `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
+Aplazado tras v1.0.0: GoCardless e-mandatos, integración PayPal, flujo de Stripe Invoice, acciones masivas en recibos, generador de informes personalizados, encuestas, facturación familiar y otras variaciones complejas de las anteriores. Lista completa de aplazados en `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,14 @@ Open http://localhost:8081 and log in with your credentials. Change `PORT=8081` 
 | v0.8.0 | ~~Convocations~~ — deferred post-1.0 (build on demand) | Deferred |
 | v1.0.0 | Stabilization & Release — CSV exports, finance dashboard, notes & reminders, annual summary, demo seed, docs polish | Done |
 | v1.0.1 | Patch — fix Celery scheduled billing/reminder task registration; CI guard against image tag overwrite | Done |
+| v1.1.0 | Custom profile fields — org-configurable member data (text, number, date, select, …) with per-field validation | Planned |
+| v1.2.0 | Flexible roles & permissions — multi-role, per-role rights beyond the 4 fixed roles | Planned |
+| v1.3.0 | SSO / identity integration — sign in via an org's IdP (SAML/OIDC); provider mode later | Planned |
+| v1.4.0 | Document library — statutes, minutes, forms with per-group visibility | Planned |
+| v1.5.0 | Events calendar + RSVP — calendar view and participation tracking | Planned |
+| (later) | Optional super-admin modules — photo albums, forum, guestbook, weblinks directory, inventory/lending, portal widgets | Planned |
 
-Deferred past v1.0.0: GoCardless e-mandates, PayPal integration, Stripe Invoice flow, bulk receipt actions, custom report builder, surveys, club document library, family group billing, and other complex variations of the above. See `memship-definition/docs/public/ROADMAP-v1.0.0.md` for the full deferred list.
+Deferred past v1.0.0: GoCardless e-mandates, PayPal integration, Stripe Invoice flow, bulk receipt actions, custom report builder, surveys, family group billing, and other complex variations of the above. See `memship-definition/docs/public/ROADMAP-v1.0.0.md` for the full deferred list.
 
 ---
 


### PR DESCRIPTION
Adds the market-research core feature gaps to the README roadmap in all three locales, as requested.

| Version | Milestone |
|---------|-----------|
| v1.1.0 | Custom profile fields — org-configurable member data with per-field validation |
| v1.2.0 | Flexible roles & permissions — multi-role, per-role rights |
| v1.3.0 | SSO / identity integration — SAML/OIDC (client first, provider later) |
| v1.4.0 | Document library — statutes, minutes, forms |
| v1.5.0 | Events calendar + RSVP |
| (later) | Optional super-admin modules — photos, forum, guestbook, weblinks, inventory, portal widgets |

Ranking follows `memship-definition/docs/market-research/MARKET-RESEARCH-oss-alternatives.md`. Status is **Planned** (customer-demand-gated; the plugins-vs-built-in extension-strategy decision is still parked). Also removes "club document library" from the deferred list since it's now a planned item (v1.4.0).

The v1.1.0 implementation plan is drafted at `memship-definition/docs/public/IMPLEMENTATION-PLAN-v1.1.0-custom-profile-fields.md` (EAV storage, attached to persons, MVP field types, feature-flag gated).

Docs-only — outside CI/Build-Images path filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)