### PR TITLE
docs(roadmap): decouple roadmap from version numbers; assign versions at release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,16 @@ See the [Development section of the README](README.md#development) for the full 
 
 Releases are driven by **git tags — there is no `VERSION` file and no version-bumping git hooks.** The git tag is the single source of truth for the version.
 
+### Choosing a version
+
+Version numbers follow [semantic versioning](https://semver.org/) and are **chosen at release time, not reserved on the roadmap in advance.** The [roadmap](README.md#roadmap) lists planned features without numbers; a feature only gets its number when it ships. Pick it relative to the latest released tag:
+
+- **Minor** (`x.Y.0`) — a new feature or roadmap item (a new domain, a new member-facing capability).
+- **Patch** (`x.y.Z`) — bug fixes and small polish, no new feature.
+- **Major** (`X.0.0`) — a breaking change to the API, data model, or deployment/upgrade contract.
+
+Because features are built in parallel, **the number is claimed at release, not when you branch.** Whoever releases first takes the next number; the next feature to ship takes the one after — so don't hard-code a target version into your branch, commits, or the roadmap while the work is in flight. When your feature is ready, add its row to the **Released** table in the [roadmap](README.md#roadmap) *in the same PR as the feature code*, then tag. That is also what satisfies the roadmap guard (step 4 below): the tagged commit must already carry the released version's README row.
+
 The flow is **build once, promote**:
 
 1. A PR merges to `main`. CI runs, then the Build Images workflow pushes **release-candidate images** tagged `sha-<commit>` and `main` to GHCR.
@@ -121,7 +131,7 @@ The flow is **build once, promote**:
    ```
 
    This creates an annotated `v1.3.0` tag and pushes it.
-4. The Release workflow **promotes the exact RC image** for that commit to `:1.3.0` and `:latest` — it does not rebuild, so staging and production ship identical bytes. It also checks that the version has a row in the README roadmap.
+4. The Release workflow **promotes the exact RC image** for that commit to `:1.3.0` and `:latest` — it does not rebuild, so staging and production ship identical bytes. It also checks that the released version has a row in the README roadmap's **Released** table.
 
 The version the running app reports comes from the `APP_VERSION` environment variable (set from the image tag at deploy time); running from source, it falls back to `git describe`.
 

--- a/README.ca.md
+++ b/README.ca.md
@@ -65,6 +65,10 @@ Obriu http://localhost:8081 i inicieu sessió amb les vostres credencials. Canvi
 
 ## Full de ruta
 
+Memship segueix el [versionat semàntic](https://semver.org/) i **els números de versió s'assignen en el moment del llançament, mai es reserven al full de ruta per avançat.** A continuació, la taula **Publicat** és l'historial llançat; **Planificat** és una llista prioritzada del que ve. Un element planificat rep versió només quan es publica — consulta [Triar una versió](CONTRIBUTING.md#choosing-a-version) per saber com s'escull el número.
+
+### Publicat
+
 | Versió | Fita | Estat |
 |--------|------|-------|
 | v0.1.0 | Gestió de socis MVP — autenticació, RBAC, CRUD de socis, tipus de membresies, i18n, Docker, CI | Fet |
@@ -98,21 +102,26 @@ Obriu http://localhost:8081 i inicieu sessió amb les vostres credencials. Canvi
 | v0.4.5 | Recordatoris de pagament — notificacions per correu de rebuts vençuts | Fet |
 | v0.5.0 | Comunicacions simples — anuncis de l'administrador a tots els socis / grup / tipus de quota | Fet |
 | v0.5.1 | Vista d'enviaments de comunicacions — seguiment de destinataris + "Vist" a l'app | Fet |
-| v0.6.0 | ~~Reserves simples~~ — ajornat després de v1.0.0 (segons demanda) | Ajornat |
 | v0.7.0 | Carnet digital de soci + registre QR — carnet en PDF, numeració automàtica de socis | Fet |
 | v0.7.1 | Millores del carnet — vista de carnet per a l'admin, foto de perfil del soci, redisseny del perfil | Fet |
-| v0.8.0 | ~~Convocatòries~~ — ajornat després de v1.0.0 (segons demanda) | Ajornat |
 | v1.0.0 | Estabilització i llançament — exportacions CSV, tauler financer, notes i recordatoris, resum anual, dades demo, polit de docs | Fet |
 | v1.0.1 | Pedaç — corregeix el registre de tasques programades de facturació/recordatoris a Celery; protecció de CI contra la sobreescriptura d'etiquetes d'imatge | Fet |
 | v1.1.0 | Camps de perfil personalitzats — dades de soci configurables per l'organització (text, número, data, selecció, …) amb validació per camp i visibilitat/edició per camp | Fet |
 | v1.1.1 | Pedaç — reorganització de la navegació de configuració: ajustos de pagaments i de socis agrupats a les pestanyes Pagaments i Socis | Fet |
-| v1.2.0 | Rols i permisos flexibles — multi-rol i permisos per rol més enllà dels 4 rols fixos | Planificat |
-| v1.3.0 | Integració SSO / identitat — inici de sessió amb l'IdP de l'organització (SAML/OIDC); mode proveïdor més endavant | Planificat |
-| v1.4.0 | Biblioteca de documents — estatuts, actes, formularis amb visibilitat per grup | Planificat |
-| v1.5.0 | Calendari d'esdeveniments + confirmació d'assistència — vista de calendari i seguiment de participació | Planificat |
-| després de v1.5.0 | Mòduls opcionals per a superadmin — àlbums de fotos, fòrum, llibre de visites, directori d'enllaços, inventari/préstecs, ginys del portal (l'enfocament de lliurament es decideix en completar les millores principals) | Planificat |
 
-Ajornat després de v1.0.0: GoCardless e-mandats, integració PayPal, flux d'Stripe Invoice, accions massives en rebuts, generador d'informes personalitzats, enquestes, facturació familiar i altres variacions complexes de les anteriors. Llista completa d'ajornats a `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
+### Planificat
+
+Prioritzat, encara sense versió. Cada element esdevé un llançament versionat quan es publica, i el llançament pren el següent número semàntic per ordre.
+
+- **Integració SSO / identitat** — inici de sessió amb l'IdP de l'organització (SAML/OIDC); mode proveïdor més endavant _(en curs)_
+- **Reserves simples** — els socis reserven recursos compartits (camps, pistes, sales) en un calendari per espai _(en curs)_
+- **Convocatòries** — convocatòries formals d'Assemblea General amb confirmació del soci mitjançant token
+- **Rols i permisos flexibles** — multi-rol i permisos per rol més enllà dels 4 rols fixos
+- **Biblioteca de documents** — estatuts, actes, formularis amb visibilitat per grup
+- **Calendari d'esdeveniments + confirmació d'assistència** — vista de calendari i seguiment de participació
+- **Extensions — sistema de mòduls/connectors** — complements opcionals lliurats com a mòduls/connectors: àlbums de fotos, fòrum, llibre de visites, directori d'enllaços, inventari/préstecs, ginys del portal
+
+Les variacions complexes es construeixen sota demanda, quan una implementació real les necessita: GoCardless e-mandats, PayPal, flux d'Stripe Invoice, accions massives en rebuts, generador d'informes personalitzats, enquestes, facturació familiar, reserves amb classes de grup/llista d'espera, votació i adjunts en convocatòries, i variants més profundes de les funcions anteriors.
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -65,6 +65,10 @@ Abre http://localhost:8081 e inicia sesión con tus credenciales. Cambia `PORT=8
 
 ## Hoja de ruta
 
+Memship sigue el [versionado semántico](https://semver.org/) y **los números de versión se asignan en el momento del lanzamiento, nunca se reservan en la hoja de ruta por adelantado.** A continuación, la tabla **Publicado** es el historial lanzado; **Planificado** es una lista priorizada de lo siguiente. Un elemento planificado recibe versión solo cuando se lanza — consulta [Elegir una versión](CONTRIBUTING.md#choosing-a-version) para saber cómo se escoge el número.
+
+### Publicado
+
 | Versión | Hito | Estado |
 |---------|------|--------|
 | v0.1.0 | Gestión de socios MVP — autenticación, RBAC, CRUD de socios, tipos de membresía, i18n, Docker, CI | Hecho |
@@ -98,21 +102,26 @@ Abre http://localhost:8081 e inicia sesión con tus credenciales. Cambia `PORT=8
 | v0.4.5 | Recordatorios de pago — notificaciones por email de recibos vencidos | Hecho |
 | v0.5.0 | Comunicaciones simples — anuncios del admin a todos los socios / grupo / tipo de cuota | Hecho |
 | v0.5.1 | Vista de envíos de comunicaciones — seguimiento de destinatarios + "Visto" en la app | Hecho |
-| v0.6.0 | ~~Reservas simples~~ — aplazado tras v1.0.0 (según demanda) | Aplazado |
 | v0.7.0 | Carnet digital de socio + registro QR — carnet en PDF, numeración automática de socios | Hecho |
 | v0.7.1 | Mejoras del carnet — vista de carnet para el admin, foto de perfil del socio, rediseño del perfil | Hecho |
-| v0.8.0 | ~~Convocatorias~~ — aplazado tras v1.0.0 (según demanda) | Aplazado |
 | v1.0.0 | Estabilización y lanzamiento — exportaciones CSV, panel financiero, notas y recordatorios, resumen anual, datos demo, pulido de docs | Hecho |
 | v1.0.1 | Parche — corrige el registro de tareas programadas de facturación/recordatorios en Celery; protección de CI contra la sobrescritura de etiquetas de imagen | Hecho |
 | v1.1.0 | Campos de perfil personalizados — datos de socio configurables por la organización (texto, número, fecha, selección, …) con validación por campo y visibilidad/edición por campo | Hecho |
 | v1.1.1 | Parche — reorganización de la navegación de configuración: ajustes de pagos y de socios agrupados en las pestañas Pagos y Socios | Hecho |
-| v1.2.0 | Roles y permisos flexibles — multi-rol y permisos por rol más allá de los 4 roles fijos | Planificado |
-| v1.3.0 | Integración SSO / identidad — inicio de sesión con el IdP de la organización (SAML/OIDC); modo proveedor más adelante | Planificado |
-| v1.4.0 | Biblioteca de documentos — estatutos, actas, formularios con visibilidad por grupo | Planificado |
-| v1.5.0 | Calendario de eventos + confirmación de asistencia — vista de calendario y seguimiento de participación | Planificado |
-| tras v1.5.0 | Módulos opcionales para superadmin — álbumes de fotos, foro, libro de visitas, directorio de enlaces, inventario/préstamos, widgets del portal (el enfoque de entrega se decide al completar las mejoras principales) | Planificado |
 
-Aplazado tras v1.0.0: GoCardless e-mandatos, integración PayPal, flujo de Stripe Invoice, acciones masivas en recibos, generador de informes personalizados, encuestas, facturación familiar y otras variaciones complejas de las anteriores. Lista completa de aplazados en `memship-definition/docs/public/ROADMAP-v1.0.0.md`.
+### Planificado
+
+Priorizado, aún sin versión. Cada elemento se convierte en un lanzamiento versionado cuando se publica, y el lanzamiento toma el siguiente número semántico por orden.
+
+- **Integración SSO / identidad** — inicio de sesión con el IdP de la organización (SAML/OIDC); modo proveedor más adelante _(en curso)_
+- **Reservas simples** — los socios reservan recursos compartidos (campos, pistas, salas) en un calendario por espacio _(en curso)_
+- **Convocatorias** — convocatorias formales de Asamblea General con confirmación del socio mediante token
+- **Roles y permisos flexibles** — multi-rol y permisos por rol más allá de los 4 roles fijos
+- **Biblioteca de documentos** — estatutos, actas, formularios con visibilidad por grupo
+- **Calendario de eventos + confirmación de asistencia** — vista de calendario y seguimiento de participación
+- **Extensiones — sistema de módulos/plugins** — complementos opcionales entregados como módulos/plugins: álbumes de fotos, foro, libro de visitas, directorio de enlaces, inventario/préstamos, widgets del portal
+
+Las variaciones complejas se construyen bajo demanda, cuando una implementación real las necesita: GoCardless e-mandatos, PayPal, flujo de Stripe Invoice, acciones masivas en recibos, generador de informes personalizados, encuestas, facturación familiar, reservas con clases de grupo/lista de espera, votación y adjuntos en convocatorias, y variantes más profundas de las funciones anteriores.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Open http://localhost:8081 and log in with your credentials. Change `PORT=8081` 
 
 ## Roadmap
 
+Memship follows [semantic versioning](https://semver.org/), and **version numbers are assigned at release time — never reserved on the roadmap in advance.** Below, the **Released** table is the shipped history; **Planned** is a priority-ordered list of what's next. A planned item is given a version only when it ships — see [Choosing a version](CONTRIBUTING.md#choosing-a-version) for how the number is picked.
+
+### Released
+
 | Version | Milestone | Status |
 |---------|-----------|--------|
 | v0.1.0 | Member Management MVP — auth, RBAC, member CRUD, membership types, i18n, Docker, CI | Done |
@@ -98,21 +102,26 @@ Open http://localhost:8081 and log in with your credentials. Change `PORT=8081` 
 | v0.4.5 | Payment reminders — overdue email notifications | Done |
 | v0.5.0 | Simple Communications — admin announcements to all/group/membership type | Done |
 | v0.5.1 | Communications sent view — recipient tracking + in-app "Seen" | Done |
-| v0.6.0 | ~~Simple Bookings~~ — deferred post-1.0 (build on demand) | Deferred |
 | v0.7.0 | Digital Member Card + QR Check-in — PDF card, auto member numbers | Done |
 | v0.7.1 | Member card polish — admin card view on member page, member profile photo upload, profile page redesign | Done |
-| v0.8.0 | ~~Convocations~~ — deferred post-1.0 (build on demand) | Deferred |
 | v1.0.0 | Stabilization & Release — CSV exports, finance dashboard, notes & reminders, annual summary, demo seed, docs polish | Done |
 | v1.0.1 | Patch — fix Celery scheduled billing/reminder task registration; CI guard against image tag overwrite | Done |
 | v1.1.0 | Custom profile fields — org-configurable member data (text, number, date, select, …) with per-field validation and per-field visibility/editability | Done |
 | v1.1.1 | Patch — settings navigation reorganised: payment and member settings grouped under Payments and Members tabs | Done |
-| v1.2.0 | Flexible roles & permissions — multi-role, per-role rights beyond the 4 fixed roles | Planned |
-| v1.3.0 | SSO / identity integration — sign in via an org's IdP (SAML/OIDC); provider mode later | Planned |
-| v1.4.0 | Document library — statutes, minutes, forms with per-group visibility | Planned |
-| v1.5.0 | Events calendar + RSVP — calendar view and participation tracking | Planned |
-| after v1.5.0 | Optional super-admin modules — photo albums, forum, guestbook, weblinks directory, inventory/lending, portal widgets (delivery approach decided once the core gaps ship) | Planned |
 
-Deferred past v1.0.0: GoCardless e-mandates, PayPal integration, Stripe Invoice flow, bulk receipt actions, custom report builder, surveys, family group billing, and other complex variations of the above. See `memship-definition/docs/public/ROADMAP-v1.0.0.md` for the full deferred list.
+### Planned
+
+Priority-ordered, not yet versioned. Each becomes a versioned release when it ships, and the release claims the next semver number in order.
+
+- **SSO / identity integration** — sign in via an org's IdP (SAML/OIDC); provider mode later _(in progress)_
+- **Simple Bookings** — members reserve time on shared resources (pitches, courts, rooms) on a per-space calendar _(in progress)_
+- **Convocations** — formal General Assembly calls with token-based member RSVP
+- **Flexible roles & permissions** — multi-role, per-role rights beyond the 4 fixed roles
+- **Document library** — statutes, minutes, forms with per-group visibility
+- **Events calendar + RSVP** — calendar view and participation tracking
+- **Extensions — modules/plugins system** — optional add-ons delivered as modules/plugins: photo albums, forum, guestbook, weblinks directory, inventory/lending, portal widgets
+
+Complex variations are built on demand, when a real deployment needs them: GoCardless e-mandates, PayPal, Stripe Invoice flow, bulk receipt actions, custom report builder, surveys, family group billing, group-class/waitlist bookings, convocation voting & document attachments, and similar deeper cuts of the features above.
 
 ---
 


### PR DESCRIPTION
## Why

Pre-assigning version numbers to unbuilt roadmap items caused a collision: bookings work and the in-progress SSO feature were both pointed at fixed future versions, and shifting one meant renumbering the whole planned band. This decouples the roadmap from version numbers so parallel work can't clash over a number.

## What changed

**READMEs (en/es/ca)** — roadmap split into two sections:
- **Released** — the versioned changelog (history, unchanged). Removed the never-released `v0.6.0`/`v0.8.0` phantom rows.
- **Planned** — an *unversioned*, priority-ordered list. Current order: SSO *(in progress)* → Simple Bookings *(in progress)* → Convocations → Flexible roles → Document library → Events calendar + RSVP → Extensions (modules/plugins).
- Fixed a stale pointer to the retired `memship-definition` repo (folded the deferred list inline).

**CONTRIBUTING.md** — new **Choosing a version** section:
- semver minor/patch/major rules;
- the coordination rule for parallel work: **the number is claimed at release, not at branch time** — whoever ships first takes the next number, and the feature PR adds its row to the Released table (which is what the `release.yml` roadmap guard checks) before tagging.

## Notes
- Docs-only; no code paths touched, so CI does not run on these files.
- The release roadmap guard stays satisfied — every *released* version still has its row; only never-released numbers were removed.
- `memship-context` (STATUS.md / ROADMAP) still references the old numbered band — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)