### PR TITLE
fix(settings): group member-related settings under a Members tab

### DIFF
--- a/frontend/app/[locale]/(portal)/settings/page.tsx
+++ b/frontend/app/[locale]/(portal)/settings/page.tsx
@@ -172,7 +172,7 @@ export default function SettingsPage() {
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{t("settings.title")}</h1>
 
-      <Tabs defaultValue={isSuperAdmin ? "organization" : "membership-types"}>
+      <Tabs defaultValue={isSuperAdmin ? "organization" : "members"}>
         <TabsList>
           {isSuperAdmin && (
             <TabsTrigger value="organization">{t("settings.organization")}</TabsTrigger>
@@ -180,16 +180,9 @@ export default function SettingsPage() {
           {isSuperAdmin && (
             <TabsTrigger value="payments">{t("settings.payments")}</TabsTrigger>
           )}
-          {isSuperAdmin && (
-            <TabsTrigger value="communications">{t("settings.communications.tab")}</TabsTrigger>
-          )}
-          {isSuperAdmin && (
-            <TabsTrigger value="member-card">{t("settings.memberCard.tab")}</TabsTrigger>
-          )}
-          {isSuperAdmin && (
-            <TabsTrigger value="profile-fields">{t("profileFields.tab")}</TabsTrigger>
-          )}
-          <TabsTrigger value="membership-types">{t("nav.membershipTypes")}</TabsTrigger>
+          {/* Ungated: membership types is the one setting a plain admin can
+              reach, and it lives in here. */}
+          <TabsTrigger value="members">{t("nav.members")}</TabsTrigger>
         </TabsList>
 
         {isSuperAdmin && <TabsContent value="organization">
@@ -434,20 +427,37 @@ export default function SettingsPage() {
           </Tabs>
         </TabsContent>}
 
-        {isSuperAdmin && <TabsContent value="communications">
-          <CommunicationsSettings />
-        </TabsContent>}
+        {/* Everything about members and how the org talks to them. The group
+            is ungated; its children keep their own gates, so a plain admin
+            lands here and sees only membership types. */}
+        <TabsContent value="members">
+          <Tabs defaultValue={isSuperAdmin ? "communications" : "membership-types"}>
+            <TabsList className={SUBTAB_LIST}>
+              {isSuperAdmin && (
+                <TabsTrigger value="communications" className={SUBTAB_TRIGGER}>{t("settings.communications.tab")}</TabsTrigger>
+              )}
+              {isSuperAdmin && (
+                <TabsTrigger value="member-card" className={SUBTAB_TRIGGER}>{t("settings.memberCard.tab")}</TabsTrigger>
+              )}
+              {isSuperAdmin && (
+                <TabsTrigger value="profile-fields" className={SUBTAB_TRIGGER}>{t("profileFields.tab")}</TabsTrigger>
+              )}
+              <TabsTrigger value="membership-types" className={SUBTAB_TRIGGER}>{t("nav.membershipTypes")}</TabsTrigger>
+            </TabsList>
 
-        {isSuperAdmin && <TabsContent value="member-card">
-          <MemberCardSettings />
-        </TabsContent>}
-
-        {isSuperAdmin && <TabsContent value="profile-fields">
-          <ProfileFieldsSettings />
-        </TabsContent>}
-
-        <TabsContent value="membership-types">
-          <MembershipTypesSettings />
+            {isSuperAdmin && <TabsContent value="communications">
+              <CommunicationsSettings />
+            </TabsContent>}
+            {isSuperAdmin && <TabsContent value="member-card">
+              <MemberCardSettings />
+            </TabsContent>}
+            {isSuperAdmin && <TabsContent value="profile-fields">
+              <ProfileFieldsSettings />
+            </TabsContent>}
+            <TabsContent value="membership-types">
+              <MembershipTypesSettings />
+            </TabsContent>
+          </Tabs>
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
Follow-up to #21. Communications, Member card, Profile fields and Membership types are all about members and how the organization talks to them, so they now sit as sub-tabs under a single **Members** tab.

Top level goes from six tabs to three: **Organization · Payments · Members**.

## The gating trap

`membership-types` was the only tab **not** behind `isSuperAdmin` — a plain `admin` sees exactly one tab today, and `defaultValue` fell back to it. Nesting it under a super-admin-gated group would have locked plain admins out of the settings page entirely.

So the group tab is deliberately **ungated** while its four children keep their own gates. For the same reason the nested `Tabs` takes a role-dependent `defaultValue`: pointing it at `communications` would leave a plain admin selected on a tab whose trigger and content are both gated out, i.e. a blank panel where the membership types table should be.

Both facts are commented in the code, since they look like redundant conditionals otherwise.

## Verified as both roles

- **Super admin** — Members shows four sub-tabs; each renders its settings component
- **Plain admin** — lands on Members with Membership types alone, table loads, access unchanged from before this PR

Typecheck, ESLint and browser console all clean. No new i18n keys: the group reuses `nav.members`.

## Note

Six flat tabs already fit on one row after #21, so this is an information-architecture change rather than an overflow fix — worth a moment's use before merging to confirm the two-clicks-deep trade is worth it.

It does set up the longer-term direction well: three groups with sub-tabs maps cleanly onto settings sub-routes (`/settings/organization`, `/settings/payments`, `/settings/members`) if the GitLab-style submenu is ever built, with the bonus that routes are deep-linkable where tabs are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7vZcqbKgCrURvN8SDPRBD