### PR TITLE
docs(readme): correct v1.1.0 status and add v1.1.1 roadmap row

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -104,7 +104,8 @@ Obriu http://localhost:8081 i inicieu sessió amb les vostres credencials. Canvi
 | v0.8.0 | ~~Convocatòries~~ — ajornat després de v1.0.0 (segons demanda) | Ajornat |
 | v1.0.0 | Estabilització i llançament — exportacions CSV, tauler financer, notes i recordatoris, resum anual, dades demo, polit de docs | Fet |
 | v1.0.1 | Pedaç — corregeix el registre de tasques programades de facturació/recordatoris a Celery; protecció de CI contra la sobreescriptura d'etiquetes d'imatge | Fet |
-| v1.1.0 | Camps de perfil personalitzats — dades de soci configurables per l'organització (text, número, data, selecció, …) amb validació per camp i visibilitat/edició per camp | Publicat |
+| v1.1.0 | Camps de perfil personalitzats — dades de soci configurables per l'organització (text, número, data, selecció, …) amb validació per camp i visibilitat/edició per camp | Fet |
+| v1.1.1 | Pedaç — reorganització de la navegació de configuració: ajustos de pagaments i de socis agrupats a les pestanyes Pagaments i Socis | Fet |
 | v1.2.0 | Rols i permisos flexibles — multi-rol i permisos per rol més enllà dels 4 rols fixos | Planificat |
 | v1.3.0 | Integració SSO / identitat — inici de sessió amb l'IdP de l'organització (SAML/OIDC); mode proveïdor més endavant | Planificat |
 | v1.4.0 | Biblioteca de documents — estatuts, actes, formularis amb visibilitat per grup | Planificat |

--- a/README.es.md
+++ b/README.es.md
@@ -104,7 +104,8 @@ Abre http://localhost:8081 e inicia sesión con tus credenciales. Cambia `PORT=8
 | v0.8.0 | ~~Convocatorias~~ — aplazado tras v1.0.0 (según demanda) | Aplazado |
 | v1.0.0 | Estabilización y lanzamiento — exportaciones CSV, panel financiero, notas y recordatorios, resumen anual, datos demo, pulido de docs | Hecho |
 | v1.0.1 | Parche — corrige el registro de tareas programadas de facturación/recordatorios en Celery; protección de CI contra la sobrescritura de etiquetas de imagen | Hecho |
-| v1.1.0 | Campos de perfil personalizados — datos de socio configurables por la organización (texto, número, fecha, selección, …) con validación por campo y visibilidad/edición por campo | Publicado |
+| v1.1.0 | Campos de perfil personalizados — datos de socio configurables por la organización (texto, número, fecha, selección, …) con validación por campo y visibilidad/edición por campo | Hecho |
+| v1.1.1 | Parche — reorganización de la navegación de configuración: ajustes de pagos y de socios agrupados en las pestañas Pagos y Socios | Hecho |
 | v1.2.0 | Roles y permisos flexibles — multi-rol y permisos por rol más allá de los 4 roles fijos | Planificado |
 | v1.3.0 | Integración SSO / identidad — inicio de sesión con el IdP de la organización (SAML/OIDC); modo proveedor más adelante | Planificado |
 | v1.4.0 | Biblioteca de documentos — estatutos, actas, formularios con visibilidad por grupo | Planificado |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Open http://localhost:8081 and log in with your credentials. Change `PORT=8081` 
 | v0.8.0 | ~~Convocations~~ — deferred post-1.0 (build on demand) | Deferred |
 | v1.0.0 | Stabilization & Release — CSV exports, finance dashboard, notes & reminders, annual summary, demo seed, docs polish | Done |
 | v1.0.1 | Patch — fix Celery scheduled billing/reminder task registration; CI guard against image tag overwrite | Done |
-| v1.1.0 | Custom profile fields — org-configurable member data (text, number, date, select, …) with per-field validation and per-field visibility/editability | Shipped |
+| v1.1.0 | Custom profile fields — org-configurable member data (text, number, date, select, …) with per-field validation and per-field visibility/editability | Done |
+| v1.1.1 | Patch — settings navigation reorganised: payment and member settings grouped under Payments and Members tabs | Done |
 | v1.2.0 | Flexible roles & permissions — multi-role, per-role rights beyond the 4 fixed roles | Planned |
 | v1.3.0 | SSO / identity integration — sign in via an org's IdP (SAML/OIDC); provider mode later | Planned |
 | v1.4.0 | Document library — statutes, minutes, forms with per-group visibility | Planned |


### PR DESCRIPTION
Two small roadmap-table corrections across the three READMEs.

**1. v1.1.0 status wording.** It was marked `Shipped` / `Publicado` / `Publicat` while all 35 other completed rows use `Done` / `Hecho` / `Fet`. Corrected — the table now has 37 consistent `Done` rows and no outliers.

**2. Adds the v1.1.1 row** for the settings navigation reorganisation (#21 and #22), which is on `main` but not in any released image.

The row has to land *before* the tag, not after: `.github/workflows/release.yml:57-66` greps `README.md` **at the tagged commit** and `exit 1`s if the version is missing. Patch rows are the established convention here — v0.3.1–v0.3.6, v0.7.1 and v1.0.1 all have them.

## Release sequence after merge

This is docs-only, so `ci.yml`'s paths filter (`backend/**`, `frontend/**`, `.github/workflows/ci.yml`) means **no CI run and therefore no RC image** for the merge commit — Build Images triggers on `workflow_run` of CI. Tagging that commit directly would fall back to building from the tag rather than promoting.

The clean path is to force the RC build first, since `workflow_dispatch` rebuilds both images unconditionally (`build-images.yml:51-56`):

1. merge this PR
2. `gh workflow run "Build Images"` on `main`
3. `./scripts/release.sh 1.1.1` — guard passes, RC image exists, images promote without a rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7vZcqbKgCrURvN8SDPRBD