### PR TITLE
feat(frontend): show app version in portal footer

### DIFF
--- a/frontend/app/[locale]/(portal)/layout.tsx
+++ b/frontend/app/[locale]/(portal)/layout.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from "@/features/auth/hooks/use-auth";
 import { AppSidebar } from "@/components/layout/sidebar";
 import { Header } from "@/components/layout/header";
+import { AppFooter } from "@/components/layout/footer";
 import { BrandTheme } from "@/components/layout/brand-theme";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { useRouter, usePathname } from "@/lib/i18n/routing";
@@ -53,6 +54,7 @@ export default function PortalLayout({
       <SidebarInset>
         <Header />
         <main className="flex-1 p-4 md:p-6">{children}</main>
+        <AppFooter />
       </SidebarInset>
     </SidebarProvider>
   );

--- a/frontend/app/api/health/route.ts
+++ b/frontend/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8003";
+
+export async function GET() {
+  const res = await fetch(`${API_BASE_URL}/api/v1/health`, {
+    cache: "no-store",
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/frontend/components/layout/footer.tsx
+++ b/frontend/components/layout/footer.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { useVersion } from "@/features/system/hooks/use-version";
+
+export function AppFooter() {
+  const t = useTranslations();
+  const { data } = useVersion();
+
+  return (
+    <footer className="border-t px-4 py-3 text-center text-xs text-muted-foreground md:px-6">
+      {t("app.name")}
+      {data?.version ? ` · ${t("footer.version", { version: data.version })}` : ""}
+    </footer>
+  );
+}

--- a/frontend/features/system/hooks/use-version.ts
+++ b/frontend/features/system/hooks/use-version.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getHealth } from "../services/system-api";
+
+export function useVersion() {
+  return useQuery({
+    queryKey: ["system", "health"],
+    queryFn: getHealth,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}

--- a/frontend/features/system/services/system-api.ts
+++ b/frontend/features/system/services/system-api.ts
@@ -1,0 +1,11 @@
+import { apiClient } from "@/lib/client-api";
+
+export type HealthInfo = {
+  status: string;
+  version: string;
+  environment: string;
+};
+
+export function getHealth() {
+  return apiClient<HealthInfo>("/health");
+}

--- a/frontend/locales/ca/common.json
+++ b/frontend/locales/ca/common.json
@@ -3,6 +3,9 @@
     "name": "Memship",
     "tagline": "Gestió de socis per a tothom"
   },
+  "footer": {
+    "version": "Versió {version}"
+  },
   "nav": {
     "dashboard": "Tauler",
     "members": "Socis",

--- a/frontend/locales/en/common.json
+++ b/frontend/locales/en/common.json
@@ -3,6 +3,9 @@
     "name": "Memship",
     "tagline": "Membership management for everyone"
   },
+  "footer": {
+    "version": "Version {version}"
+  },
   "nav": {
     "dashboard": "Dashboard",
     "members": "Members",

--- a/frontend/locales/es/common.json
+++ b/frontend/locales/es/common.json
@@ -3,6 +3,9 @@
     "name": "Memship",
     "tagline": "Gestión de socios para todos"
   },
+  "footer": {
+    "version": "Versión {version}"
+  },
   "nav": {
     "dashboard": "Panel",
     "members": "Socios",


### PR DESCRIPTION
## Summary

Adds a **footer to the portal layout** that displays the running application version — closing the gap where the frontend never surfaced any version to users. The version is the backend's, read at runtime, so a deployed image shows its promoted semver tag (e.g. `1.0.2`) and a from-source dev env shows `dev` / the `git describe` value.

## What changed

- **`frontend/app/api/health/route.ts`** (new) — Next.js proxy route: `GET /api/health` → backend `GET /api/v1/health` (public, no auth). Follows the existing proxy pattern.
- **`frontend/features/system/services/system-api.ts`** + **`hooks/use-version.ts`** (new) — `useVersion()` TanStack Query hook (`retry: false`, 5-min `staleTime`) over the health endpoint.
- **`frontend/components/layout/footer.tsx`** (new) — `AppFooter`: muted, centered, top-bordered footer rendering `Memship · {version}`. Uses the root `useTranslations()` namespace (this repo spread-merges each locale file's top-level keys).
- **`app/[locale]/(portal)/layout.tsx`** — mounts `<AppFooter />` inside `SidebarInset` below `<main>`.
- **`locales/{es,ca,en}/common.json`** — new `footer.version` key (`Versión / Versió / Version {version}`).

## Why

The frontend had no version display anywhere and never called the backend's `/health` (which already returns `version`). With git tags now the single source of truth for the version, surfacing it in the UI lets anyone confirm which build they're on.

## Validation

- `tsc --noEmit` clean, `eslint` clean, i18n key parity across es/ca/en.
- Ran the full dev stack and logged into the portal — footer renders **"Memship · Versión dev"**; proxy route and backend health both return the version. (Screenshot verified locally.)

## Notes

- This is the first change to touch `frontend/`, so it should exercise the **frontend RC image build** half of the new pipeline (previously only the backend built).
- Dev env reports `dev` (compose sets `APP_VERSION=dev`); deployed images report the promoted tag via `APP_VERSION=${IMAGE_TAG}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)