### PR TITLE
feat(staging): deploy main HEAD to a staging VPS, and make the bundled Caddy optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,20 @@
 # API_PORT=8003
 # DB_PORT=5433
 
+# Reverse proxy
+# ------------------------------------------------------------------
+# By default memship runs its own Caddy, which obtains and renews an HTTPS
+# certificate on its own. Put your hostname in the Caddyfile and there is
+# nothing to set here.
+#
+# The three settings below apply ONLY when running behind an external proxy:
+#   docker compose -f docker-compose.yml -f docker-compose.external-proxy.yml up -d
+# That drops the bundled Caddy and publishes routing labels for Traefik
+# instead. See docs/self-hosting/reverse-proxy.md.
+# MEMSHIP_HOST=memship.yourclub.org
+# TRAEFIK_NETWORK=traefik_proxy
+# TRAEFIK_CERTRESOLVER=cloudflare
+
 # Database
 DB_PASSWORD=memship
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,118 @@
+# Deploy Staging
+#
+# Staging tracks `main` HEAD. After Build Images publishes the release-candidate
+# images for a merged commit, this deploys those exact images to the staging VPS.
+# The commit staging validates is the one release.sh later tags, and release.yml
+# promotes the same image without rebuilding — so what ships is what was tested.
+#
+# Required repository secrets:
+#   STAGING_HOST         hostname or IP of the VPS
+#   STAGING_USER         deploy user (member of the docker group)
+#   STAGING_SSH_KEY      private key for that user — dedicated to this workflow
+#   STAGING_KNOWN_HOSTS  output of `ssh-keyscan <host>`, so the host key is
+#                        pinned rather than trusted on first use
+name: Deploy Staging
+
+on:
+  workflow_run:
+    workflows: ["Build Images"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to deploy (full, or the 12-char short form). Defaults to main HEAD. Use this to roll back."
+        required: false
+
+# One deploy at a time; never cancel one midway, since that can leave the stack
+# half-updated.
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    environment:
+      name: staging
+      url: https://staging.openmemship.com
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Resolve the images to deploy
+        id: images
+        env:
+          INPUT_SHA: ${{ github.event.inputs.sha }}
+          EVENT_SHA: ${{ github.event.workflow_run.head_sha }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          SHA="${INPUT_SHA:-${EVENT_SHA:-$GITHUB_SHA}}"
+          SHORT="${SHA:0:12}"
+
+          # Build Images only rebuilds the service that changed, so
+          # `sha-<commit>` exists for one image and not the other on most
+          # merges. Fall back to whatever `:main` currently points at, pinned
+          # by digest — still an exact, immutable reference.
+          resolve() {
+            local image="$1"
+            if docker buildx imagetools inspect "${image}:sha-${SHORT}" >/dev/null 2>&1; then
+              echo "${image}:sha-${SHORT}"
+            else
+              local digest
+              digest="$(docker buildx imagetools inspect "${image}:main" --format '{{.Manifest.Digest}}')"
+              echo "${image}@${digest}"
+            fi
+          }
+
+          API_IMAGE="$(resolve "ghcr.io/${OWNER}/memship-backend")"
+          FRONTEND_IMAGE="$(resolve "ghcr.io/${OWNER}/memship-frontend")"
+
+          {
+            echo "sha=${SHA}"
+            echo "short=${SHORT}"
+            echo "api_image=${API_IMAGE}"
+            echo "frontend_image=${FRONTEND_IMAGE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure SSH
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.STAGING_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${{ secrets.STAGING_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Deploy
+        env:
+          HOST: ${{ secrets.STAGING_HOST }}
+          USER_NAME: ${{ secrets.STAGING_USER }}
+          API_IMAGE: ${{ steps.images.outputs.api_image }}
+          FRONTEND_IMAGE: ${{ steps.images.outputs.frontend_image }}
+          IMAGE_TAG: sha-${{ steps.images.outputs.short }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -o BatchMode=yes "${USER_NAME}@${HOST}" \
+            "API_IMAGE='${API_IMAGE}' FRONTEND_IMAGE='${FRONTEND_IMAGE}' IMAGE_TAG='${IMAGE_TAG}' bash -s" \
+            < scripts/staging-deploy.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Staging deploy"
+            echo ""
+            echo "- commit: \`${{ steps.images.outputs.sha }}\`"
+            echo "- api: \`${{ steps.images.outputs.api_image }}\`"
+            echo "- frontend: \`${{ steps.images.outputs.frontend_image }}\`"
+            echo ""
+            echo "Tag this commit for release only once it has been validated on staging."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.external-proxy.yml
+++ b/docker-compose.external-proxy.yml
@@ -1,0 +1,85 @@
+# Run memship behind an EXTERNAL reverse proxy (Traefik) instead of the
+# bundled Caddy.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.external-proxy.yml up -d
+#
+# The application containers are identical either way — only what sits in front
+# of them changes. That is deliberate: the stack a club self-hosts and the stack
+# we run on staging stay the same images with the same settings.
+#
+# Use this when something else already terminates TLS on the host: our staging
+# and demo VPS, a Docker Swarm deployment, or a club that already runs its own
+# proxy. Otherwise use docker-compose.yml on its own and keep the bundled Caddy.
+#
+# Required in .env:
+#   MEMSHIP_HOST          the hostname, e.g. staging.openmemship.com
+#   TRAEFIK_NETWORK       the external network Traefik watches
+#   TRAEFIK_CERTRESOLVER  the ACME resolver configured in traefik.yml
+
+services:
+  # Disables the bundled proxy. The profile is never activated, so Caddy is
+  # simply not part of this deployment. Done from the override rather than the
+  # base file so that a plain `docker compose up -d` still starts Caddy and the
+  # ordinary self-hosted install needs no .env at all.
+  caddy:
+    profiles: ["bundled-proxy-disabled"]
+
+  api:
+    # `!override` REPLACES the port list. Without the tag Compose APPENDS, and
+    # the base file's published 8003 would survive alongside anything added
+    # here. Publishing it on a public VPS is not protected by ufw either —
+    # Docker writes its own iptables rules ahead of it — so the API would be
+    # reachable on the internet, bypassing the proxy and its TLS.
+    ports: !override []
+    networks:
+      # `default` must stay listed. A service that declares networks no longer
+      # joins the default one implicitly, and the API still needs db and redis.
+      - default
+      - proxy
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: ${TRAEFIK_NETWORK:?set TRAEFIK_NETWORK in .env}
+
+      # Uploaded files are served by the API, not the frontend — the route whose
+      # absence broke images on the bundled proxy. Keep both prefixes together.
+      traefik.http.routers.memship-api.rule: Host(`${MEMSHIP_HOST:?set MEMSHIP_HOST in .env}`) && (PathPrefix(`/api/v1`) || PathPrefix(`/uploads`))
+      traefik.http.routers.memship-api.entrypoints: websecure
+      traefik.http.routers.memship-api.tls.certresolver: ${TRAEFIK_CERTRESOLVER:?set TRAEFIK_CERTRESOLVER in .env}
+      traefik.http.routers.memship-api.priority: "20"
+      traefik.http.routers.memship-api.service: memship-api
+
+      # Payment providers POST here from their own infrastructure and cannot
+      # present credentials. It is a separate router, at a higher priority and
+      # with NO middlewares, so that adding an auth middleware to gate a staging
+      # or demo site cannot break webhook delivery. These endpoints authenticate
+      # by provider signature, which is their real security boundary.
+      traefik.http.routers.memship-webhooks.rule: Host(`${MEMSHIP_HOST}`) && PathPrefix(`/api/v1/webhooks`)
+      traefik.http.routers.memship-webhooks.entrypoints: websecure
+      traefik.http.routers.memship-webhooks.tls.certresolver: ${TRAEFIK_CERTRESOLVER}
+      traefik.http.routers.memship-webhooks.priority: "30"
+      traefik.http.routers.memship-webhooks.service: memship-api
+
+      traefik.http.services.memship-api.loadbalancer.server.port: "8000"
+
+  frontend:
+    networks:
+      - default
+      - proxy
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: ${TRAEFIK_NETWORK}
+      # Lowest priority: the catch-all, reached only when neither API rule matches.
+      traefik.http.routers.memship-frontend.rule: Host(`${MEMSHIP_HOST}`)
+      traefik.http.routers.memship-frontend.entrypoints: websecure
+      traefik.http.routers.memship-frontend.tls.certresolver: ${TRAEFIK_CERTRESOLVER}
+      traefik.http.routers.memship-frontend.priority: "10"
+      traefik.http.services.memship-frontend.loadbalancer.server.port: "3000"
+
+  # Same reasoning as the API: never publish Postgres on a public host.
+  db:
+    ports: !override []
+
+networks:
+  proxy:
+    external: true
+    name: ${TRAEFIK_NETWORK:?set TRAEFIK_NETWORK in .env}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,66 @@
+# Staging overlay — use together with the base file:
+#   docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
+#
+# Mail containment. Staging runs demo data, but a demo record can hold a real
+# address and every email path works, so nothing may leave the box. Mailpit
+# accepts all SMTP and shows what was sent at :8025, which also makes "did the
+# receipt email actually send?" checkable instead of assumed.
+
+services:
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: memship-mailpit
+    expose:
+      - "1025"
+      - "8025"
+    environment:
+      MP_DATABASE: /data/mailpit.db
+      MP_MAX_MESSAGES: 5000
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    volumes:
+      - mailpit:/data
+    restart: unless-stopped
+
+  # depends_on is restated in full — an override that lists only mailpit would
+  # drop the db/redis health conditions from the base file.
+  api:
+    environment:
+      SMTP_HOST: mailpit
+      SMTP_PORT: 1025
+      SMTP_TLS: "false"
+      SMTP_USER: ""
+      SMTP_PASSWORD: ""
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      mailpit:
+        condition: service_started
+
+  celery-worker:
+    environment:
+      SMTP_HOST: mailpit
+      SMTP_PORT: 1025
+      SMTP_TLS: "false"
+      SMTP_USER: ""
+      SMTP_PASSWORD: ""
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      mailpit:
+        condition: service_started
+
+  celery-beat:
+    environment:
+      SMTP_HOST: mailpit
+      SMTP_PORT: 1025
+      SMTP_TLS: "false"
+      SMTP_USER: ""
+      SMTP_PASSWORD: ""
+
+volumes:
+  mailpit:

--- a/docs/self-hosting/reverse-proxy.md
+++ b/docs/self-hosting/reverse-proxy.md
@@ -1,0 +1,140 @@
+# Reverse proxy
+
+Memship ships with a reverse proxy already configured. Something has to terminate
+HTTPS and route requests to two different containers, so the stack includes
+**Caddy** and it works without configuration beyond your hostname.
+
+If you already run a proxy on the same server, you can use that instead and turn
+the bundled one off. Both are supported.
+
+## Which one you want
+
+**Use the bundled Caddy** if memship is the only thing on the server, or the main
+thing. This is the default and the recommended path. You get automatic HTTPS with
+no certificate files to manage and no account to create anywhere.
+
+**Use an external proxy** if the server already terminates TLS for other sites, if
+you are deploying to Docker Swarm, or if your organisation has a proxy it wants
+everything to sit behind.
+
+Whichever you pick, **the application containers are identical.** Only what sits
+in front of them changes.
+
+## The default: bundled Caddy
+
+Set your hostname in `Caddyfile`, replacing `:80`:
+
+```
+memship.yourclub.org {
+    handle /api/v1/* {
+        reverse_proxy api:8000
+    }
+    handle /uploads/* {
+        reverse_proxy api:8000
+    }
+    handle {
+        reverse_proxy frontend:3000
+    }
+}
+```
+
+Then:
+
+```bash
+docker compose up -d
+```
+
+Caddy requests a certificate from Let's Encrypt on first start and renews it
+automatically. For that to work:
+
+- the hostname must already resolve to this server's public IP, and
+- ports **80 and 443** must be reachable from the internet. Port 80 is used for
+  the certificate challenge, so do not close it even though the site itself is
+  HTTPS.
+
+Certificates are kept in the `caddy_data` volume. Leave that volume alone —
+deleting it means requesting new certificates, and Let's Encrypt applies rate
+limits.
+
+Keep the three route blocks in that order and do not drop `/uploads/*`: uploaded
+files — your organisation's logo, member photos, activity images — are served by
+the API, not the frontend. Without that block they will not load.
+
+## The alternative: an external proxy
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.external-proxy.yml up -d
+```
+
+This override does three things: it removes the bundled Caddy (via a Compose
+profile that is never activated), it stops publishing the API and PostgreSQL
+ports on the host, and it attaches the API and frontend to an external Docker
+network with routing labels for [Traefik](https://traefik.io).
+
+Set these in `.env` first:
+
+```bash
+MEMSHIP_HOST=memship.yourclub.org
+TRAEFIK_NETWORK=traefik_proxy       # the network your Traefik watches
+TRAEFIK_CERTRESOLVER=cloudflare     # a resolver defined in your traefik.yml
+```
+
+The network must already exist and your Traefik must be attached to it:
+
+```bash
+docker network create traefik_proxy
+```
+
+Three routers are published, and the priorities matter:
+
+| Router | Matches | Priority |
+|---|---|---|
+| `memship-webhooks` | `/api/v1/webhooks/*` | 30 |
+| `memship-api` | `/api/v1/*` and `/uploads/*` | 20 |
+| `memship-frontend` | everything else | 10 |
+
+**If you add an authentication middleware** — to keep a test or demo site
+private — apply it to `memship-api` and `memship-frontend` only. Payment
+providers POST to the webhook endpoints from their own servers and cannot present
+credentials, so an auth middleware covering them silently breaks payment
+confirmation. That is why webhooks are a separate router with no middlewares
+attached. Those endpoints verify a provider signature on every request, which is
+their real protection.
+
+### Using another proxy
+
+Nginx, HAProxy, Apache or anything else works too — the override's Traefik labels
+are simply ignored by a proxy that does not read them. Route to the containers on
+the shared network with the same three rules:
+
+- `/api/v1/*` → `api:8000`
+- `/uploads/*` → `api:8000`
+- everything else → `frontend:3000`
+
+Set `MEMSHIP_HOST` and `TRAEFIK_NETWORK` anyway, since the override requires them;
+`TRAEFIK_CERTRESOLVER` can be any value, as nothing will read it.
+
+## After changing the proxy
+
+Whichever proxy terminates TLS, these must match your real public URL or logins
+and single sign-on will fail:
+
+```bash
+FRONTEND_URL=https://memship.yourclub.org
+CORS_ORIGINS=https://memship.yourclub.org
+BACKEND_PUBLIC_URL=https://memship.yourclub.org
+```
+
+`BACKEND_PUBLIC_URL` is what the SSO callback URL is built from, so it has to
+match the redirect URI registered with Google or Apple exactly, including
+`https://`.
+
+## A note on published ports
+
+The default `docker-compose.yml` publishes the API on `8003` and PostgreSQL on
+`5433` so you can reach them while setting things up. **On a public server, close
+them.** A host firewall is not enough on its own: Docker inserts its own iptables
+rules, and a published port can stay reachable from the internet even when `ufw`
+is configured to deny it. Either set `API_PORT` and `DB_PORT` to bind to
+`127.0.0.1`, or use the external-proxy override, which stops publishing them
+altogether.

--- a/scripts/staging-deploy.sh
+++ b/scripts/staging-deploy.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Runs ON the staging VPS. Piped in over SSH by .github/workflows/deploy-staging.yml:
+#
+#   ssh user@host "API_IMAGE=... FRONTEND_IMAGE=... IMAGE_TAG=... bash -s" < scripts/staging-deploy.sh
+#
+# Can also be run by hand on the box to redeploy or roll back:
+#
+#   API_IMAGE=ghcr.io/marcandreuf/memship-backend:sha-a04e2846f66d \
+#   FRONTEND_IMAGE=ghcr.io/marcandreuf/memship-frontend:sha-a04e2846f66d \
+#   IMAGE_TAG=sha-a04e2846f66d bash scripts/staging-deploy.sh
+#
+set -euo pipefail
+
+DEPLOY_DIR="${DEPLOY_DIR:-/opt/memship}"
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.staging.yml)
+
+: "${API_IMAGE:?API_IMAGE is required}"
+: "${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}"
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+
+cd "$DEPLOY_DIR"
+
+# Pin the exact images being validated. Rewritten each deploy rather than
+# appended, so .env cannot accumulate stale pins that shadow the new ones.
+touch .env
+sed -i -E '/^(API_IMAGE|FRONTEND_IMAGE|IMAGE_TAG)=/d' .env
+{
+    echo "API_IMAGE=${API_IMAGE}"
+    echo "FRONTEND_IMAGE=${FRONTEND_IMAGE}"
+    echo "IMAGE_TAG=${IMAGE_TAG}"
+} >> .env
+
+echo "Deploying:"
+echo "  api      ${API_IMAGE}"
+echo "  frontend ${FRONTEND_IMAGE}"
+
+"${COMPOSE[@]}" pull
+"${COMPOSE[@]}" up -d --remove-orphans
+
+# The api entrypoint applies migrations before serving, so a failed migration
+# shows up as an api that never answers. Wait for it rather than declaring
+# success the moment the container is created.
+echo -n "Waiting for the API"
+for _ in $(seq 1 60); do
+    if "${COMPOSE[@]}" exec -T api curl -fsS http://localhost:8000/api/v1/health >/dev/null 2>&1; then
+        echo " — healthy"
+        # Confirm the worker came back too: it is the part that fails quietly.
+        if ! "${COMPOSE[@]}" exec -T celery-worker \
+            uv run celery -A app.core.celery_app inspect ping -t 10 >/dev/null 2>&1; then
+            echo "ERROR: the API is up but the Celery worker did not answer a ping." >&2
+            echo "Emails and the scheduled billing jobs will not run. Check:" >&2
+            echo "  ${COMPOSE[*]} logs celery-worker" >&2
+            exit 1
+        fi
+        echo "Celery worker responding."
+        docker image prune -f --filter "until=168h" >/dev/null 2>&1 || true
+        exit 0
+    fi
+    echo -n "."
+    sleep 5
+done
+
+echo >&2
+echo "ERROR: the API did not become healthy within 5 minutes." >&2
+echo "Most likely a failed migration. Check:  ${COMPOSE[*]} logs api" >&2
+exit 1


### PR DESCRIPTION
**Base is #34, not `main`** — this stacks on the deploy-stack fix, which must land first. GitHub will retarget this to `main` once #34 merges. Review only the two commits above the base.

`build-images.yml` already publishes a release-candidate image per commit and `release.yml` promotes that exact image on a tag — but nothing consumed the RC in between, so "promote the validated image" promoted an image nothing had validated. This adds the missing consumer.

## Deploy pipeline

- `.github/workflows/deploy-staging.yml` — triggers on **Build Images** succeeding on `main`
- `scripts/staging-deploy.sh` — the half that runs on the VPS, piped in over SSH. A script in the repo rather than a heredoc in the workflow, so it is reviewable and can be run by hand to roll back
- `docker-compose.staging.yml` — Mailpit, so nothing can email a real person from demo data

Images are resolved **per service**. Build Images only rebuilds what changed, so `sha-<commit>` exists for one image and not the other on most merges; the other falls back to whatever `:main` points at, pinned by digest so the deploy is still exact.

The deploy waits for the API to answer before reporting success — the entrypoint applies migrations before serving, so a failed migration otherwise looks like a successful deploy. It then pings the Celery worker, since that is the component that fails silently and staging is where that should surface.

## Optional bundled proxy

`docker-compose.external-proxy.yml` runs memship behind an existing Traefik — our staging/demo box, a Swarm deployment, or a club with its own proxy. **The application containers are identical either way**; only what terminates TLS changes.

Three details worth review:

- The disabling profile is in the **override**, not the base file. A profiled service is off unless activated, so putting it in the base would mean a plain `docker compose up -d` silently starts no proxy. The ordinary self-hosted install is unchanged and needs no `.env`.
- Ports use the `!override` tag because Compose **appends** port lists — a plain override would leave the base file's `8003` published alongside. This is a security issue on a VPS: Docker writes iptables rules ahead of `ufw`, so a published port stays internet-reachable even when the firewall denies it. The API and Postgres are both closed here.
- Webhooks get their own router at higher priority with **no middlewares**. Payment providers POST from their own infrastructure and cannot present credentials, so an auth middleware added later to gate a demo site would otherwise break payment confirmation silently.

Documented for self-hosters in `docs/self-hosting/reverse-proxy.md`. Proxy choice recorded in memship-context `docs/cloud/DECISION-reverse-proxy.md`: Caddy stays the default for client installs, Traefik runs our infrastructure and the Swarm path.

## Not verified

**The VPS does not exist yet**, so the workflow and the deploy script are untested end to end. Both compose paths were validated with `docker compose config` (default → 7 services incl. caddy; external-proxy → 6, no caddy, 3 routers with correct priorities and rules intact).