### PR TITLE
docs(readme): mark optional modules as post-v1.5.0

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -109,7 +109,7 @@ Obriu http://localhost:8081 i inicieu sessió amb les vostres credencials. Canvi
 | v1.3.0 | Integració SSO / identitat — inici de sessió amb l'IdP de l'organització (SAML/OIDC); mode proveïdor més endavant | Planificat |
 | v1.4.0 | Biblioteca de documents — estatuts, actes, formularis amb visibilitat per grup | Planificat |
 | v1.5.0 | Calendari d'esdeveniments + confirmació d'assistència — vista de calendari i seguiment de participació | Planificat |
-| (més endavant) | Mòduls opcionals per a superadmin — àlbums de fotos, fòrum, llibre de visites, directori d'enllaços, inventari/préstecs, ginys del portal | Planificat |
+| després de v1.5.0 | Mòduls opcionals per a superadmin — àlbums de fotos, fòrum, llibre de visites, directori d'enllaços, inventari/préstecs, ginys del portal (l'enfocament de lliurament es decideix en completar les millores principals) | Planificat |
 
 Ajornat després de v1.0.0: GoCardless e-mandats, integració PayPal, flux d'Stripe Invoice, accions massives en rebuts, generador d'informes personalitzats, enquestes, facturació familiar i altres variacions complexes de les anteriors. Llista completa d'ajornats a `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
 

--- a/README.es.md
+++ b/README.es.md
@@ -109,7 +109,7 @@ Abre http://localhost:8081 e inicia sesión con tus credenciales. Cambia `PORT=8
 | v1.3.0 | Integración SSO / identidad — inicio de sesión con el IdP de la organización (SAML/OIDC); modo proveedor más adelante | Planificado |
 | v1.4.0 | Biblioteca de documentos — estatutos, actas, formularios con visibilidad por grupo | Planificado |
 | v1.5.0 | Calendario de eventos + confirmación de asistencia — vista de calendario y seguimiento de participación | Planificado |
-| (más adelante) | Módulos opcionales para superadmin — álbumes de fotos, foro, libro de visitas, directorio de enlaces, inventario/préstamos, widgets del portal | Planificado |
+| tras v1.5.0 | Módulos opcionales para superadmin — álbumes de fotos, foro, libro de visitas, directorio de enlaces, inventario/préstamos, widgets del portal (el enfoque de entrega se decide al completar las mejoras principales) | Planificado |
 
 Aplazado tras v1.0.0: GoCardless e-mandatos, integración PayPal, flujo de Stripe Invoice, acciones masivas en recibos, generador de informes personalizados, encuestas, facturación familiar y otras variaciones complejas de las anteriores. Lista completa de aplazados en `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Open http://localhost:8081 and log in with your credentials. Change `PORT=8081` 
 | v1.3.0 | SSO / identity integration — sign in via an org's IdP (SAML/OIDC); provider mode later | Planned |
 | v1.4.0 | Document library — statutes, minutes, forms with per-group visibility | Planned |
 | v1.5.0 | Events calendar + RSVP — calendar view and participation tracking | Planned |
-| (later) | Optional super-admin modules — photo albums, forum, guestbook, weblinks directory, inventory/lending, portal widgets | Planned |
+| after v1.5.0 | Optional super-admin modules — photo albums, forum, guestbook, weblinks directory, inventory/lending, portal widgets (delivery approach decided once the core gaps ship) | Planned |
 
 Deferred past v1.0.0: GoCardless e-mandates, PayPal integration, Stripe Invoice flow, bulk receipt actions, custom report builder, surveys, family group billing, and other complex variations of the above. See `memship-definition/docs/public/ROADMAP-v1.0.0.md` for the full deferred list.
 


### PR DESCRIPTION
The plugins-vs-built-in **extension-strategy decision is parked until the core-gap roadmap (v1.1.0–v1.5.0) is implemented**. The optional super-admin modules depend on that decision, so re-label their roadmap row from "(later)" to **"after v1.5.0"** and note the delivery approach is chosen once the core gaps ship. All three locales.

Docs-only — outside CI/Build-Images path filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)