### PR TITLE
docs(readme): correct the released version history

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -108,9 +108,7 @@ Memship segueix el [versionat semàntic](https://semver.org/) i **els números d
 | v1.0.1 | Pedaç — corregeix el registre de tasques programades de facturació/recordatoris a Celery; protecció de CI contra la sobreescriptura d'etiquetes d'imatge | Fet |
 | v1.1.0 | Camps de perfil personalitzats — dades de soci configurables per l'organització (text, número, data, selecció, …) amb validació per camp i visibilitat/edició per camp | Fet |
 | v1.1.1 | Pedaç — reorganització de la navegació de configuració: ajustos de pagaments i de socis agrupats a les pestanyes Pagaments i Socis | Fet |
-| v1.2.0 | Integració SSO / identitat — alta pública amb verificació per correu, flux d'aprovació per la junta, inici de sessió amb Google / Apple i configuració de proveïdors SSO pel superadministrador des d'una pestanya d'Integracions | Fet |
-| v1.2.1 | Configuració de correu a Ajustos — el superadministrador defineix Resend / Google SMTP des d'una pestanya d'Integracions | Fet |
-| v1.2.2 | Pedaç — elimina una migració duplicada de configuració de correu amb un identificador de revisió que xocava amb un altre existent, cosa que feia fallar `alembic upgrade head` en arrencar | Fet |
+| v1.2.2 | Integració SSO / identitat i configuració de correu — alta pública amb verificació per correu, flux d'aprovació per la junta, inici de sessió amb Google / Apple, configuració de proveïdors SSO pel superadministrador i ajust de Resend / Google SMTP des d'una pestanya d'Integracions. També elimina una migració duplicada de configuració de correu amb un identificador de revisió que xocava amb un altre existent, cosa que feia fallar `alembic upgrade head` en arrencar | Fet |
 | v1.3.0 | Reserves simples — reserves de socis en espais compartits mitjançant un calendari setmanal, aforament per franja, llista d'espera FIFO amb promoció automàtica i correus de confirmació/llista d'espera | Fet |
 
 ### Planificat

--- a/README.es.md
+++ b/README.es.md
@@ -108,9 +108,7 @@ Memship sigue el [versionado semántico](https://semver.org/) y **los números d
 | v1.0.1 | Parche — corrige el registro de tareas programadas de facturación/recordatorios en Celery; protección de CI contra la sobrescritura de etiquetas de imagen | Hecho |
 | v1.1.0 | Campos de perfil personalizados — datos de socio configurables por la organización (texto, número, fecha, selección, …) con validación por campo y visibilidad/edición por campo | Hecho |
 | v1.1.1 | Parche — reorganización de la navegación de configuración: ajustes de pagos y de socios agrupados en las pestañas Pagos y Socios | Hecho |
-| v1.2.0 | Integración SSO / identidad — alta pública con verificación por correo, flujo de aprobación por la directiva, inicio de sesión con Google / Apple y configuración de proveedores SSO por el superadministrador desde una pestaña de Integraciones | Hecho |
-| v1.2.1 | Configuración de correo en Ajustes — el superadministrador define Resend / Google SMTP desde una pestaña de Integraciones | Hecho |
-| v1.2.2 | Parche — elimina una migración duplicada de configuración de correo cuyo identificador de revisión chocaba con otro existente, lo que hacía fallar `alembic upgrade head` al arrancar | Hecho |
+| v1.2.2 | Integración SSO / identidad y configuración de correo — alta pública con verificación por correo, flujo de aprobación por la directiva, inicio de sesión con Google / Apple, configuración de proveedores SSO por el superadministrador y ajuste de Resend / Google SMTP desde una pestaña de Integraciones. También elimina una migración duplicada de configuración de correo cuyo identificador de revisión chocaba con otro existente, lo que hacía fallar `alembic upgrade head` al arrancar | Hecho |
 | v1.3.0 | Reservas simples — reservas de socios en espacios compartidos mediante un calendario semanal, aforo por franja, lista de espera FIFO con promoción automática y correos de confirmación/lista de espera | Hecho |
 
 ### Planificado

--- a/README.md
+++ b/README.md
@@ -108,9 +108,7 @@ Memship follows [semantic versioning](https://semver.org/), and **version number
 | v1.0.1 | Patch — fix Celery scheduled billing/reminder task registration; CI guard against image tag overwrite                                                                                                            | Done   |
 | v1.1.0 | Custom profile fields — org-configurable member data (text, number, date, select, …) with per-field validation and per-field visibility/editability                                                              | Done   |
 | v1.1.1 | Patch — settings navigation reorganised: payment and member settings grouped under Payments and Members tabs                                                                                                     | Done   |
-| v1.2.0 | SSO / identity integration — public registration + email-verification onboarding, admin approval flow, Google / Apple sign-in, and superadmin SSO provider configuration from an Integrations tab | Done   |
-| v1.2.1 | Mailing configuration in Settings — superadmin sets Resend / Google SMTP from an Integrations tab | Done   |
-| v1.2.2 | Patch — drop a duplicate mailing-config migration whose revision id collided with an existing one, which made `alembic upgrade head` fail on startup | Done   |
+| v1.2.2 | SSO / identity integration and mailing configuration — public registration + email-verification onboarding, admin approval flow, Google / Apple sign-in, superadmin SSO provider configuration and Resend / Google SMTP setup from an Integrations tab. Also drops a duplicate mailing-config migration whose revision id collided with an existing one, which made `alembic upgrade head` fail on startup | Done   |
 | v1.3.0 | Simple Bookings — member reservations of shared spaces on a week calendar, per-slot capacity, FIFO waitlist with auto-promotion, and confirmation/waitlist emails | Done   |
 
 ### Planned


### PR DESCRIPTION
The Released changelog listed **v1.2.0** (SSO) and **v1.2.1** (mailing config) as `Done`, but neither was ever tagged — the tag sequence goes `v1.1.1 → v1.2.2`.

Both features first reached users in **v1.2.2**, together with the duplicate mailing-config migration fix that v1.2.2's own row described. Verified against `git log v1.1.1..v1.2.2`, which contains the registration/approval flow, Google and Apple sign-in, the SSO configuration UI, the mailing provider UI, and the migration fix.

## Change

Collapse the three rows into the single release that actually happened, in all three language READMEs.

| Before | After |
|---|---|
| `v1.2.0` SSO / identity integration — **never tagged** | — |
| `v1.2.1` Mailing configuration — **never tagged** | — |
| `v1.2.2` Patch — duplicate migration only | `v1.2.2` SSO + approval flow + Google/Apple sign-in + mailing configuration + the migration fix |

## Verification

Every version in each README cross-checked against `git tag`, in both directions:

- listed but not tagged: **none**
- tagged but not listed: **none**

`v1.2.0` and `v1.2.1` were the only discrepancies in the entire 39-release history. Table structure confirmed intact in `README.md`, `README.es.md` and `README.ca.md`.

## Why it happened

The phantom entries predate the rule in `CONTRIBUTING.md` that versions are assigned at release rather than reserved in advance. This is the leftover from the old numbered-band approach.

## Related, not in this PR

The same pre-decoupling numbering appears in the `memship-context` design notes, which are titled for `v1.3.0–1.3.1` SSO work — SSO shipped in `v1.2.2`, and `v1.3.1` does not exist (`v1.3.0` is Simple Bookings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5vK3Fp11mjPvmZf5traC4
