### PR TITLE
docs(contributing): clarify branches vs environments in GitHub Flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,21 @@ Have a question or want to discuss the project direction? Open an [issue](https:
 Memship uses **GitHub Flow**: `main` is the trunk and always deployable.
 
 - `main` is the single long-lived branch. It is what the staging environment deploys and what releases are cut from.
-- All work happens on **short-lived `feature/*` branches** taken from `main` and merged back through a pull request. There is no `develop` or `integration` branch.
+- All work happens on **short-lived `feature/*` branches** taken from `main` and merged back through a pull request.
 - Every push to `main` builds **release-candidate images** that staging validates before any release.
+
+**There are no long-lived environment branches** — no `develop`, `integration`, `preproduction`, `release/*`, or `hotfix/*`. GitHub Flow deliberately rejects the multi-branch Git Flow model: at this team size its ceremony is overhead, and in Git Flow `develop` *is* the integration branch, so a separate `develop` **and** `integration` (or `preproduction`) branch is redundant. One trunk avoids the question entirely.
+
+#### Branches vs. environments
+
+The most common point of confusion: **"preproduction" (staging) is an *environment*, not a branch.** Environments are targets you deploy an image *to*; they do not each need a matching branch. The mapping is:
+
+| Environment | What deploys there | Trigger |
+|---|---|---|
+| **Staging** (preproduction) | the release-candidate image built from `main` (`sha-<commit>` / `main`) | every merge to `main` |
+| **Production** | the *same* RC image, re-tagged `:X.Y.Z` + `:latest` (build once, promote — never rebuilt) | pushing a `v*.*.*` git tag |
+
+So there is nothing to "prepare" as a `preproduction` branch — a pre-production gate is provided by the **staging environment** deploying the RC image and validating it before any tag is cut. See [Releases](#releases) below for the promote flow.
 
 ### Getting Started
 


### PR DESCRIPTION
## What

Expands the **Branching model — GitHub Flow** section of `CONTRIBUTING.md` to address a recurring point of confusion: whether the project needs `develop` / `preproduction` branches.

- Explicitly names `develop`, `integration`, `preproduction`, `release/*`, `hotfix/*` as branches that intentionally **do not exist**, with the one-line rationale for rejecting Git Flow.
- Adds a **Branches vs. environments** subsection with a table mapping deploy targets to triggers:
  - **Staging (preproduction)** ← RC image from `main`, on every merge
  - **Production** ← the same image re-tagged on a `v*.*.*` tag (build-once-promote)
- States plainly that a pre-production gate is provided by the **staging environment**, so there is no `preproduction` branch to prepare.

## Why

A collaborator asked to "prepare the branches for develop and preproduction" — the Git Flow layout that was explicitly rejected in the 2026-07-15 branching decision. This makes the already-agreed model self-explanatory in the doc so it can be referred to directly.

## Note

The doc describes the intended end state; the staging environment itself is still being stood up (separate infra action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)