### PR TITLE
fix(deploy): run the Celery worker, and persist uploads and the secret key

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -9,6 +9,12 @@
 		reverse_proxy api:8000
 	}
 
+	# Uploaded files are served by the API (StaticFiles mount in app/main.py),
+	# not by the frontend.
+	handle /uploads/* {
+		reverse_proxy api:8000
+	}
+
 	# Everything else → frontend
 	handle {
 		reverse_proxy frontend:3000

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -9,6 +9,19 @@
 #   Open http://localhost:8081
 #
 
+# The API, the Celery worker and Celery beat run the same image with the same
+# settings — only the command differs. Kept in one anchor so a new setting cannot
+# be added to the API and silently forgotten on the worker.
+x-backend-env: &backend-env
+  DATABASE_URL: postgresql://memship:memship@demo-memship-db:5432/memship_db
+  SECRET_KEY: change-me-in-production-use-a-random-64-char-string
+  APP_ENV: production
+  APP_VERSION: ${IMAGE_TAG:-latest}
+  DEFAULT_LOCALE: es
+  CORS_ORIGINS: http://localhost
+  FRONTEND_URL: http://localhost
+  CELERY_BROKER_URL: redis://demo-memship-redis:6379/0
+
 services:
   demo-memship-caddy:
     image: caddy:2-alpine
@@ -45,18 +58,54 @@ services:
     expose:
       - "8000"
     environment:
-      - DATABASE_URL=postgresql://memship:memship@demo-memship-db:5432/memship_db
-      - SECRET_KEY=change-me-in-production-use-a-random-64-char-string
-      - APP_ENV=production
-      - APP_VERSION=${IMAGE_TAG:-latest}
-      - DEFAULT_LOCALE=es
-      - CORS_ORIGINS=http://localhost
-      - FRONTEND_URL=http://localhost
-      - RUN_MIGRATIONS=1
+      <<: *backend-env
+      RUN_MIGRATIONS: 1
     volumes:
       - demo-memship-storage:/app/storage
     depends_on:
       demo-memship-db:
+        condition: service_healthy
+      demo-memship-redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # Sends the confirmation, cancellation, waitlist-promotion, receipt and
+  # announcement emails. Without it every send is dropped silently — the
+  # dispatch sites swallow the failure so the request still succeeds.
+  demo-memship-celery-worker:
+    image: ghcr.io/marcandreuf/memship-backend:latest
+    pull_policy: always
+    container_name: demo-memship-celery-worker
+    command: uv run celery -A app.core.celery_app worker --loglevel=info
+    environment:
+      <<: *backend-env
+      # Only the API applies migrations; a second migrator races it on startup.
+      RUN_MIGRATIONS: 0
+    volumes:
+      - demo-memship-storage:/app/storage
+    depends_on:
+      demo-memship-db:
+        condition: service_healthy
+      demo-memship-redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # Scheduled billing run (02:00) and payment reminders (03:00) — see
+  # beat_schedule in backend/app/core/celery_app.py.
+  demo-memship-celery-beat:
+    image: ghcr.io/marcandreuf/memship-backend:latest
+    pull_policy: always
+    container_name: demo-memship-celery-beat
+    command: uv run celery -A app.core.celery_app beat --loglevel=info --schedule=/var/lib/celery/celerybeat-schedule
+    environment:
+      <<: *backend-env
+      RUN_MIGRATIONS: 0
+    volumes:
+      - demo-memship-celerybeat:/var/lib/celery
+    depends_on:
+      demo-memship-db:
+        condition: service_healthy
+      demo-memship-redis:
         condition: service_healthy
     restart: unless-stopped
 
@@ -70,6 +119,18 @@ services:
       - API_BASE_URL=http://demo-memship-api:8000
     depends_on:
       - demo-memship-api
+    restart: unless-stopped
+
+  demo-memship-redis:
+    image: redis:7-alpine
+    container_name: demo-memship-redis
+    expose:
+      - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     restart: unless-stopped
 
   demo-memship-db:
@@ -91,3 +152,4 @@ services:
 volumes:
   demo-memship-pgdata:
   demo-memship-storage:
+  demo-memship-celerybeat:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,27 @@
 # To use pre-built images from GHCR instead of building locally,
 # set IMAGE_TAG in .env (e.g., IMAGE_TAG=0.1.3)
 
+# The API, the Celery worker and Celery beat run the same image with the same
+# settings — only the command differs. Kept in one anchor so a new setting cannot
+# be added to the API and silently forgotten on the worker.
+x-backend-env: &backend-env
+  DATABASE_URL: postgresql://memship:${DB_PASSWORD:-memship}@db:5432/memship_db
+  SECRET_KEY: ${SECRET_KEY:-dev-secret-key-change-in-production}
+  APP_ENV: ${APP_ENV:-production}
+  DEFAULT_LOCALE: ${DEFAULT_LOCALE:-es}
+  CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost}
+  # Report the deployed image tag as the app version (no VERSION file; images
+  # are promoted, not rebuilt, so the version is supplied at deploy time).
+  APP_VERSION: ${IMAGE_TAG:-latest}
+  CELERY_BROKER_URL: redis://redis:6379/0
+  SMTP_HOST: ${SMTP_HOST:-}
+  SMTP_PORT: ${SMTP_PORT:-587}
+  SMTP_USER: ${SMTP_USER:-}
+  SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+  SMTP_FROM: ${SMTP_FROM:-noreply@memship.local}
+  SMTP_TLS: ${SMTP_TLS:-true}
+  FRONTEND_URL: ${FRONTEND_URL:-http://localhost}
+
 services:
   caddy:
     image: caddy:2-alpine
@@ -35,24 +56,61 @@ services:
     ports:
       - "${API_PORT:-8003}:8000"
     environment:
-      - DATABASE_URL=postgresql://memship:${DB_PASSWORD:-memship}@db:5432/memship_db
-      - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-in-production}
-      - APP_ENV=${APP_ENV:-production}
-      - DEFAULT_LOCALE=${DEFAULT_LOCALE:-es}
-      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost}
-      # Report the deployed image tag as the app version (no VERSION file; images
-      # are promoted, not rebuilt, so the version is supplied at deploy time).
-      - APP_VERSION=${IMAGE_TAG:-latest}
-      - SMTP_HOST=${SMTP_HOST:-}
-      - SMTP_PORT=${SMTP_PORT:-587}
-      - SMTP_USER=${SMTP_USER:-}
-      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
-      - SMTP_FROM=${SMTP_FROM:-noreply@memship.local}
-      - SMTP_TLS=${SMTP_TLS:-true}
-      - FRONTEND_URL=${FRONTEND_URL:-http://localhost}
-      - RUN_MIGRATIONS=1
+      <<: *backend-env
+      RUN_MIGRATIONS: 1
+    volumes:
+      # Uploaded files (logos, member photos, activity covers, attachments) AND
+      # the auto-generated encryption key at storage/secret.key. Without this
+      # volume a container recreate destroys the uploads and rotates the key,
+      # which makes every stored SSO/payment secret undecryptable — see
+      # SECRETS_KEY_FILE in backend/app/core/config.py.
+      - storage:/app/storage
     depends_on:
       db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  celery-worker:
+    image: ${API_IMAGE:-ghcr.io/marcandreuf/memship-backend:${IMAGE_TAG:-latest}}
+    build:
+      context: backend
+      dockerfile: docker/Dockerfile
+    container_name: memship-celery-worker
+    command: uv run celery -A app.core.celery_app worker --loglevel=info
+    environment:
+      <<: *backend-env
+      # Only the API applies migrations; a second migrator races it on startup.
+      RUN_MIGRATIONS: 0
+    volumes:
+      - storage:/app/storage
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  celery-beat:
+    image: ${API_IMAGE:-ghcr.io/marcandreuf/memship-backend:${IMAGE_TAG:-latest}}
+    build:
+      context: backend
+      dockerfile: docker/Dockerfile
+    container_name: memship-celery-beat
+    # Scheduled billing run (02:00) and payment reminders (03:00) — see
+    # beat_schedule in backend/app/core/celery_app.py. The schedule database is
+    # kept on a volume so a restart does not re-fire a job it already ran.
+    command: uv run celery -A app.core.celery_app beat --loglevel=info --schedule=/var/lib/celery/celerybeat-schedule
+    environment:
+      <<: *backend-env
+      RUN_MIGRATIONS: 0
+    volumes:
+      - celerybeat:/var/lib/celery
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     restart: unless-stopped
 
@@ -68,6 +126,18 @@ services:
       - API_BASE_URL=http://api:8000
     depends_on:
       - api
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: memship-redis
+    expose:
+      - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     restart: unless-stopped
 
   db:
@@ -91,5 +161,7 @@ services:
 
 volumes:
   pgdata:
+  storage:
+  celerybeat:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
The shipped deployment stacks had no Redis, no Celery worker and no beat, so every email the product sends was dropped. All six dispatch sites wrap `.delay()` in `try/except: pass`, so the failure was **silent** — registration, cancellation, waitlist-promotion, booking, receipt and announcement emails never arrived and nothing was logged. The two beat jobs, the 02:00 billing run and the 03:00 payment reminders, never ran at all.

`docker-compose.yml` also mounted no volume on the api service, so `/app/storage` lived inside the container. A `docker compose pull && up -d` therefore destroyed every uploaded file and regenerated `storage/secret.key` — which `config.py:57-58` warns must be persistent, because rotating it makes stored SSO and payment-provider secrets undecryptable.

The root `Caddyfile` was missing the `/uploads/*` route the quickstart config already had, sending uploaded files to the frontend instead of the API.

A club self-hosting via the quickstart today gets no emails and no recurring billing, with no error surfaced anywhere.

## Changes

- `redis`, `celery-worker` and `celery-beat` added to both deploy stacks
- `storage` volume mounted on api and worker; `celerybeat` volume for the schedule database
- `/uploads/*` route added to the root `Caddyfile`
- Shared backend settings moved into a YAML anchor, so a setting cannot be added to the api and forgotten on the worker
- `RUN_MIGRATIONS=0` on worker and beat — only the api migrates, otherwise they race on startup

## Verification

Run against the published image, not just `compose config`:

- Worker connects to the broker and registers all nine tasks; beat starts; api returns 200
- Encrypted a canary value, then `--force-recreate` on the api: key md5 identical, canary still decrypts
- Same image with **no** volume, two runs: two different key hashes — confirming the counterfactual

Noted while testing: on a *fresh* storage volume, api and worker can race initialising it (`mkdir ... file exists`). A second `up -d` succeeds. Left alone rather than papered over.

## Note

This matters most for the staging environment, where deploys recreate containers on every merge — see #NEXT.