### PR TITLE
fix(settings): drop orphan tabs, repair the e2e suite, cover the OAuth callback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,26 @@ pnpm build                       # Production build
 pnpm lint                        # Run linter
 ```
 
+### E2E (Cypress)
+```bash
+cd e2e
+pnpm test:parallel:prod          # Full suite, 4 workers, production build (use this)
+pnpm test:parallel               # Full suite against whatever is on :3000
+pnpm cypress:run --spec 'cypress/e2e/auth/login.cy.ts'   # Single spec
+```
+
+**Run the full suite against a production build.** `next dev` compiles each
+route on first request; with 4 workers sharing one dev server that stall pushes
+navigations past their timeouts, so specs fail — or pass only on retry — and
+which ones fail changes between runs. `test:parallel:prod` builds, serves, runs
+and tears down. Measured on the same commit: 167/167 with no retries in 15m
+against a production build, versus 165–166/167 with ~12 retry-only passes in
+68m against the dev server.
+
+Retries mask this, so read the failure screenshots in `cypress/screenshots/`
+(gitignored, overwritten each run) — a screenshot with no "attempt N" suffix
+means a test failed once and passed on retry. A clean run leaves none.
+
 ### Docker (backend services)
 ```bash
 cd backend/docker

--- a/backend/tests/integration/api/v1/test_oauth_callback.py
+++ b/backend/tests/integration/api/v1/test_oauth_callback.py
@@ -1,0 +1,326 @@
+"""Integration tests for the OAuth callback endpoint.
+
+``test_oauth_sso.py`` covers identity resolution by calling
+``find_or_create_from_oauth`` directly, and covers the callback route only in
+its unconfigured-provider form, which returns 404 before any authentication
+runs. Everything the endpoint itself decides once the provider *is* configured
+was therefore unexercised.
+
+That matters most for two gates:
+
+    if not user.is_active:  -> account_disabled
+    if user.is_locked:      -> account_locked
+
+Neither is enforced anywhere else. ``find_or_create_from_oauth`` resolves a user
+by email without filtering on either flag, so the endpoint is the only thing
+stopping a disabled or locked account signing in through a provider. The
+password path already asserts the locked case (``test_auth.py``); this closes
+the same hole on the SSO path.
+
+These stub the authlib client at ``get_provider``, which is the seam the
+endpoint imports at module level.
+"""
+
+import pytest
+
+from app.core.security.password import hash_password
+from app.domains.auth.models import User, UserIdentity
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+GOOGLE_CALLBACK = "/api/v1/auth/oauth/google/callback?code=x&state=y"
+APPLE_CALLBACK = "/api/v1/auth/oauth/apple/callback"
+
+CLAIMS = {
+    "sub": "google-sub-1",
+    "email": "sso@test.com",
+    "email_verified": True,
+    "given_name": "Sso",
+    "family_name": "User",
+}
+
+
+class _FakeOAuthClient:
+    """Stands in for the authlib client the provider registry builds.
+
+    Only ``authorize_access_token`` is reached on the callback path. Raising
+    from it reproduces every way authlib rejects a callback — denied consent, a
+    replayed or expired code, a failed state check, a bad id_token signature —
+    all of which the endpoint funnels into one redirect.
+    """
+
+    def __init__(self, claims=None, raises=None):
+        self._claims = claims
+        self._raises = raises
+
+    async def authorize_access_token(self, request):
+        if self._raises is not None:
+            raise self._raises
+        return {"userinfo": self._claims}
+
+
+@pytest.fixture
+def stub_provider(monkeypatch):
+    def _install(claims=None, raises=None):
+        client = _FakeOAuthClient(claims=claims, raises=raises)
+        monkeypatch.setattr(
+            "app.api.v1.endpoints.auth.get_provider",
+            lambda name, resolved: client,
+        )
+        return client
+
+    return _install
+
+
+def _ensure_membership_type(db):
+    mt = db.query(MembershipType).first()
+    if not mt:
+        mt = MembershipType(name="General", slug="general", is_active=True)
+        db.add(mt)
+        db.flush()
+    return mt
+
+
+def _set_features(db, **flags):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if not org:
+        org = OrganizationSettings(id=1, name="Test Club")
+        db.add(org)
+        db.flush()
+    org.features = {**(org.features or {}), **flags}
+    db.flush()
+
+
+def _password_user(db, email="sso@test.com", **flags):
+    person = Person(first_name="Existing", last_name="User", email=email)
+    db.add(person)
+    db.flush()
+    user = User(
+        person_id=person.id,
+        email=email,
+        password_hash=hash_password("password123"),
+        role="member",
+        is_active=flags.get("is_active", True),
+        is_locked=flags.get("is_locked", False),
+        email_verified=True,
+    )
+    db.add(user)
+    db.flush()
+    mt = _ensure_membership_type(db)
+    db.add(
+        Member(
+            person_id=person.id,
+            user_id=user.id,
+            membership_type_id=mt.id,
+            member_number="M-9001",
+            status="active",
+        )
+    )
+    db.flush()
+    return user
+
+
+def _location(response):
+    assert response.status_code in (302, 303, 307), response.status_code
+    return response.headers["location"]
+
+
+# --- Provider rejected the sign-in ----------------------------------------
+
+
+def test_token_exchange_failure_redirects_to_login(client, db, stub_provider):
+    """Denied consent, replayed code, bad state or bad id_token all land here.
+
+    The endpoint deliberately collapses them into one opaque error rather than
+    echoing the provider's message, so this also pins that nothing leaks.
+    """
+    stub_provider(raises=RuntimeError("mismatching_state: CSRF Warning"))
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    location = _location(response)
+    assert "error=sso_failed" in location
+    assert "CSRF" not in location
+    assert "mismatching_state" not in location
+    assert db.query(User).count() == 0
+
+
+def test_claims_without_subject_are_refused(client, db, stub_provider):
+    stub_provider(claims={"email": "sso@test.com", "email_verified": True})
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert "error=sso_failed" in _location(response)
+    assert db.query(User).count() == 0
+
+
+def test_claims_without_email_are_refused(client, db, stub_provider):
+    stub_provider(claims={"sub": "google-sub-1", "email_verified": True})
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert "error=sso_failed" in _location(response)
+    assert db.query(User).count() == 0
+
+
+def test_empty_userinfo_is_refused(client, db, stub_provider):
+    """A token with no userinfo at all must not fall through as a sign-in."""
+    stub_provider(claims=None)
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert "error=sso_failed" in _location(response)
+    assert db.query(User).count() == 0
+
+
+# --- Service refusals mapped to redirects ---------------------------------
+
+
+def test_unverified_provider_email_redirects_not_500(client, db, stub_provider):
+    """EmailNotVerifiedError must surface as a redirect, not an exception."""
+    _password_user(db)
+    stub_provider(claims={**CLAIMS, "email_verified": False})
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert "error=sso_email_unverified" in _location(response)
+    assert db.query(UserIdentity).count() == 0
+
+
+def test_closed_registration_redirects_not_500(client, db, stub_provider):
+    _ensure_membership_type(db)
+    _set_features(db, public_registration=False)
+    stub_provider(claims=CLAIMS)
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert "error=registration_closed" in _location(response)
+    assert db.query(User).count() == 0
+
+
+# --- The gates that exist only here ---------------------------------------
+
+
+def test_disabled_account_cannot_sign_in_through_sso(client, db, stub_provider):
+    """A deactivated member must not get in via the provider.
+
+    find_or_create_from_oauth resolves by email without checking is_active, so
+    without the endpoint's gate this returns a session cookie.
+    """
+    _password_user(db, is_active=False)
+    stub_provider(claims=CLAIMS)
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert "error=account_disabled" in _location(response)
+    assert "access_token" not in response.headers.get("set-cookie", "")
+
+
+def test_locked_account_cannot_sign_in_through_sso(client, db, stub_provider):
+    """Mirror of test_auth.py's locked-password-login test, on the SSO path.
+
+    Uses a returning identity — someone who signed in before and was locked
+    afterwards — which is how this actually happens.
+    """
+    user = _password_user(db)
+    db.add(
+        UserIdentity(
+            user_id=user.id,
+            provider="google",
+            provider_subject="google-sub-1",
+            email=user.email,
+        )
+    )
+    user.is_locked = True
+    db.flush()
+    stub_provider(claims=CLAIMS)
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert "error=account_locked" in _location(response)
+    assert "access_token" not in response.headers.get("set-cookie", "")
+
+
+# --- The success path ------------------------------------------------------
+
+
+def test_successful_signin_issues_a_session_cookie(client, db, stub_provider):
+    _ensure_membership_type(db)
+    stub_provider(claims=CLAIMS)
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    location = _location(response)
+    assert "/dashboard" in location
+    assert "error=" not in location
+
+    cookie = response.headers.get("set-cookie", "")
+    assert "access_token=" in cookie
+    assert "HttpOnly" in cookie
+
+    user = db.query(User).filter(User.email == "sso@test.com").one()
+    assert user.password_hash is None
+    assert user.last_login_at is not None
+
+
+def test_returning_user_signs_in_without_creating_a_second_account(
+    client, db, stub_provider
+):
+    _ensure_membership_type(db)
+    stub_provider(claims=CLAIMS)
+
+    client.get(GOOGLE_CALLBACK, follow_redirects=False)
+    client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert db.query(User).filter(User.email == "sso@test.com").count() == 1
+    assert db.query(UserIdentity).count() == 1
+
+
+def test_pending_member_still_gets_a_session(client, db, stub_provider):
+    """The portal shows an awaiting-approval screen, so the sign-in must work."""
+    _ensure_membership_type(db)
+    _set_features(db, registration_requires_approval=True)
+    stub_provider(claims=CLAIMS)
+
+    response = client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    assert "/dashboard" in _location(response)
+    assert "access_token=" in response.headers.get("set-cookie", "")
+
+    user = db.query(User).filter(User.email == "sso@test.com").one()
+    member = db.query(Member).filter(Member.user_id == user.id).one()
+    assert member.status == "pending"
+
+
+# --- Apple sends email_verified as a string --------------------------------
+
+
+def test_apple_string_true_is_treated_as_verified(client, db, stub_provider):
+    """Apple sends "true"/"false" as strings, not booleans."""
+    _ensure_membership_type(db)
+    stub_provider(
+        claims={**CLAIMS, "sub": "apple-sub-1", "email_verified": "true"}
+    )
+
+    response = client.post(APPLE_CALLBACK, data={"code": "x"}, follow_redirects=False)
+
+    assert "/dashboard" in _location(response)
+    assert db.query(User).filter(User.email == "sso@test.com").count() == 1
+
+
+def test_apple_string_false_is_not_truthy(client, db, stub_provider):
+    """The coercion earns its keep here: bool("false") is True.
+
+    Without it, Apple reporting an unverified address would read as verified
+    and allow linking into an existing account by email.
+    """
+    _password_user(db)
+    stub_provider(
+        claims={**CLAIMS, "sub": "apple-sub-1", "email_verified": "false"}
+    )
+
+    response = client.post(APPLE_CALLBACK, data={"code": "x"}, follow_redirects=False)
+
+    assert "error=sso_email_unverified" in _location(response)
+    assert db.query(UserIdentity).count() == 0

--- a/e2e/cypress/e2e/activities/activity-list.cy.ts
+++ b/e2e/cypress/e2e/activities/activity-list.cy.ts
@@ -23,9 +23,12 @@ describe("Activity List — Admin", () => {
   });
 
   it("shows all statuses for admin via filter", () => {
-    // Admin can filter to see draft activities
+    // Admin can filter to see draft activities.
+    // Scope to the dropdown option: "Draft" also appears as a status badge in
+    // the table, and the open select puts pointer-events:none on the body, so
+    // an unscoped cy.contains can match the badge and never be clickable.
     cy.get("select, [role='combobox']").first().click();
-    cy.contains("Draft").click();
+    cy.get("[role='option']").contains("Draft").click();
     cy.contains("Annual Gala Dinner").should("be.visible");
   });
 

--- a/e2e/cypress/e2e/billing-runs/recurring-billing.cy.ts
+++ b/e2e/cypress/e2e/billing-runs/recurring-billing.cy.ts
@@ -6,7 +6,7 @@ describe("Recurring Billing — Settings tab (super admin)", () => {
   beforeEach(() => {
     cy.loginAsSuperAdmin();
     cy.visit("/en/settings");
-    cy.contains('[role="tab"]', "Recurring billing").click();
+    cy.settingsTab("Payments", "Recurring billing");
   });
 
   it("shows the recurring billing controls", () => {
@@ -34,7 +34,7 @@ describe("Recurring Billing — Settings tab (super admin)", () => {
 
   it("does not clobber other feature flags (membership types still load)", () => {
     // Saving the recurring-billing keys must merge into features JSONB, not replace it.
-    cy.contains('[role="tab"]', "Membership Types").click();
+    cy.settingsTab("Members", "Membership Types");
     cy.contains(/full member|student/i).should("be.visible");
   });
 });

--- a/e2e/cypress/e2e/payment-reminders/payment-reminders.cy.ts
+++ b/e2e/cypress/e2e/payment-reminders/payment-reminders.cy.ts
@@ -6,7 +6,7 @@ describe("Payment Reminders — Settings tab (super admin)", () => {
   beforeEach(() => {
     cy.loginAsSuperAdmin();
     cy.visit("/en/settings");
-    cy.contains('[role="tab"]', "Payment reminders").click();
+    cy.settingsTab("Payments", "Payment reminders");
   });
 
   it("shows the payment reminder controls", () => {
@@ -35,7 +35,7 @@ describe("Payment Reminders — Settings tab (super admin)", () => {
 
   it("does not clobber other feature flags (membership types still load)", () => {
     // Saving the reminder keys must merge into the features JSONB, not replace it.
-    cy.contains('[role="tab"]', "Membership Types").click();
+    cy.settingsTab("Members", "Membership Types");
     cy.contains(/full member|student/i).should("be.visible");
   });
 });

--- a/e2e/cypress/e2e/registrations/eligibility-rules.cy.ts
+++ b/e2e/cypress/e2e/registrations/eligibility-rules.cy.ts
@@ -72,12 +72,21 @@ describe("8. Eligibility Rules — Age Restrictions", () => {
 });
 
 describe("8. Eligibility Rules — Member Status", () => {
-  it("8.7a — pending member is not eligible", () => {
+  // A pending member no longer reaches the eligibility check at all: the
+  // portal layout short-circuits to the approval screen before any page
+  // renders, so the block happens earlier and harder than this section's
+  // other cases. Asserted here to keep the pending status covered alongside
+  // suspended and expired.
+  it("8.7a — pending member is stopped by the approval gate", () => {
     cy.login("david@test.com", PASSWORD);
-    visitRegisterPage("Yoga Workshop");
 
-    cy.contains("You are not eligible").should("be.visible");
-    cy.contains("Member status is not active").should("be.visible");
+    cy.contains("Awaiting approval").should("be.visible");
+    cy.contains("david@test.com").should("be.visible");
+
+    // The portal itself is unreachable — no sidebar, no activities list.
+    cy.visit("/en/activities");
+    cy.contains("Awaiting approval").should("be.visible");
+    cy.contains("h3", "Yoga Workshop").should("not.exist");
   });
 
   it("8.7b — suspended member is not eligible", () => {

--- a/e2e/cypress/e2e/settings/payment-providers.cy.ts
+++ b/e2e/cypress/e2e/settings/payment-providers.cy.ts
@@ -2,7 +2,7 @@ describe("Payment Providers — Super Admin", () => {
   beforeEach(() => {
     cy.loginAsSuperAdmin();
     cy.visit("/en/settings");
-    cy.contains("button", "Payment Providers").click();
+    cy.settingsTab("Payments", "Payment Providers");
   });
 
   it("shows Payment Providers tab and list", () => {

--- a/e2e/cypress/e2e/settings/settings.cy.ts
+++ b/e2e/cypress/e2e/settings/settings.cy.ts
@@ -19,8 +19,8 @@ describe("Settings — Super Admin", () => {
   });
 
   it("shows membership types tab", () => {
-    cy.contains("button", "Membership Types").should("be.visible");
-    cy.contains("button", "Membership Types").click();
+    // Membership Types is a sub-tab of Members, not a top-level tab.
+    cy.settingsTab("Members", "Membership Types");
     cy.contains("Full Member").should("be.visible");
     cy.contains("Student").should("be.visible");
   });

--- a/e2e/cypress/e2e/validation/error-handling.cy.ts
+++ b/e2e/cypress/e2e/validation/error-handling.cy.ts
@@ -21,7 +21,10 @@ describe("Error Handling — Toast Notifications", () => {
     });
 
     it("shows success toast when saving organization settings", () => {
-      cy.get('input[name="name"]').should("be.visible");
+      // Visible is not enough: the form mounts empty and is reset once the
+      // settings query resolves. Saving in that window submits a blank name
+      // and gets a 422 instead of the success toast.
+      cy.get('input[name="name"]').should("not.have.value", "");
       cy.contains("button", "Save").click();
       cy.get(TOAST).should("contain.text", "Saved successfully");
     });
@@ -105,8 +108,8 @@ describe("Error Handling — Error Toasts on Invalid Data", () => {
     it("shows error toast when creating with duplicate slug", () => {
       cy.loginAsSuperAdmin();
       cy.visit("/en/settings");
-      // Switch to Membership Types tab
-      cy.contains("button", "Membership Types").click();
+      // Membership Types is a sub-tab of Members, not a top-level tab.
+      cy.settingsTab("Members", "Membership Types");
       // Click the create/new button in the membership types section
       cy.get('[role="tabpanel"]').find("button").contains(/create|new/i).click();
       cy.get('[role="dialog"]').should("be.visible");

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -27,6 +27,12 @@ declare global {
       logout(): Chainable<void>;
       /** Login via API (faster, no UI) */
       apiLogin(email: string, password: string): Chainable<void>;
+      /**
+       * Select a settings tab. Settings nests sub-tabs inside parent tabs, so
+       * a leaf like "Payment Providers" is only in the DOM once its parent is
+       * open. Pass the parent alone for a top-level tab, or parent + child.
+       */
+      settingsTab(parent: string, child?: string): Chainable<void>;
     }
   }
 }
@@ -64,9 +70,29 @@ Cypress.Commands.add("apiLogin", (email: string, password: string) => {
   });
 });
 
+// --- Navigation commands ---
+
+Cypress.Commands.add("settingsTab", (parent: string, child?: string) => {
+  // The parent list is the first tablist on the page; sub-tab lists render
+  // inside whichever parent panel is active, so scope the child to that panel
+  // rather than matching a label that may also exist at the top level.
+  cy.contains('[role="tab"]', parent).click();
+  if (child) {
+    cy.get('[role="tabpanel"][data-state="active"]')
+      .contains('[role="tab"]', child)
+      .click();
+  }
+});
+
+// --- Authentication commands (cont.) ---
+
 Cypress.Commands.add("logout", () => {
   // Click user dropdown in sidebar footer, then logout
   cy.get('[data-slot="sidebar-footer"]').find("button").click();
   cy.contains("Sign Out").click();
-  cy.url().should("include", "/login", { timeout: 10000 });
+  // Headroom for runs against `next dev`, where /login is compiled on first
+  // request and 4 parallel workers share one server — that pushes this
+  // redirect past 10s and makes the test flaky. Against a production build
+  // it resolves quickly; the allowance only matters for local dev runs.
+  cy.url().should("include", "/login", { timeout: 30000 });
 });

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -17,6 +17,7 @@
     "test:smoke": "cypress run --env grepTags=@smoke",
     "test:tag": "cypress run --env grepTags=",
     "test:parallel": "./scripts/run-parallel.sh 4",
+    "test:parallel:prod": "./scripts/run-parallel-prod.sh 4",
     "test:parallel:all": "cypress-parallel -s cypress:run -t 4 -d cypress/e2e"
   },
   "devDependencies": {

--- a/e2e/scripts/run-parallel-prod.sh
+++ b/e2e/scripts/run-parallel-prod.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Run the cypress suite in parallel against a production frontend build.
+#
+# `next dev` compiles each route on first request. With several workers sharing
+# one dev server that stall pushes navigations past their timeouts, so specs
+# fail or survive only on retry, and which ones fail changes between runs.
+# A production build serves prebuilt routes and removes the problem.
+#
+# Usage: ./scripts/run-parallel-prod.sh [threads]
+
+set -e
+cd "$(dirname "$0")/.."
+
+THREADS=${1:-4}
+FRONTEND_DIR="../frontend"
+PORT=3000
+SERVER_PID=""
+
+# `lsof` cannot see the listener in every environment, so ask `ss` first and
+# fall back to an actual request.
+port_in_use() {
+  if command -v ss >/dev/null 2>&1 && ss -ltn 2>/dev/null | grep -q ":$PORT "; then
+    return 0
+  fi
+  curl -sf -o /dev/null --max-time 2 "http://localhost:$PORT/" 2>/dev/null
+}
+
+listeners_on_port() {
+  ss -ltnp 2>/dev/null | grep ":$PORT " | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u
+}
+
+cleanup() {
+  [ -n "$SERVER_PID" ] || return 0
+  echo "-> Stopping production server (PID: $SERVER_PID)..."
+  pkill -P "$SERVER_PID" 2>/dev/null || true
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+
+  # `pnpm start` re-parents `next-server`, so the port can still be held once
+  # the wrapper is gone. Kill whatever is actually still listening.
+  for _ in $(seq 1 10); do
+    port_in_use || return 0
+    for p in $(listeners_on_port); do
+      kill "$p" 2>/dev/null || true
+    done
+    sleep 1
+  done
+
+  port_in_use && echo "WARNING: port $PORT is still held after teardown." || true
+  return 0
+}
+trap cleanup EXIT INT TERM
+
+if port_in_use; then
+  echo "ERROR: port $PORT is already in use. Stop the dev server first:"
+  echo "  ./scripts/dev.sh stop frontend"
+  exit 1
+fi
+
+echo "-> Building the frontend..."
+(cd "$FRONTEND_DIR" && pnpm build)
+
+echo "-> Starting the production server on :$PORT..."
+(cd "$FRONTEND_DIR" && pnpm start) &
+SERVER_PID=$!
+
+echo "-> Waiting for the server to accept requests..."
+for _ in $(seq 1 60); do
+  if curl -sf -o /dev/null "http://localhost:$PORT/en/login"; then
+    echo "-> Server is up."
+    break
+  fi
+  sleep 2
+done
+
+if ! curl -sf -o /dev/null "http://localhost:$PORT/en/login"; then
+  echo "ERROR: the production server did not come up on :$PORT."
+  exit 1
+fi
+
+# Report the suite's own result — the EXIT trap must not mask it.
+set +e
+./scripts/run-parallel.sh "$THREADS"
+SUITE_EXIT=$?
+set -e
+
+exit "$SUITE_EXIT"

--- a/frontend/app/[locale]/(portal)/settings/page.tsx
+++ b/frontend/app/[locale]/(portal)/settings/page.tsx
@@ -184,15 +184,6 @@ export default function SettingsPage() {
             <TabsTrigger value="payments">{t("settings.payments")}</TabsTrigger>
           )}
           {isSuperAdmin && (
-            <TabsTrigger value="payment-providers">{t("settings.providers.tab")}</TabsTrigger>
-          )}
-          {isSuperAdmin && (
-            <TabsTrigger value="recurring-billing">{t("settings.recurringBilling.tab")}</TabsTrigger>
-          )}
-          {isSuperAdmin && (
-            <TabsTrigger value="payment-reminders">{t("settings.paymentReminders.tab")}</TabsTrigger>
-          )}
-          {isSuperAdmin && (
             <TabsTrigger value="communications">{t("settings.communications.tab")}</TabsTrigger>
           )}
           {isSuperAdmin && (


### PR DESCRIPTION
_Supersedes #30, which GitHub auto-closed when the branch was renamed from `test/sso-callback-coverage` to `fix/settings-tabs-and-e2e-suite`. Same two commits, same head._

Two commits: the OAuth callback coverage this branch was originally opened for, plus the settings/e2e work that came out of getting the Cypress suite green again.

## Product fix

The settings `TabsList` carried three top-level triggers — **Payment Providers**, **Recurring billing** and **Payment reminders** — whose panels moved under the Payments parent in the v1.1.1 reorg. With no matching top-level `TabsContent`, clicking any of them rendered a **blank page** for real users.

The failing Cypress specs were reporting that bug, not drifting from it: `cy.contains` matched the orphan trigger, clicked it, and correctly found nothing.

## SSO callback coverage (`4a33e77`)

`test_oauth_sso.py` covered identity resolution by calling `find_or_create_from_oauth` directly and only reached the callback route in its unconfigured-provider form, so the endpoint body never executed.

The gap that mattered: `auth.py:377` `account_disabled` and `auth.py:379` `account_locked`. Neither is enforced anywhere else — `find_or_create_from_oauth` resolves by email without filtering on either flag. The password path already asserts the locked case; same control, proven on one path only.

13 tests, each guard mutated out to confirm failure. **auth.py 69% → 91%**, suite 1005 → 1018, overall 84.02% → 84.41%.

## E2E repairs

Specs now route through the real nesting via a new `cy.settingsTab(parent, child)` command, which scopes the child lookup to the active panel so labels present at both levels cannot collide.

Three further bugs, all found by running the suite rather than reading it:

- **`eligibility-rules` 8.7a** asserted an eligibility message a pending member can no longer reach — the portal layout short-circuits to `PendingApproval` before any page renders. Rewritten to assert the approval gate, which had **no E2E coverage at all**.
- **`error-handling`** reached for Membership Types as a top-level tab (a fifth spec with the nesting problem), and clicked Save before the settings form was populated, submitting a blank name and getting a 422 instead of the success toast. Both were passing only on retry.
- **`activity-list`** matched the "Draft" status badge in the table instead of the dropdown option; an open select puts `pointer-events: none` on the body, so the badge could never be clicked. Scoped to `[role="option"]`.

## Run the suite against a production build

`next dev` compiles routes on first request. Four workers sharing one dev server push navigations past their timeouts, so specs fail — or survive on retry — and **which ones fail changes between runs**.

| Same commit | Result | Retry-only passes | Time |
|---|---|---|---|
| Dev server, run 1 | 166/167 | 2 | 66m |
| Dev server, run 2 | 165/167 | ~12 | 68m |
| **Production build** | **167/167** | **0** | **15m** |

Added `pnpm test:parallel:prod` (builds, serves, runs, tears down) and documented it in `CLAUDE.md`.

## Verification

`167/167`, zero retries, exit 0, clean teardown — reproduced across two full runs after the final fix. `pnpm build` and `tsc --noEmit` both clean.

## Known limitations, not addressed here

- **The specs are not idempotent against a shared DB.** Repeated runs grew activities to 28 and permanently broke `activity-list` — "green" partly depends on how recently the DB was seeded.
- **Retries mask real defects.** Three of the bugs above were passing tests. Any CI wiring should surface retry-only passes rather than reporting them green.
- Communications and Member Card are still reachable from two places in settings — the same duplicate-navigation smell that produced the orphan triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5vK3Fp11mjPvmZf5traC4

