### PR TITLE
fix(settings): group payment tabs and style sub-tabs as pills

### DIFF
--- a/frontend/app/[locale]/(portal)/settings/page.tsx
+++ b/frontend/app/[locale]/(portal)/settings/page.tsx
@@ -172,15 +172,6 @@ export default function SettingsPage() {
             <TabsTrigger value="payments">{t("settings.payments")}</TabsTrigger>
           )}
           {isSuperAdmin && (
-            <TabsTrigger value="payment-providers">{t("settings.providers.tab")}</TabsTrigger>
-          )}
-          {isSuperAdmin && (
-            <TabsTrigger value="recurring-billing">{t("settings.recurringBilling.tab")}</TabsTrigger>
-          )}
-          {isSuperAdmin && (
-            <TabsTrigger value="payment-reminders">{t("settings.paymentReminders.tab")}</TabsTrigger>
-          )}
-          {isSuperAdmin && (
             <TabsTrigger value="communications">{t("settings.communications.tab")}</TabsTrigger>
           )}
           {isSuperAdmin && (
@@ -406,20 +397,30 @@ export default function SettingsPage() {
           </div>
         </TabsContent>}
 
+        {/* Everything payment-related lives under one tab — four separate
+            top-level tabs pushed the bar past a single row. */}
         {isSuperAdmin && <TabsContent value="payments">
-          <PaymentsSettings />
-        </TabsContent>}
+          <Tabs defaultValue="payments-general">
+            <TabsList>
+              <TabsTrigger value="payments-general">{t("settings.paymentsGeneral")}</TabsTrigger>
+              <TabsTrigger value="payment-providers">{t("settings.providers.tab")}</TabsTrigger>
+              <TabsTrigger value="recurring-billing">{t("settings.recurringBilling.tab")}</TabsTrigger>
+              <TabsTrigger value="payment-reminders">{t("settings.paymentReminders.tab")}</TabsTrigger>
+            </TabsList>
 
-        {isSuperAdmin && <TabsContent value="payment-providers">
-          <PaymentProvidersSettings />
-        </TabsContent>}
-
-        {isSuperAdmin && <TabsContent value="recurring-billing">
-          <RecurringBillingSettings />
-        </TabsContent>}
-
-        {isSuperAdmin && <TabsContent value="payment-reminders">
-          <PaymentRemindersSettings />
+            <TabsContent value="payments-general">
+              <PaymentsSettings />
+            </TabsContent>
+            <TabsContent value="payment-providers">
+              <PaymentProvidersSettings />
+            </TabsContent>
+            <TabsContent value="recurring-billing">
+              <RecurringBillingSettings />
+            </TabsContent>
+            <TabsContent value="payment-reminders">
+              <PaymentRemindersSettings />
+            </TabsContent>
+          </Tabs>
         </TabsContent>}
 
         {isSuperAdmin && <TabsContent value="communications">

--- a/frontend/app/[locale]/(portal)/settings/page.tsx
+++ b/frontend/app/[locale]/(portal)/settings/page.tsx
@@ -77,6 +77,15 @@ type SettingsFormValues = z.infer<typeof settingsSchema>;
 
 const ADDRESS_FIELDS = ["address_line1", "address_line2", "city", "state_province", "postal_code", "country"] as const;
 
+// Nested tab styling. The shared Tabs component is underline-styled; a second
+// underline row would read as a peer of the top-level bar, so sub-tabs use the
+// muted pill look (shadcn's stock appearance) to sit visually inside their parent.
+// self-start: the Tabs root is `flex flex-col`, so without it the list
+// stretches to full width and the pill track spans the page.
+const SUBTAB_LIST = "h-auto w-auto self-start gap-0 rounded-lg border-0 bg-muted p-1";
+const SUBTAB_TRIGGER =
+  "rounded-md border-0 px-3 py-1 data-[state=active]:bg-background data-[state=active]:shadow-sm";
+
 export default function SettingsPage() {
   const t = useTranslations();
   const { user } = useAuth();
@@ -400,12 +409,14 @@ export default function SettingsPage() {
         {/* Everything payment-related lives under one tab — four separate
             top-level tabs pushed the bar past a single row. */}
         {isSuperAdmin && <TabsContent value="payments">
+          {/* Muted pills, not the underline the top-level bar uses — so the
+              nested row reads as a child of Payments rather than a peer. */}
           <Tabs defaultValue="payments-general">
-            <TabsList>
-              <TabsTrigger value="payments-general">{t("settings.paymentsGeneral")}</TabsTrigger>
-              <TabsTrigger value="payment-providers">{t("settings.providers.tab")}</TabsTrigger>
-              <TabsTrigger value="recurring-billing">{t("settings.recurringBilling.tab")}</TabsTrigger>
-              <TabsTrigger value="payment-reminders">{t("settings.paymentReminders.tab")}</TabsTrigger>
+            <TabsList className={SUBTAB_LIST}>
+              <TabsTrigger value="payments-general" className={SUBTAB_TRIGGER}>{t("settings.paymentsGeneral")}</TabsTrigger>
+              <TabsTrigger value="payment-providers" className={SUBTAB_TRIGGER}>{t("settings.providers.tab")}</TabsTrigger>
+              <TabsTrigger value="recurring-billing" className={SUBTAB_TRIGGER}>{t("settings.recurringBilling.tab")}</TabsTrigger>
+              <TabsTrigger value="payment-reminders" className={SUBTAB_TRIGGER}>{t("settings.paymentReminders.tab")}</TabsTrigger>
             </TabsList>
 
             <TabsContent value="payments-general">

--- a/frontend/locales/ca/settings.json
+++ b/frontend/locales/ca/settings.json
@@ -119,6 +119,7 @@
       "paddingHint": "Longitud de la seqüència amb zeros",
       "assignNumbers": "Assigna números als socis que no en tinguin",
       "assignedCount": "{count} número(s) de soci assignat(s)"
-    }
+    },
+    "paymentsGeneral": "General"
   }
 }

--- a/frontend/locales/en/settings.json
+++ b/frontend/locales/en/settings.json
@@ -119,6 +119,7 @@
       "paddingHint": "Length of the zero-padded sequence",
       "assignNumbers": "Assign numbers to members without one",
       "assignedCount": "{count} member number(s) assigned"
-    }
+    },
+    "paymentsGeneral": "General"
   }
 }

--- a/frontend/locales/es/settings.json
+++ b/frontend/locales/es/settings.json
@@ -119,6 +119,7 @@
       "paddingHint": "Longitud de la secuencia con ceros",
       "assignNumbers": "Asignar números a los socios que no tengan",
       "assignedCount": "{count} número(s) de socio asignado(s)"
-    }
+    },
+    "paymentsGeneral": "General"
   }
 }


### PR DESCRIPTION
The settings tab bar had grown to nine super-admin tabs and no longer fit one row. Adding the Profile fields tab in v1.1.0 pushed it over.

## Cause

`TabsList` is `flex-nowrap` with a fixed `h-9`, and `TabsTrigger` has no `shrink-0` (`components/ui/tabs.tsx:29,45`). At nine triggers the flex items shrank below their content width, so the labels wrapped *inside* each trigger — "Tarjeta de socio" rendered on two lines and spilled past the 36px bar.

## Fix

Four of the nine were payment-related, so **Pagos**, **Proveedores de pago**, **Facturación recurrente** and **Recordatorios de pago** are now sub-tabs under a single **Payments** tab. Top level goes 9 → 6, which fits comfortably.

No settings component changed — only where they are mounted, so the forms themselves carry no risk.

The nested row uses the **muted pill** style (shadcn's stock Tabs appearance) rather than a second underline row: two identical underline rows read as peers, and the hierarchy would rest on vertical position alone. Scoped to this page via two `className` constants, so the shared component is untouched and no other tab set in the app moves.

One non-obvious detail, commented in the code: the pill track needs `self-start`. The `Tabs` root is `flex flex-col`, so the list stretches across the cross axis and the track spans the full page width regardless of `w-auto` — this is not a Tailwind override problem (`cn()` does use `tailwind-merge`).

## Notes

- Adds `settings.paymentsGeneral` for the inner "General" tab; the other three inner labels reuse their existing keys. `settings` namespace parity clean at 107 keys across es/ca/en.
- Verified in the browser in **light and dark** mode: six tabs on one row, sub-tabs switch correctly, no console errors.
- Typecheck and ESLint clean.

This buys headroom rather than immunity — another two or three features put the bar back where it was. At that point the real answer is a settings submenu with sub-routes; the sidebar primitives (`SidebarMenuSub`, `SidebarMenuSubButton`) already exist, though there is no `collapsible.tsx` yet and Settings is still a single ~440-line page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7vZcqbKgCrURvN8SDPRBD