### PR TITLE
docs: self-hosting and user documentation (docs/ folder)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,61 @@
+# Memship Documentation
+
+Documentation for **self-hosting operators**, **organization admins**, and **members**.
+
+> **Languages.** Operator/self-hosting docs are written in **English** (the audience is
+> developers and system administrators, often international). The admin and member guides
+> are **Spanish-first** (`.es.md`), since the people running a club and its members are
+> primarily Spanish-speaking; Catalan (`.ca.md`) and English (`.md`) translations are added
+> on demand.
+
+## Getting started
+
+New to Memship? Start here.
+
+- [Quick start](getting-started/quickstart.md) — try Memship with a single command _(EN)_
+- [Installation](getting-started/installation.md) — production Docker install _(EN)_
+- [First-time setup](getting-started/first-setup.md) — create your admin and organization _(EN)_
+
+## Self-hosting (operators)
+
+Running Memship on your own server.
+
+- [Configuration reference](self-hosting/configuration.md) — every environment variable _(EN)_
+- [Email delivery](self-hosting/email.md) — SMTP or Resend _(EN)_
+- [Backups & restore](self-hosting/backups-and-restore.md) _(EN)_
+- [Upgrading](self-hosting/upgrading.md) — image tags and migrations _(EN)_
+- Reverse proxy & TLS — _planned_
+- Payment providers (Stripe, Redsys/Bizum) — _planned_
+- Troubleshooting — _planned_
+
+## Guía del administrador (admin guide)
+
+Para el personal que gestiona la organización desde el panel de administración.
+
+- [Introducción](admin-guide/overview.es.md) — roles, navegación y panel _(ES)_
+- Socios · Actividades · Pagos · SEPA · Comunicaciones · Carné digital ·
+  Campos personalizados · Reservas · Informes · Configuración — _planificado_
+
+## Guía del socio (member guide)
+
+Para las personas socias que usan el portal.
+
+- Cuenta y perfil · Actividades · Pagos · Carné digital · Reservas — _planificado_
+
+## Reference
+
+- Roles & permissions — _planned_
+- FAQ — _planned_
+- Glossary — _planned_
+
+---
+
+## Contributing to the docs
+
+- **Docs live with the code.** When a feature PR changes behaviour, update its page in the
+  same PR. Each admin/member guide page maps 1:1 to a feature module in the app.
+- **Keep heading anchors stable.** In-app help links point at specific headings
+  (e.g. `admin-guide/activities#lista-de-espera`). Renaming a heading breaks those links, so
+  change anchors deliberately.
+- **Plain Markdown, tool-agnostic.** These files render on GitHub today and can be published
+  by a docs-site generator later without rework. Avoid tool-specific syntax.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,20 +33,34 @@ Running Memship on your own server.
 Para el personal que gestiona la organización desde el panel de administración.
 
 - [Introducción](admin-guide/overview.es.md) — roles, navegación y panel _(ES)_
-- Socios · Actividades · Pagos · SEPA · Comunicaciones · Carné digital ·
-  Campos personalizados · Reservas · Informes · Configuración — _planificado_
+- [Socios](admin-guide/members.es.md) — ciclo de vida, tipos de membresía, grupos _(ES)_
+- [Actividades](admin-guide/activities.es.md) — inscripciones, modalidades, descuentos _(ES)_
+- [Pagos y recibos](admin-guide/payments.es.md) — recibos, cuotas, IVA, pago en línea _(ES)_
+- [Domiciliación SEPA](admin-guide/sepa.es.md) — mandatos y remesas _(ES)_
+- [Comunicaciones](admin-guide/communications.es.md) — anuncios a los socios _(ES)_
+- [Carné digital](admin-guide/member-cards.es.md) — carné QR y control de acceso _(ES)_
+- [Campos de perfil](admin-guide/custom-fields.es.md) — campos personalizados _(ES)_
+- [Informes y panel](admin-guide/reports.es.md) — panel, resumen anual, exportaciones _(ES)_
+- [Configuración](admin-guide/settings.es.md) — organización, facturación, automatizaciones _(ES)_
 
 ## Guía del socio (member guide)
 
 Para las personas socias que usan el portal.
 
-- Cuenta y perfil · Actividades · Pagos · Carné digital · Reservas — _planificado_
+- [Tu cuenta y tu perfil](member-guide/account.es.md) — acceso, perfil, idioma, foto _(ES)_
+- [Actividades](member-guide/activities.es.md) — inscribirse, lista de espera _(ES)_
+- [Pagos y recibos](member-guide/payments.es.md) — mis recibos, pagar online, forma de pago _(ES)_
+- [Carné digital](member-guide/member-card.es.md) — carné QR _(ES)_
 
 ## Reference
 
-- Roles & permissions — _planned_
+- [Roles y permisos](reference/roles-and-permissions.es.md) _(ES)_
 - FAQ — _planned_
 - Glossary — _planned_
+
+> **Simple Bookings** (reserva de espacios) is not yet part of a released version — it ships on
+> its own feature branch. Its admin and member pages will be added **with that feature's PR**,
+> per the "docs live with the code" rule below.
 
 ---
 

--- a/docs/admin-guide/activities.es.md
+++ b/docs/admin-guide/activities.es.md
@@ -1,0 +1,62 @@
+# Actividades
+
+Las actividades son eventos, cursos, talleres o competiciones en los que los socios pueden
+inscribirse. Cada actividad puede tener modalidades, niveles de precio y reglas de
+elegibilidad.
+
+## Crear una actividad
+
+Al crear una actividad configuras:
+
+- **Información básica** — nombre, descripción y descripción breve.
+- **Fechas** — inicio y fin de la actividad, y el **periodo de inscripción** (apertura y
+  cierre).
+- **Ubicación** — con detalles y URL opcionales.
+- **Capacidad** — mínimo y máximo de participantes.
+- **Elegibilidad** — rango de edad (edad mínima/máxima).
+- **Cancelación** — permitir o no la cancelación por el socio, y el plazo (horas antes del
+  inicio).
+- **Imagen de portada** — visible para los socios como miniatura.
+
+## Estados y publicación
+
+Una actividad pasa por los estados **Borrador → Publicada → Archivada** (además de *Cancelada*
+y *Completada*). Solo las actividades **publicadas** son visibles para los socios. Usa las
+acciones **Publicar**, **Archivar** y **Cancelar actividad** según corresponda.
+
+## Modalidades
+
+Las **modalidades** son variantes de una misma actividad, cada una con su propia **capacidad**,
+**precio** y **fecha límite de inscripción** (p. ej. distintos grupos de nivel o turnos).
+
+## Precios
+
+Puedes definir varios **precios**, a nivel de actividad o de modalidad, con **validez temporal**
+(*válido desde / hasta*) para configurar, por ejemplo, tarifas de inscripción anticipada. Un
+precio puede marcarse como **por defecto** u **opcional**, y un importe de 0 se muestra como
+**Gratis**.
+
+## Descuentos
+
+Los **códigos de descuento** pueden ser de tipo **porcentaje** o **importe fijo**, con un número
+**máximo de usos** (o ilimitado) y fechas de validez. El socio introduce el código al
+inscribirse.
+
+## Consentimientos
+
+Cada actividad puede requerir **consentimientos** (obligatorios u opcionales) que el socio debe
+aceptar durante la inscripción. Se ordenan y se editan desde la pestaña correspondiente.
+
+## Documentos adjuntos
+
+Puedes definir **tipos de documento** que el socio debe adjuntar al inscribirse, indicando las
+**extensiones permitidas**, el **tamaño máximo** y si son obligatorios.
+
+## Inscripciones
+
+Desde la pestaña **Inscripciones** ves a los socios inscritos y su estado: **Confirmado**, **En
+espera**, **Pendiente** o **Cancelado**. Cuando una actividad se llena, las nuevas inscripciones
+pasan automáticamente a la **lista de espera** y se promocionan al liberarse plazas. Puedes
+**cambiar el estado** de una inscripción manualmente.
+
+Cada inscripción confirmada puede generar automáticamente un [recibo](payments.es.md).

--- a/docs/admin-guide/communications.es.md
+++ b/docs/admin-guide/communications.es.md
@@ -1,0 +1,37 @@
+# Comunicaciones
+
+Envío de anuncios a los socios por correo electrónico y con notificación en la app.
+
+> **Requisito previo.** Activa las comunicaciones en
+> [Ajustes → Comunicaciones](settings.es.md) y configura el
+> [envío de correo](../self-hosting/email.md).
+
+## Crear un anuncio
+
+Desde **Comunicaciones → Nuevo anuncio**:
+
+1. **Contenido** — un **asunto** y el **mensaje**. El cuerpo admite **Markdown básico**
+   (negrita, cursiva, enlaces y listas) y dispone de **vista previa**.
+2. **Audiencia** — elige a quién se envía:
+   - **Todos los miembros**.
+   - Un **grupo** concreto.
+   - Un **tipo de cuota** (tipo de membresía).
+
+   Al seleccionar la audiencia se muestra cuántos miembros la recibirán.
+3. **Guardar borrador** para terminarlo más tarde, o **Enviar**.
+
+## Envío
+
+Al enviar, el anuncio se distribuye **por correo** y como **notificación en la app** a la
+audiencia seleccionada.
+
+> **Un anuncio enviado no se puede editar.** Revísalo bien antes de confirmar el envío.
+
+## Seguimiento
+
+En la ficha de un anuncio enviado, la pestaña **Destinatarios** muestra, por persona, el
+**canal** (correo / en la app) y si lo ha **visto**. El resumen indica la fecha de envío, el
+número de destinatarios y cuántos lo han visto.
+
+Los socios ven los anuncios en su portal y reciben una **notificación**; pueden marcarlos como
+leídos.

--- a/docs/admin-guide/custom-fields.es.md
+++ b/docs/admin-guide/custom-fields.es.md
@@ -1,0 +1,32 @@
+# Campos de perfil personalizados
+
+Permiten definir campos propios para las fichas de los socios **sin cambiar el código** (por
+ejemplo: talla de equipación, número de licencia federativa, alergias…).
+
+> **Requisito previo.** Actívalos en **Ajustes → Campos de perfil**.
+
+## Definir un campo
+
+Desde **Añadir campo** configuras:
+
+- **Clave** — identificador estable en minúsculas. **No se puede cambiar** después de crear el
+  campo.
+- **Tipo** — **Texto**, **Texto largo**, **Número**, **Fecha**, **Sí/No** o **Lista de
+  opciones**. **No se puede cambiar** después de crear el campo.
+- **Etiqueta** — en cada idioma (ES/CA/EN) y un **texto de ayuda** opcional.
+- **Opciones** — para el tipo *Lista de opciones*, cada una con su valor y etiqueta.
+- **Obligatorio**, **Activo** y **Orden**.
+
+## Visibilidad y edición
+
+Cada campo controla por separado quién puede verlo y editarlo:
+
+- **Acceso del socio** — qué puede hacer el socio con su propio valor: **Oculto**, **Solo
+  lectura** o **Editable**.
+- **Acceso del administrador** — los administradores **siempre pueden ver** el campo; el
+  superadministrador **siempre puede editarlo**.
+
+## Eliminar un campo
+
+Si un campo ya tiene datos guardados, al eliminarlo **se archiva** en lugar de borrarse, para
+no perder la información existente. Los campos archivados aparecen marcados como **Archivado**.

--- a/docs/admin-guide/member-cards.es.md
+++ b/docs/admin-guide/member-cards.es.md
@@ -1,0 +1,33 @@
+# Carné digital y control de acceso
+
+Carné de socio digital con código QR y verificación en el control de acceso.
+
+> **Requisito previo.** Activa las tarjetas de socio en
+> [Ajustes → Tarjeta de socio](settings.es.md).
+
+## Numeración de socios
+
+En los ajustes de la tarjeta configuras la **numeración**:
+
+- **Prefijo** — p. ej. `SCB-` genera `SCB-0001`.
+- **Dígitos** — longitud de la secuencia rellenada con ceros.
+- **Asignar números** a los socios que aún no tengan uno; se indica cuántos números se han
+  asignado.
+
+## El carné del socio
+
+Cada socio dispone en su portal de un **carné digital** con su número de socio, su estado y un
+**código QR**, que puede **descargar en PDF**. Ver la
+[guía del socio → Carné digital](../member-guide/member-card.es.md).
+
+## Control de acceso (escaneo)
+
+La página **Escanear tarjeta de socio** permite verificar el estado de un socio en el control de
+acceso:
+
+- **Escanear con la cámara** el código QR del carné, o **introducir el código manualmente**.
+- El resultado muestra el **número** de socio y su **estado** (Activo, Pendiente, Suspendido,
+  Cancelado o Caducado).
+- **Escanear otro** para verificar al siguiente.
+
+Si un código no es válido o no corresponde a ningún socio, se indica con un aviso.

--- a/docs/admin-guide/members.es.md
+++ b/docs/admin-guide/members.es.md
@@ -1,0 +1,63 @@
+# Socios
+
+Gestión del ciclo de vida de los socios, los tipos de membresía y los grupos.
+
+## Lista de socios
+
+La lista permite buscar, filtrar por **estado** y por **tipo de membresía**, y paginar los
+resultados. Desde ahí puedes abrir la ficha de cada socio o crear uno nuevo con **Nuevo socio**.
+
+## Crear y editar un socio
+
+Al dar de alta un socio se registran, entre otros datos:
+
+- **Nombre**, **Fecha de nacimiento**, **DNI/NIE** y **Género**.
+- **Tipo de membresía** (ver más abajo).
+- **Notas internas** — visibles solo para administradores.
+
+La **Fecha de alta** queda registrada automáticamente.
+
+### Contactos
+
+En la pestaña **Contacto** de la ficha puedes añadir varios medios de contacto (teléfono,
+correo, etc.), cada uno con un **tipo** y una **etiqueta** (p. ej. «Personal», «Trabajo»). Marca
+uno como **contacto principal**.
+
+### Datos bancarios
+
+En la ficha se registran el **IBAN** y el **BIC/SWIFT** del socio, necesarios para la
+[domiciliación SEPA](sepa.es.md).
+
+## Estados del socio
+
+Desde la ficha puedes cambiar el estado con las acciones **Activar**, **Suspender** y
+**Cancelar**. Memship **no elimina** socios de forma permanente en el flujo normal: se cancelan
+para conservar el histórico.
+
+## Tipos de membresía
+
+Los tipos de membresía definen las categorías de socios de tu organización (p. ej. *Socio
+Pleno*, *Estudiante*, *Senior*). Cada tipo tiene:
+
+- **Nombre** y **descripción**.
+- **Precio base (EUR)** y **frecuencia de facturación**.
+- **Grupo** asociado (opcional).
+- Restricciones de edad (opcional).
+
+Los tipos de membresía son la base de la [generación de cuotas](payments.es.md#generar-cuotas)
+y de la [facturación recurrente](settings.es.md#facturación-recurrente).
+
+## Grupos
+
+Los grupos permiten organizar a los socios en conjuntos (por equipo, categoría, sección…) que
+luego sirven, por ejemplo, para dirigir [comunicaciones](communications.es.md) a una audiencia
+concreta.
+
+## Menores y tutores
+
+Memship admite socios menores con un tutor asociado, para clubes con secciones infantiles o
+juveniles.
+
+## Auditoría
+
+La pestaña **Auditoría** de la ficha muestra el registro de cambios realizados sobre ese socio.

--- a/docs/admin-guide/overview.es.md
+++ b/docs/admin-guide/overview.es.md
@@ -1,0 +1,59 @@
+# Introducción a la guía del administrador
+
+Esta guía está dirigida al **personal que gestiona la organización** desde el panel de
+administración de Memship: altas de socios, actividades, cobros, comunicaciones y
+configuración.
+
+> **Idioma.** Las guías del administrador y del socio se escriben primero en español
+> (`.es.md`), porque quienes gestionan un club y sus socios son mayoritariamente
+> hispanohablantes. Las traducciones al catalán (`.ca.md`) y al inglés (`.md`) se añaden según
+> la demanda.
+
+## Roles
+
+Memship distingue tres roles:
+
+| Rol                    | Qué puede hacer                                                              |
+|------------------------|------------------------------------------------------------------------------|
+| **Superadministrador** | Administración a nivel de plataforma, incluida la configuración de las pasarelas de pago. |
+| **Administrador de la organización** | Gestión diaria: socios, actividades, facturación y comunicaciones. |
+| **Socio**              | Uso del portal del socio: perfil, actividades, pagos, carné y reservas.       |
+
+La mayor parte de esta guía se refiere al **administrador de la organización**.
+
+## Iniciar sesión
+
+El acceso se realiza con **correo electrónico y contraseña**. Si has olvidado la contraseña,
+usa el enlace de recuperación de la pantalla de inicio de sesión (requiere que el
+[envío de correo](../self-hosting/email.md) esté configurado).
+
+## Áreas del panel
+
+El panel de administración se organiza en torno a estas áreas. Cada una tendrá su propia página
+en esta guía a medida que se desarrolle la documentación:
+
+- **Panel (Dashboard)** — resumen con gráficos de estado de socios y de recibos, e importes
+  pendientes, pagados y vencidos.
+- **Socios** — ciclo de vida completo (alta, cambios de estado, baja), tipos de cuota, grupos y
+  soporte para menores con tutor.
+- **Actividades** — creación y publicación, inscripciones con control de elegibilidad, lista de
+  espera, códigos de descuento, consentimientos y adjuntos.
+- **Pagos** — recibos, generación de cuotas, IVA, facturación y generación de PDF.
+- **SEPA** — mandatos de domiciliación, remesas (XML pain.008) e importación de devoluciones.
+- **Pagos en línea** — cobro con Stripe y Redsys/Bizum.
+- **Comunicaciones** — anuncios a todos los socios, a un grupo o a un tipo de cuota.
+- **Carné digital** — carné en PDF con número de socio y check-in por QR.
+- **Campos personalizados** — campos de perfil configurables por la organización.
+- **Reservas** — reserva de espacios compartidos por franjas, con aforo y lista de espera.
+- **Informes** — exportaciones CSV, panel financiero y resumen anual.
+- **Configuración** — marca (nombre, color, logotipo), dirección, datos bancarios y facturación.
+
+## Configuración inicial
+
+Antes de dar de alta a socios reales, completa la [configuración inicial](../getting-started/first-setup.md):
+datos de la organización, marca, datos bancarios y facturación, y verifica el envío de correo.
+
+## Próximas páginas
+
+Las páginas detalladas de cada área (Socios, Actividades, Pagos, etc.) se irán añadiendo a esta
+guía. Consulta el [índice de la documentación](../README.md) para ver el estado.

--- a/docs/admin-guide/overview.es.md
+++ b/docs/admin-guide/overview.es.md
@@ -29,24 +29,29 @@ usa el enlace de recuperación de la pantalla de inicio de sesión (requiere que
 
 ## Áreas del panel
 
-El panel de administración se organiza en torno a estas áreas. Cada una tendrá su propia página
-en esta guía a medida que se desarrolle la documentación:
+El panel de administración se organiza en torno a estas áreas:
 
 - **Panel (Dashboard)** — resumen con gráficos de estado de socios y de recibos, e importes
   pendientes, pagados y vencidos.
-- **Socios** — ciclo de vida completo (alta, cambios de estado, baja), tipos de cuota, grupos y
-  soporte para menores con tutor.
-- **Actividades** — creación y publicación, inscripciones con control de elegibilidad, lista de
-  espera, códigos de descuento, consentimientos y adjuntos.
-- **Pagos** — recibos, generación de cuotas, IVA, facturación y generación de PDF.
-- **SEPA** — mandatos de domiciliación, remesas (XML pain.008) e importación de devoluciones.
-- **Pagos en línea** — cobro con Stripe y Redsys/Bizum.
-- **Comunicaciones** — anuncios a todos los socios, a un grupo o a un tipo de cuota.
-- **Carné digital** — carné en PDF con número de socio y check-in por QR.
-- **Campos personalizados** — campos de perfil configurables por la organización.
-- **Reservas** — reserva de espacios compartidos por franjas, con aforo y lista de espera.
-- **Informes** — exportaciones CSV, panel financiero y resumen anual.
-- **Configuración** — marca (nombre, color, logotipo), dirección, datos bancarios y facturación.
+- **[Socios](members.es.md)** — ciclo de vida completo (alta, cambios de estado, baja), tipos de
+  cuota, grupos y soporte para menores con tutor.
+- **[Actividades](activities.es.md)** — creación y publicación, inscripciones con control de
+  elegibilidad, lista de espera, códigos de descuento, consentimientos y adjuntos.
+- **[Pagos](payments.es.md)** — recibos, generación de cuotas, IVA, facturación, generación de
+  PDF y cobro en línea (Stripe, Redsys/Bizum).
+- **[SEPA](sepa.es.md)** — mandatos de domiciliación, remesas (XML pain.008) e importación de
+  devoluciones.
+- **[Comunicaciones](communications.es.md)** — anuncios a todos los socios, a un grupo o a un
+  tipo de cuota.
+- **[Carné digital](member-cards.es.md)** — carné en PDF con número de socio y check-in por QR.
+- **[Campos personalizados](custom-fields.es.md)** — campos de perfil configurables por la
+  organización.
+- **[Informes](reports.es.md)** — exportaciones CSV, panel financiero y resumen anual.
+- **[Configuración](settings.es.md)** — marca (nombre, color, logotipo), dirección, datos
+  bancarios, facturación y automatizaciones.
+
+> La reserva de espacios (**Simple Bookings**) aún no forma parte de una versión publicada y se
+> documentará cuando se libere.
 
 ## Configuración inicial
 

--- a/docs/admin-guide/payments.es.md
+++ b/docs/admin-guide/payments.es.md
@@ -1,0 +1,59 @@
+# Pagos y recibos
+
+Gestión de recibos, generación de cuotas, IVA y cobros (incluido el pago en línea).
+
+## El recibo y su ciclo de vida
+
+Cada recibo tiene un **número**, un **socio**, una **descripción**, importes (**base**, **IVA**,
+**descuento**, **total**) y un **estado**. El ciclo de vida es:
+
+**Nuevo → Emitido → Cobrado** — y, según el caso, **Devuelto**, **Anulado** o **Vencido**.
+
+Acciones disponibles según el estado: **Emitir**, **Cobrar**, **Devolver**, **Anular** y
+**Reemitir** (para un recibo devuelto). Desde el recibo también puedes **Descargar PDF**.
+
+## Origen de los recibos
+
+Un recibo puede tener origen:
+
+- **Cuota** — cuota de socio (ver *Generar cuotas* y la
+  [facturación recurrente](settings.es.md#facturación-recurrente)).
+- **Actividad** — generado automáticamente al confirmar una [inscripción](activities.es.md);
+  se anula si la inscripción se cancela.
+- **Manual** — creado a mano desde la ficha del socio.
+
+## Generar cuotas
+
+La acción **Generar cuotas** crea recibos para todos los socios activos según su **tipo de
+membresía**. Es la forma de emitir la cuota periódica de forma masiva sin crearlos uno a uno.
+
+## IVA y facturación
+
+- El **tipo de IVA** se calcula sobre la base; el tipo por defecto se configura en
+  [Ajustes → Facturación](settings.es.md#facturación).
+- La **numeración** usa un prefijo configurable y, opcionalmente, se reinicia cada año
+  (p. ej. `FAC-2026-0001`).
+- El **PDF** del recibo incluye la cabecera de la organización, los datos del socio y el
+  desglose de IVA, en el idioma correspondiente (ES/CA/EN).
+
+## Métodos de pago y cobro en línea
+
+Un recibo puede cobrarse por **efectivo**, **transferencia**, **tarjeta**, **domiciliación**
+(ver [SEPA](sepa.es.md)) o mediante una **pasarela de pago en línea**.
+
+Cuando hay un proveedor configurado, el socio ve el botón **Pagar ahora** en sus recibos
+pendientes y puede pagar con:
+
+- **Stripe** — pago con tarjeta.
+- **Redsys** — pasarela bancaria española con 3D Secure.
+- **Bizum** — a través de Redsys.
+
+> La confirmación definitiva de los pagos con pasarela llega por la **notificación asíncrona**
+> del proveedor, no por la vuelta del navegador. La configuración de proveedores se hace en
+> [Ajustes → Proveedores de pago](settings.es.md#proveedores-de-pago) y en la
+> [guía de self-hosting](../self-hosting/configuration.md).
+
+## Panel financiero
+
+El [panel](reports.es.md) muestra el estado de los recibos y los importes **pendiente**,
+**cobrado este mes** y **vencido**.

--- a/docs/admin-guide/reports.es.md
+++ b/docs/admin-guide/reports.es.md
@@ -1,0 +1,27 @@
+# Informes y panel
+
+Panel de control, resumen financiero, resumen anual y exportaciones de datos.
+
+## Panel (Dashboard)
+
+El panel del administrador resume el estado de la organización:
+
+- **Socios** — activos, pendientes y total.
+- **Actividades** — publicadas, en borrador y total; y **inscripciones** por estado
+  (confirmadas, en espera, canceladas, pendientes).
+- **Resumen financiero** — importe **pendiente**, **cobrado este mes** y **vencido**, con
+  gráficos de estado de recibos.
+- **Próxima facturación recurrente** — día y días restantes, si está activada.
+
+## Resumen anual
+
+Desde el panel, **Resumen anual** ofrece la visión financiera del ejercicio (ingresos y
+pendiente por año), útil para el cierre y la memoria anual.
+
+## Exportaciones
+
+Memship permite **exportar datos a CSV** para su uso en hojas de cálculo o en la contabilidad
+de la organización.
+
+> A medida que se añadan nuevos informes y formatos de exportación, se documentarán en esta
+> página.

--- a/docs/admin-guide/sepa.es.md
+++ b/docs/admin-guide/sepa.es.md
@@ -1,0 +1,39 @@
+# Domiciliación SEPA
+
+Cobro de recibos por domiciliación bancaria mediante mandatos SEPA y remesas.
+
+> **Requisito previo.** Configura el **identificador de acreedor** y los datos bancarios de la
+> organización en [Ajustes → Domiciliación SEPA](settings.es.md#domiciliación-sepa).
+
+## Mandatos
+
+Un **mandato** es la autorización del socio para domiciliar cobros en su cuenta. Cada mandato
+tiene una **referencia**, el **titular** y el **IBAN/BIC** de la cuenta, un **tipo**
+(**recurrente** o **puntual**) y una **firma** (**papel** o **digital**).
+
+Flujo habitual:
+
+1. **Nuevo mandato** para el socio.
+2. **Descargar PDF** del mandato para su firma.
+3. **Subir firmado** el documento (PDF, JPG o PNG).
+4. El mandato queda **Activo** y puede usarse en remesas.
+
+Un mandato puede **cancelarse** (acción irreversible); pasa a **Cancelado**. También puede
+constar como **Expirado**.
+
+## Remesas
+
+Una **remesa** agrupa recibos domiciliados en un lote para enviarlo al banco.
+
+1. **Nueva remesa** y **selecciona los recibos** — solo recibos **emitidos** o **vencidos** con
+   mandatos SEPA activos. Verás el número de recibos seleccionados y el total.
+2. **Generar XML** — produce el fichero **ISO 20022 pain.008**, estándar para los bancos de la
+   zona SEPA. **Descarga el XML** y preséntalo en tu banca electrónica.
+3. **Marcar enviada** cuando lo hayas presentado al banco.
+4. **Importar devoluciones** — sube el fichero de devoluciones para actualizar el estado de los
+   recibos afectados (se marcan como **Devuelto**). El resultado indica los recibos
+   *procesados*, *devueltos* y *no encontrados*.
+5. **Cerrar** la remesa para finalizar el lote.
+
+Estados de una remesa: **Borrador → Lista → Enviada → Procesada → Cerrada** (o **Cancelada**;
+al cancelar se desvinculan todos los recibos).

--- a/docs/admin-guide/settings.es.md
+++ b/docs/admin-guide/settings.es.md
@@ -1,0 +1,61 @@
+# Configuración de la organización
+
+Ajustes generales, facturación, SEPA, proveedores de pago y automatizaciones. Requiere permisos
+de administración.
+
+## Datos de la organización
+
+- **Datos de la organización** — nombre, razón social, CIF/NIF, correo, teléfono y sitio web.
+- **Imagen de marca** — **color de marca** y **logotipo** (JPG, PNG, WebP o SVG).
+- **Dirección** — usada en recibos y documentos legales.
+- **Localización** — **idioma por defecto** (se usa en recibos, correos y formato de números),
+  zona horaria, moneda y formato de fecha.
+
+## Banca y facturación
+
+- **Banca** — nombre del banco, **IBAN** y **BIC/SWIFT** de la organización.
+- **Facturación** — **prefijo de factura**, **siguiente número** y **numeración anual**
+  (reinicia la numeración al comienzo de cada año).
+- **IVA por defecto** — tipo aplicado por defecto al calcular recibos.
+
+## Domiciliación SEPA
+
+- **Identificador del acreedor** — identificador de acreedor SEPA (p. ej.
+  `ES12000B12345678`), obligatorio para generar remesas.
+- **Formato SEPA** — ISO 20022 **pain.008**, estándar para los bancos de la zona SEPA.
+
+Ver [Domiciliación SEPA](sepa.es.md) para el flujo de mandatos y remesas.
+
+## Proveedores de pago
+
+Configura las credenciales de las pasarelas de **pago en línea** que verán los socios en
+*Pagar ahora*: **Stripe**, **Redsys**, **Bizum** (vía Redsys) y **domiciliación SEPA**. Cada
+proveedor tiene un **nombre visible**, un **estado** (Activo / Pruebas / Desactivado) y la
+opción **Probar conexión** para validar la configuración.
+
+> Los detalles de credenciales y URLs de retorno de cada proveedor se tratan en la
+> [guía de self-hosting](../self-hosting/configuration.md).
+
+## Facturación recurrente
+
+Genera automáticamente los recibos de cuota según un calendario:
+
+- **Activar facturación recurrente**.
+- **Día del mes** (1–28) en que se ejecuta. Las cuotas trimestrales y anuales solo se facturan
+  en el primer mes de su periodo.
+- **Correo de notificación** opcional que recibe un resumen tras cada ejecución.
+
+## Recordatorios de pago
+
+Envía correos automáticos a los socios con recibos vencidos:
+
+- **Días tras el vencimiento** antes del primer recordatorio.
+- **Repetir cada (días)** entre recordatorios sucesivos.
+- **Recordatorios máximos** por recibo (1–10).
+
+## Otras opciones
+
+- **Comunicaciones** — activa el envío de [anuncios](communications.es.md).
+- **Tarjeta de socio** — activa el [carné digital](member-cards.es.md) y su numeración.
+- **Campos de perfil** — activa los [campos personalizados](custom-fields.es.md).
+- **Opciones de género** — configura las opciones disponibles en los formularios de socios.

--- a/docs/getting-started/first-setup.md
+++ b/docs/getting-started/first-setup.md
@@ -1,0 +1,52 @@
+# First-time setup
+
+After [installing](installation.md) Memship and starting the services, you need to create the
+initial accounts and configure your organization. This is done with the **seed** command.
+
+## 1. Create accounts
+
+Run the interactive seed for a real deployment — it prompts you to create your own super admin
+and organization admin, and generates **no** sample data:
+
+```bash
+docker compose exec -it api uv run python -m app.cli.seed
+```
+
+> **Do not use the `--test` / `--demo` seed modes in production.** They create publicly-known
+> credentials and fake data. Those modes are for evaluation only — see the
+> [Quick start](quickstart.md).
+
+### The three roles
+
+| Role            | What it can do                                                            |
+|-----------------|---------------------------------------------------------------------------|
+| **Super admin** | Platform-level administration, including payment provider configuration.   |
+| **Org admin**   | Runs the organization day-to-day: members, activities, billing, comms.     |
+| **Member**      | Uses the member portal: profile, activities, payments, card, bookings.     |
+
+## 2. Log in
+
+Open your Memship URL and sign in as the organization admin you just created. Authentication
+is **email + password**.
+
+## 3. Configure your organization
+
+From the admin panel, go to **Settings** and complete:
+
+- **Branding** — organization name, brand colour, and logo.
+- **Address** — used on receipts and legal documents.
+- **Banking** — IBAN/BIC, needed for SEPA direct debit.
+- **Invoicing** — invoice number prefix, VAT/IVA default rate, and optional annual reset
+  (e.g. `FAC-2026-0001`).
+- **Default language** — Spanish, Catalan, or English.
+
+## 4. Verify email delivery
+
+Welcome emails, password resets, and payment notifications all depend on email being
+configured. Set up [email delivery](../self-hosting/email.md) and send a test (for example, by
+triggering a password reset) before onboarding real members.
+
+## Next steps
+
+- [Admin guide → Introducción](../admin-guide/overview.es.md) — how the admin panel is organized.
+- [Backups & restore](../self-hosting/backups-and-restore.md) — configure before going live.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,71 @@
+# Installation (Docker)
+
+This guide covers a **production** self-hosted install. For a quick local evaluation, use the
+[Quick start](quickstart.md) instead.
+
+## Prerequisites
+
+- A server with Docker and Docker Compose
+- Git (to clone the repository)
+- A domain name and the ability to point DNS at your server (recommended, for TLS)
+
+## Option A — Pre-built images (recommended)
+
+Uses published images from the GitHub Container Registry.
+
+```bash
+git clone https://github.com/marcandreuf/memship.git
+cd memship
+
+# Configure
+cp .env.example .env
+```
+
+Edit `.env` — at minimum:
+
+- **`SECRET_KEY`** — set a random 64-character string (never keep the default).
+- **`DB_PASSWORD`** — set a strong database password.
+- **`IMAGE_TAG`** — pin a released version, e.g. `IMAGE_TAG=1.2.0`. See [Upgrading](../self-hosting/upgrading.md).
+
+See the [Configuration reference](../self-hosting/configuration.md) for every available setting.
+
+```bash
+# Pull and start all services (Caddy + API + Frontend + PostgreSQL)
+docker compose pull
+docker compose up -d
+
+# Run initial setup (creates admin accounts) — see First-time setup
+docker compose exec -it api uv run python -m app.cli.seed
+```
+
+Open **http://localhost** (or your domain).
+
+## Option B — Build from source
+
+Builds the Docker images locally from the repository source.
+
+```bash
+git clone https://github.com/marcandreuf/memship.git
+cd memship
+cp .env.example .env      # edit SECRET_KEY and DB_PASSWORD at minimum
+docker compose up -d --build
+docker compose exec -it api uv run python -m app.cli.seed
+```
+
+## Services
+
+The default Compose stack runs behind a Caddy reverse proxy:
+
+| Service   | URL                              | Description               |
+|-----------|----------------------------------|---------------------------|
+| Frontend  | `http://localhost`               | Member portal (via Caddy) |
+| API       | `http://localhost/api/v1/health` | Backend API (via Caddy)   |
+| API Direct| `http://localhost:8003`          | Backend API (direct)      |
+
+## Next steps
+
+1. [First-time setup](first-setup.md) — create your organization and admin.
+2. [Configuration reference](../self-hosting/configuration.md) — review production settings.
+3. [Email delivery](../self-hosting/email.md) — required for welcome emails, password resets,
+   and payment notifications.
+4. [Backups & restore](../self-hosting/backups-and-restore.md) — set up before going live.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,71 @@
+# Quick start
+
+Try Memship on your machine in about a minute — no cloning required. This uses pre-built
+images and is meant for **evaluation**, not production. For a real deployment, see
+[Installation](installation.md).
+
+## Prerequisites
+
+- Docker and Docker Compose
+
+## 1. Download the quick-start compose file and start
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/marcandreuf/memship/main/docker-compose.quickstart.yml -o docker-compose.yml
+docker compose pull          # fetch the latest published images
+PORT=8081 docker compose up -d
+```
+
+Change `PORT=8081` to any port you prefer (default is `80`).
+
+## 2. Load initial data
+
+Pick one of the three seed modes:
+
+**Option A — Quick demo with test accounts (no prompts)**
+
+```bash
+docker compose exec demo-memship-api uv run python -m app.cli.seed --test
+```
+
+Creates pre-configured test accounts plus sample members, activities, and registrations:
+
+| Role        | Email            | Password      |
+|-------------|------------------|---------------|
+| Super Admin | super@test.com   | TestSuper1!   |
+| Org Admin   | admin@test.com   | TestAdmin1!   |
+| Member      | member@test.com  | TestMember1!  |
+
+**Option B — Custom setup (interactive)**
+
+```bash
+docker compose exec demo-memship-api uv run python -m app.cli.seed
+```
+
+Prompts you to create your own super admin and org admin. No sample data.
+
+**Option C — Realistic demo dataset**
+
+```bash
+docker compose exec demo-memship-api uv run python -m app.cli.seed --demo
+```
+
+Creates the admin accounts plus a full year of realistic data — ~60 members across all
+statuses, activities, receipts in every state, SEPA mandates, and dashboard reminders. Ideal
+for evaluating the finance dashboard and annual summary. Safe to re-run (idempotent).
+
+## 3. Open the app
+
+Go to **http://localhost:8081** and log in with your credentials.
+
+> **Do not use the test accounts in production.** The quick-start compose file uses insecure
+> default secrets (`SECRET_KEY`, database password) and is for local evaluation only. See
+> [Installation](installation.md) and the [Configuration reference](../self-hosting/configuration.md)
+> before exposing Memship to a network.
+
+## Stop and clean up
+
+```bash
+docker compose down          # stop containers
+docker compose down -v       # stop and delete all data (volumes)
+```

--- a/docs/member-guide/account.es.md
+++ b/docs/member-guide/account.es.md
@@ -1,0 +1,35 @@
+# Tu cuenta y tu perfil
+
+Cómo acceder al portal del socio y gestionar tus datos.
+
+## Iniciar sesión
+
+Accede con tu **correo electrónico** y tu **contraseña**.
+
+### ¿Olvidaste tu contraseña?
+
+Usa **¿Olvidaste tu contraseña?** en la pantalla de inicio de sesión, introduce tu correo y
+recibirás un enlace para restablecerla. Abre el enlace, escribe tu **nueva contraseña** y vuelve
+a iniciar sesión. Los enlaces de restablecimiento **caducan**; si el tuyo ya no es válido,
+solicita uno nuevo.
+
+## Tu perfil
+
+Desde tu perfil puedes:
+
+- Consultar y actualizar tus **datos personales** y de **contacto**.
+- Cambiar el **idioma** de la interfaz (español, catalán o inglés).
+- Subir o cambiar tu **foto de perfil** (JPG, PNG o WebP).
+
+### Campos personalizados
+
+Tu organización puede definir **campos de perfil** propios (por ejemplo, talla de equipación o
+número de licencia). Según su configuración, algunos podrás editarlos y otros serán de **solo
+lectura**.
+
+## Qué encontrarás en el portal
+
+- Tus **[actividades](activities.es.md)** y las inscripciones disponibles.
+- Tus **[recibos y pagos](payments.es.md)**, y tu **forma de pago**.
+- Tu **[carné digital](member-card.es.md)** con código QR.
+- Los **anuncios** de la organización y tus **notificaciones**.

--- a/docs/member-guide/activities.es.md
+++ b/docs/member-guide/activities.es.md
@@ -1,0 +1,38 @@
+# Actividades
+
+Cómo inscribirte en las actividades de tu organización y gestionar tus inscripciones.
+
+## Explorar e inscribirte
+
+En la sección de **actividades** verás las actividades publicadas, con su imagen, fechas, plazas
+disponibles y periodo de inscripción. Para inscribirte:
+
+1. Abre la actividad y pulsa **Inscribirse**.
+2. Si la actividad tiene **modalidades** o varios **precios**, selecciona el que corresponda.
+3. Acepta los **consentimientos** obligatorios y adjunta los **documentos** requeridos, si los
+   hay.
+4. Introduce un **código de descuento** si dispones de uno.
+5. Confirma la inscripción.
+
+Solo puedes inscribirte si cumples las **reglas de elegibilidad** de la actividad (tipo de
+socio, edad, estado). Si no cumples alguna, la actividad lo indicará.
+
+## Lista de espera
+
+Si la actividad está **completa**, tu inscripción entra en la **lista de espera**. Cuando se
+libera una plaza, las inscripciones en espera se **promocionan automáticamente** por orden, y
+recibirás un aviso.
+
+## Mis actividades
+
+En **Mis actividades** ves tus inscripciones y su estado: **Confirmado**, **En espera**,
+**Pendiente** o **Cancelado**.
+
+## Cancelar una inscripción
+
+Si la actividad permite la **cancelación por el socio**, podrás cancelar tu inscripción hasta el
+plazo establecido (un número de horas antes del inicio). Pasado ese plazo, contacta con la
+organización.
+
+Al inscribirte puede generarse un **[recibo](payments.es.md)**; al cancelar dentro de plazo, el
+recibo asociado se anula.

--- a/docs/member-guide/member-card.es.md
+++ b/docs/member-guide/member-card.es.md
@@ -1,0 +1,19 @@
+# Carné digital
+
+Tu carné de socio digital con código QR, para identificarte en el control de acceso.
+
+## Tu carné
+
+En **Mi tarjeta** encontrarás tu **carné digital**, con tu **número de socio**, tu **estado** y
+un **código QR**.
+
+- **Descargar PDF** — para guardarlo en el móvil o imprimirlo.
+- En el **control de acceso**, muestra el código QR para que el personal verifique tu estado.
+
+Si tu carné no está disponible, es posible que tu organización aún no haya activado las tarjetas
+de socio; contacta con ella.
+
+## Foto de perfil
+
+Puedes añadir una **foto de perfil** (JPG, PNG o WebP) desde tu perfil, que se mostrará en tu
+carné y en la aplicación.

--- a/docs/member-guide/payments.es.md
+++ b/docs/member-guide/payments.es.md
@@ -1,0 +1,38 @@
+# Pagos y recibos
+
+Cómo consultar tus recibos, pagarlos en línea y elegir tu forma de pago.
+
+## Mis recibos
+
+En **Mis recibos** ves tus recibos con su **estado** (Pendiente, Emitido, Cobrado, Vencido…),
+el **importe** y las fechas. Puedes **descargar el PDF** de cada recibo.
+
+## Pagar en línea
+
+Si tu organización tiene el pago en línea activado, los recibos pendientes muestran el botón
+**Pagar ahora**, con estas opciones según la configuración:
+
+- **Tarjeta (Stripe)**.
+- **Tarjeta (Redsys)** — con verificación 3D Secure.
+- **Bizum** (a través de Redsys).
+
+Tras el pago verás una confirmación. La **confirmación definitiva** puede tardar unos instantes,
+porque llega desde el proveedor de pago; si queda en proceso, recibirás un correo cuando se
+confirme. Si un pago no se completa, puedes **reintentarlo**.
+
+## Tu forma de pago
+
+En **Forma de pago** eliges cómo prefieres pagar tus cuotas:
+
+- **Domiciliación bancaria (SEPA)** — cargo automático en tu cuenta. Requiere un **mandato SEPA
+  activo**.
+- **Transferencia bancaria** — transferencia manual a la cuenta de la organización.
+- **Efectivo** — pago presencial.
+- **Tarjeta**.
+
+### Domiciliación (SEPA)
+
+Para la domiciliación debes indicar tus **datos bancarios**: **IBAN**, **BIC/SWIFT** (que suele
+detectarse a partir del IBAN) y el **titular de la cuenta**. La sección muestra el estado de tu
+**mandato SEPA** (Activo, Cancelado, Expirado o Sin mandato). Si no tienes un mandato activo,
+**contacta con la organización** para firmarlo.

--- a/docs/reference/roles-and-permissions.es.md
+++ b/docs/reference/roles-and-permissions.es.md
@@ -1,0 +1,23 @@
+# Roles y permisos
+
+Memship distingue tres roles. El acceso a cada función depende del rol de la persona usuaria.
+
+| Rol                    | Ámbito                                                                       |
+|------------------------|------------------------------------------------------------------------------|
+| **Superadministrador** | Administración a nivel de plataforma. Además de lo que puede el administrador de la organización, gestiona la **configuración de las pasarelas de pago** y otros ajustes de plataforma. |
+| **Administrador de la organización** | Gestión diaria de la organización: **socios**, **actividades**, **pagos y recibos**, **SEPA**, **comunicaciones**, **carné digital**, **campos de perfil**, **informes** y **configuración**. |
+| **Socio**              | Portal del socio: su **perfil**, sus **actividades**, sus **recibos y forma de pago**, y su **carné digital**. |
+
+## Notas
+
+- El acceso a algunas áreas depende además de que la función esté **activada** en la
+  [configuración](../admin-guide/settings.es.md) (comunicaciones, tarjeta de socio, campos de
+  perfil, etc.).
+- En los **campos de perfil personalizados**, la visibilidad y edición se controlan por campo:
+  los administradores **siempre pueden ver** un campo y el superadministrador **siempre puede
+  editarlo**; para el socio, cada campo puede ser oculto, de solo lectura o editable. Ver
+  [Campos de perfil](../admin-guide/custom-fields.es.md).
+- Memship es de **un solo inquilino** (single-tenant): una base de datos por organización.
+
+> Un modelo de **roles y permisos flexibles** (múltiples roles y permisos por rol, más allá de
+> los tres actuales) está en la hoja de ruta; esta página se actualizará cuando se publique.

--- a/docs/self-hosting/backups-and-restore.md
+++ b/docs/self-hosting/backups-and-restore.md
@@ -1,0 +1,42 @@
+# Backups & restore
+
+Memship ships helper scripts for backing up and restoring the PostgreSQL database. Set up
+backups **before** going live and test a restore at least once.
+
+> **What to back up.** These scripts cover the **database**. Uploaded files (logos, activity
+> images, generated PDFs) live in the storage volume (`STORAGE_LOCAL_PATH`, default `storage`).
+> Include that volume in your server-level backup routine as well.
+
+## Create a backup
+
+```bash
+./scripts/db-backup.sh
+```
+
+Backups are written to the `backups/` directory. Backups older than 10 days are cleaned up
+automatically.
+
+For unattended backups, schedule the script with cron, for example nightly:
+
+```cron
+0 3 * * *  cd /path/to/memship && ./scripts/db-backup.sh
+```
+
+## Restore
+
+The restore script lists available backups and lets you pick one. It runs as a **dry-run by
+default** so you can confirm the target before making changes:
+
+```bash
+./scripts/db-restore.sh            # dry-run: shows what would happen
+./scripts/db-restore.sh --confirm  # actually restore
+```
+
+> **Restoring overwrites the current database.** Take a fresh backup first and make sure you
+> are restoring into the intended environment.
+
+## Off-server copies
+
+The `backups/` directory lives on the same server as the database. For real disaster recovery,
+copy backups off the server regularly (object storage, another host, etc.) so a server failure
+does not take your only copy with it.

--- a/docs/self-hosting/configuration.md
+++ b/docs/self-hosting/configuration.md
@@ -1,0 +1,98 @@
+# Configuration reference
+
+Memship is configured through environment variables, typically set in a `.env` file next to
+`docker-compose.yml`. Copy `.env.example` to `.env` and adjust. This page documents every
+setting the backend reads.
+
+> **Minimum for production:** change `SECRET_KEY` and `DB_PASSWORD`, set `IMAGE_TAG` to a
+> released version, and configure [email](email.md).
+
+## Security
+
+| Variable      | Default                 | Description                                                                 |
+|---------------|-------------------------|-----------------------------------------------------------------------------|
+| `SECRET_KEY`  | `change-me-in-production` | **Change this.** Signing key for auth tokens. Use a random 64-char string. |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | `30`      | Access token lifetime in minutes.                                          |
+
+## Database
+
+| Variable        | Default                                                    | Description                                             |
+|-----------------|------------------------------------------------------------|---------------------------------------------------------|
+| `DB_PASSWORD`   | `memship`                                                  | **Change this.** PostgreSQL password used by Compose.   |
+| `DATABASE_URL`  | `postgresql://memship:memship@localhost:5433/memship_db`   | Full connection string. In Compose it points at the `db` service. |
+
+## Application
+
+| Variable         | Default                 | Description                                                        |
+|------------------|-------------------------|-------------------------------------------------------------------|
+| `APP_ENV`        | `development`            | Set to `production` for deployments. Affects debug behaviour and API docs exposure. |
+| `APP_VERSION`    | _(from image / git tag)_ | Baked into the image at build time; leave unset when running published images. |
+| `DEFAULT_LOCALE` | `es`                     | Default interface language: `es`, `ca`, or `en`.                  |
+| `CORS_ORIGINS`   | `http://localhost:3000`  | Comma-separated list of allowed browser origins. Set to your site URL(s). |
+| `FRONTEND_URL`   | `http://localhost:3000`  | Public URL of the frontend; used in email links.                  |
+| `BACKEND_PUBLIC_URL` | `http://localhost:8003` | Publicly reachable backend URL for payment-provider callbacks (e.g. Redsys `Ds_Merchant_MerchantURL`). In production this **must** be the external hostname the gateway can POST to. |
+
+## Ports
+
+Set in `.env` for the Compose stack (defaults shown in `.env.example`):
+
+| Variable     | Default | Description                    |
+|--------------|---------|--------------------------------|
+| `HTTP_PORT`  | `80`    | Caddy HTTP port.               |
+| `HTTPS_PORT` | `443`   | Caddy HTTPS port.              |
+| `API_PORT`   | `8003`  | Direct backend API port.       |
+| `DB_PORT`    | `5433`  | PostgreSQL host port.          |
+
+## Email
+
+Email is **disabled** unless either a Resend API key or an SMTP host is set. See
+[Email delivery](email.md) for a full walkthrough.
+
+**Resend (preferred, managed delivery):**
+
+| Variable            | Default | Description                     |
+|---------------------|---------|---------------------------------|
+| `RESEND_API_KEY`    | _(empty)_ | Enables Resend delivery.       |
+| `RESEND_FROM_EMAIL` | _(empty)_ | Verified sender address.       |
+
+**SMTP (self-hosted alternative):**
+
+| Variable        | Default                 | Description                          |
+|-----------------|-------------------------|--------------------------------------|
+| `SMTP_HOST`     | _(empty)_               | Enables SMTP delivery when set.      |
+| `SMTP_PORT`     | `587`                   | SMTP port.                           |
+| `SMTP_USER`     | _(empty)_               | SMTP username.                       |
+| `SMTP_PASSWORD` | _(empty)_               | SMTP password.                       |
+| `SMTP_FROM`     | `noreply@memship.local` | From address.                        |
+| `SMTP_TLS`      | `true`                  | Use STARTTLS.                        |
+
+If both are configured, Resend takes precedence.
+
+## Background jobs (Celery / Redis)
+
+| Variable            | Default                    | Description                                                |
+|---------------------|----------------------------|------------------------------------------------------------|
+| `CELERY_BROKER_URL` | `redis://localhost:6379/0` | Redis broker for async email, recurring billing, reminders. Redis is included in the Compose stack. |
+
+The worker and scheduler (Celery beat) run as part of the stack and power async emails,
+scheduled fee generation, and payment reminders.
+
+## File storage
+
+| Variable             | Default   | Description                                              |
+|----------------------|-----------|----------------------------------------------------------|
+| `STORAGE_LOCAL_PATH` | `storage` | Local path for uploads (logos, activity images, PDFs). Mounted as a Docker volume — include it in [backups](backups-and-restore.md). |
+| `MAX_UPLOAD_SIZE_MB` | `10`      | Maximum upload size in megabytes.                        |
+
+## Server
+
+| Variable | Default   | Description                  |
+|----------|-----------|------------------------------|
+| `HOST`   | `0.0.0.0` | Bind address of the backend. |
+| `PORT`   | `8000`    | In-container backend port.   |
+
+## Migrations
+
+| Variable         | Default | Description                                                             |
+|------------------|---------|-------------------------------------------------------------------------|
+| `RUN_MIGRATIONS` | _(set to `1` in Compose)_ | When `1`, the backend runs database migrations on startup. See [Upgrading](upgrading.md). |

--- a/docs/self-hosting/email.md
+++ b/docs/self-hosting/email.md
@@ -1,0 +1,65 @@
+# Email delivery
+
+Memship sends transactional email for welcome messages, password resets, activity
+confirmations, waitlist promotions, payment receipts, and overdue reminders. **Email is
+disabled until you configure a transport.** Two options are supported.
+
+## Which transport?
+
+| Transport  | Best for                                  | Notes                                              |
+|------------|-------------------------------------------|----------------------------------------------------|
+| **Resend** | Most self-hosters who want reliable delivery | Managed API, good deliverability, minimal setup. |
+| **SMTP**   | Fully self-hosted mail, or an existing mail relay | Works with any SMTP server.                 |
+
+If both are configured, **Resend takes precedence.**
+
+## Option A — Resend
+
+1. Create a Resend account and verify your sending domain.
+2. Create an API key.
+3. Set in `.env`:
+
+   ```bash
+   RESEND_API_KEY=re_your_key_here
+   RESEND_FROM_EMAIL=noreply@yourdomain.org
+   ```
+
+4. Recreate the backend so it picks up the change:
+
+   ```bash
+   docker compose up -d --force-recreate api
+   ```
+
+## Option B — SMTP
+
+Set in `.env`:
+
+```bash
+SMTP_HOST=smtp.yourprovider.com
+SMTP_PORT=587
+SMTP_USER=your-username
+SMTP_PASSWORD=your-password
+SMTP_FROM=noreply@yourdomain.org
+SMTP_TLS=true
+```
+
+Then recreate the backend:
+
+```bash
+docker compose up -d --force-recreate api
+```
+
+## Verify
+
+Trigger a real send to confirm delivery — for example, request a **password reset** from the
+login page, or create a member and check the welcome email arrives. Emails are localized
+(ES/CA/EN) based on the recipient's language.
+
+## Troubleshooting
+
+- **No email at all** — confirm `RESEND_API_KEY` or `SMTP_HOST` is set; if neither is set,
+  email is intentionally disabled.
+- **Emails delayed** — sending is asynchronous via Celery. Check the worker logs:
+  `docker compose logs -f worker`.
+- **Links point to the wrong host** — set `FRONTEND_URL` to your public site URL (see the
+  [Configuration reference](configuration.md)).

--- a/docs/self-hosting/upgrading.md
+++ b/docs/self-hosting/upgrading.md
@@ -1,0 +1,51 @@
+# Upgrading
+
+Memship is released as versioned Docker images. Upgrading means pointing at a newer image tag,
+pulling, and recreating the stack — database migrations run automatically on startup.
+
+## Versioning
+
+Memship follows [semantic versioning](https://semver.org/). **Git tags are the single source
+of truth** for the version — there is no `VERSION` file. Published images are tagged with the
+release version (e.g. `1.2.0`) and `latest`.
+
+Pin a specific version in production rather than tracking `latest`, so upgrades are
+deliberate. Set it in `.env`:
+
+```bash
+IMAGE_TAG=1.2.0
+```
+
+## Upgrade procedure
+
+1. **Back up first.** See [Backups & restore](backups-and-restore.md).
+
+2. **Review the release notes** for the target version (breaking changes, new required
+   settings) on the [releases page](https://github.com/marcandreuf/memship/releases).
+
+3. **Bump the tag** in `.env`:
+
+   ```bash
+   IMAGE_TAG=1.3.0
+   ```
+
+4. **Pull and recreate:**
+
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+
+## Database migrations
+
+Migrations run automatically on backend startup when `RUN_MIGRATIONS=1` (the default in the
+Compose stack). No manual migration step is needed for a standard upgrade.
+
+If you prefer to run migrations manually, set `RUN_MIGRATIONS=0` and run them yourself against
+the backend container after pulling the new image.
+
+## Rolling back
+
+Roll back by setting `IMAGE_TAG` to the previous version and recreating the stack. Note that
+**database migrations are not automatically reversed** — if a release included a migration,
+restore the database backup you took in step 1 rather than only downgrading the image.


### PR DESCRIPTION
## Summary

Adds a `docs/` folder to the public repo with documentation for the three audiences: **self-hosting operators**, **organization admins**, and **members**. Plain Markdown, tool-agnostic — renders on GitHub today and can be published by any docs-site generator later without rework.

Content is grounded in the actual app (`config.py`, `.env.example`, the compose files, the READMEs, and the frontend ES locale strings), not invented.

## Structure

- **getting-started/** _(EN)_ — quickstart, installation, first-setup
- **self-hosting/** _(EN, operator audience)_ — configuration reference (every env var), email (SMTP/Resend), backups & restore, upgrading
- **admin-guide/** _(ES, org-admin audience)_ — overview + one page per released feature: members, activities, payments, sepa, communications, member-cards, custom-fields, reports, settings
- **member-guide/** _(ES, member audience)_ — account, activities, payments, member-card
- **reference/** _(ES)_ — roles-and-permissions

## Conventions established

- **Language split:** operator/self-hosting docs in English; admin/member guides Spanish-first (`.es.md`), with `ca`/`en` added on demand.
- **Docs live with the code:** each admin/member page maps 1:1 to a frontend module, so a feature PR updates its page in the same change. Documented in `docs/README.md`.
- **Stable heading anchors:** so future in-app `?` help can deep-link into these pages (e.g. `admin-guide/activities#lista-de-espera`). The `<HelpTip>` component itself is a follow-up.

## Notes

- **Simple Bookings is intentionally excluded** — it is not in a released version yet (ships on its own branch), so its docs should ride with that feature's PR per the docs-live-with-code rule. The index and admin overview note this.
- All internal doc links verified (no broken relative links).

## Follow-ups (not in this PR)

- Publishing pipeline / docs-site tool (deliberately deferred; Markdown keeps options open).
- In-app `<HelpTip>` component + `helpKey`→anchor map.
- CA/EN translations of high-traffic pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)