### PR TITLE
docs: make CONTRIBUTING accurate; document worker/beat and image rebuild

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Thank you for your interest in contributing to Memship!
 
 ## Current Status
 
-Memship is in early development. The project foundation (infrastructure, CI/CD, core architecture) is being built. Once the foundation is stable, we will actively welcome code contributions.
+Memship is in active development. The foundation — infrastructure, CI/CD, and core architecture — is in place, and **code contributions are welcome**. See the [roadmap](README.md#roadmap) for what is shipped and what is planned.
 
-## How You Can Help Now
+## How You Can Help
 
 ### Feature Requests & Ideas
 
@@ -24,21 +24,46 @@ If you find a bug, open an [issue](https://github.com/marcandreuf/memship/issues
 
 Have a question or want to discuss the project direction? Open an [issue](https://github.com/marcandreuf/memship/issues) with the `question` label.
 
-## Code Contributions (Coming Soon)
-
-Once the project is ready for code contributions, the following guidelines will apply:
+## Code Contributions
 
 ### Getting Started
 
-1. Fork the repository
+1. Fork the repository (or, if you have push access, clone it directly)
 2. Create a feature branch from `main`
 3. Make your changes
-4. Run tests to ensure nothing is broken
-5. Submit a pull request
+4. Run the tests to ensure nothing is broken
+5. Open a pull request against `main`
 
 ### Development Setup
 
-Detailed setup instructions will be added once the infrastructure is in place.
+**Prerequisites:** Docker + Docker Compose, Node.js 22+ with [pnpm](https://pnpm.io), and [uv](https://github.com/astral-sh/uv) for Python.
+
+The backend (API, PostgreSQL, Redis, Celery worker and beat) runs in Docker; the frontend runs locally with pnpm. One script manages all of it:
+
+```bash
+./scripts/dev.sh start all     # Start backend (Docker) + frontend (local)
+./scripts/dev.sh status        # Show what is running
+./scripts/dev.sh stop all      # Stop everything
+```
+
+Then seed the database with test accounts:
+
+```bash
+./scripts/dev.sh seed test     # Creates test accounts and sample data, no prompts
+```
+
+The app is at http://localhost:3000 and the API docs at http://localhost:8003/api/docs. Log in with `admin@test.com` / `TestAdmin1!`.
+
+Run the backend tests with `./scripts/dev.sh test`.
+
+See the [Development section of the README](README.md#development) for the full command reference, service URLs, and the rest of the seeded test accounts.
+
+> **Note:** Python dependencies are baked into the backend Docker image — `pyproject.toml` is not bind-mounted. After adding or upgrading a backend dependency, rebuild the image or the running container will not have it:
+>
+> ```bash
+> docker compose -f backend/docker/docker-compose.yml build --no-cache api
+> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
+> ```
 
 ### Commit Messages
 

--- a/README.ca.md
+++ b/README.ca.md
@@ -232,9 +232,20 @@ Atureu-ho tot:
 | `./scripts/dev.sh status` | Mostrar l'estat de tots els serveis |
 | `./scripts/dev.sh logs backend` | Veure els registres de l'API |
 | `./scripts/dev.sh logs frontend` | Veure els registres del frontend (tail -f) |
+| `./scripts/dev.sh logs worker` | Veure els registres del worker de Celery |
+| `./scripts/dev.sh logs beat` | Veure els registres de Celery beat (planificador) |
 | `./scripts/dev.sh seed` | Executar la configuració inicial de la base de dades (interactiva) |
 | `./scripts/dev.sh seed test` | Inicialitzar amb comptes de prova (sense preguntes) |
 | `./scripts/dev.sh test` | Executar les proves del backend |
+
+`start all` aixeca el worker i el beat de Celery juntament amb l'API i la base de dades. `worker` i `beat` també són destinacions vàlides per a `start`, `stop` i `restart` si els necessites controlar per separat.
+
+> **Afegeixes una dependència del backend?** Les dependències de Python estan integrades a la imatge de Docker — `pyproject.toml` no es munta com a volum — així que una dependència nova no hi serà al contenidor en execució fins que el reconstrueixis:
+>
+> ```bash
+> docker compose -f backend/docker/docker-compose.yml build --no-cache api
+> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
+> ```
 
 ### URLs dels serveis
 

--- a/README.es.md
+++ b/README.es.md
@@ -232,9 +232,20 @@ Parar todo:
 | `./scripts/dev.sh status` | Ver estado de todos los servicios |
 | `./scripts/dev.sh logs backend` | Ver logs de la API |
 | `./scripts/dev.sh logs frontend` | Ver logs del frontend (tail -f) |
+| `./scripts/dev.sh logs worker` | Ver logs del worker de Celery |
+| `./scripts/dev.sh logs beat` | Ver logs de Celery beat (planificador) |
 | `./scripts/dev.sh seed` | Ejecutar configuración inicial de la BD (interactivo) |
 | `./scripts/dev.sh seed test` | Seed con cuentas de prueba (sin preguntas) |
 | `./scripts/dev.sh test` | Ejecutar tests del backend |
+
+`start all` levanta el worker y el beat de Celery junto con la API y la base de datos. `worker` y `beat` también son destinos válidos para `start`, `stop` y `restart` si necesitas controlarlos por separado.
+
+> **¿Añades una dependencia del backend?** Las dependencias de Python están integradas en la imagen de Docker — `pyproject.toml` no se monta como volumen — así que una dependencia nueva no estará en el contenedor en ejecución hasta que lo reconstruyas:
+>
+> ```bash
+> docker compose -f backend/docker/docker-compose.yml build --no-cache api
+> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
+> ```
 
 ### URLs de los servicios
 

--- a/README.md
+++ b/README.md
@@ -233,9 +233,20 @@ Stop everything:
 | `./scripts/dev.sh status` | Show status of all services |
 | `./scripts/dev.sh logs backend` | View API logs |
 | `./scripts/dev.sh logs frontend` | View frontend logs (tail -f) |
+| `./scripts/dev.sh logs worker` | View Celery worker logs |
+| `./scripts/dev.sh logs beat` | View Celery beat (scheduler) logs |
 | `./scripts/dev.sh seed` | Run initial database setup (interactive) |
 | `./scripts/dev.sh seed test` | Seed with test accounts (no prompts) |
 | `./scripts/dev.sh test` | Run backend tests |
+
+`start all` brings up the Celery worker and beat along with the API and database. `worker` and `beat` are also valid targets for `start`, `stop` and `restart` if you need to control them on their own.
+
+> **Adding a backend dependency?** Python dependencies are baked into the Docker image — `pyproject.toml` is not bind-mounted — so a new dependency will be missing from the running container until you rebuild it:
+>
+> ```bash
+> docker compose -f backend/docker/docker-compose.yml build --no-cache api
+> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
+> ```
 
 ### Service URLs
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Memship Dev Environment Manager
 # Backend runs in Docker (API + DB), Frontend runs locally with pnpm
-# Usage: ./scripts/dev.sh {start|stop|restart|status|logs|seed|test} [backend|frontend|all]
+# Usage: ./scripts/dev.sh {start|stop|restart|status|logs|seed|test} [backend|frontend|worker|beat|all]
 
 set -e
 


### PR DESCRIPTION
## Why

`CONTRIBUTING.md` — the first file a new contributor opens — still described a project that was not ready for code contributions:

> **Code Contributions (Coming Soon)** — "Once the project is ready for code contributions, the following guidelines will apply..."
>
> **Development Setup** — "Detailed setup instructions will be added once the infrastructure is in place."

Both have been untrue for months. The effect was that a newcomer was told setup docs did not exist, while the README sitting next to it had them in full. It also said "Fork the repository", which is wrong for someone with push access.

Prompted by onboarding a new collaborator.

## What changed

**`CONTRIBUTING.md`**
- Drop the "Coming Soon" framing — contributions are welcome.
- Real Development Setup: prerequisites, `./scripts/dev.sh start all`, `seed test`, app + API docs URLs, how to run tests, and a pointer to the README for the full reference.
- Note that push-access holders branch rather than fork.
- **No version numbers anywhere** — the file went stale because it described a moment in time; this avoids rebuilding that trap.

**Two things that existed only in the code, now documented**
- `dev.sh` accepts `worker` and `beat` targets, and its own error message lists them as valid — but the usage line omitted them and no doc mentioned them. Added to the usage line and to the Dev Commands table, with a note that `start all` already covers both.
- Python deps are baked into the backend image (`pyproject.toml` is not bind-mounted), so adding a dependency needs an image rebuild. This cost real debugging time during v1.0.1 E2E (`ModuleNotFoundError: segno` against a stale image). Now documented in `CONTRIBUTING.md` and all three READMEs.

## Notes

- README changes are in **en/es/ca**, translated rather than copied, so the three stay in parity.
- Docs only — no runtime code touched. `VERSION` is untouched and no tag was created.
- Facts verified against the code rather than the existing docs: `admin@test.com` / `TestAdmin1!` (`seed.py:485-486`), ports 3000/8003 (compose + `frontend/dev.sh`), both README anchors resolve, `bash -n scripts/dev.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)