### PR TITLE
docs(roadmap): record v1.4.0 — flexible roles & permissions

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -110,12 +110,12 @@ Memship segueix el [versionat semàntic](https://semver.org/) i **els números d
 | v1.1.1 | Pedaç — reorganització de la navegació de configuració: ajustos de pagaments i de socis agrupats a les pestanyes Pagaments i Socis | Fet |
 | v1.2.2 | Integració SSO / identitat i configuració de correu — alta pública amb verificació per correu, flux d'aprovació per la junta, inici de sessió amb Google / Apple, configuració de proveïdors SSO pel superadministrador i ajust de Resend / Google SMTP des d'una pestanya d'Integracions. També elimina una migració duplicada de configuració de correu amb un identificador de revisió que xocava amb un altre existent, cosa que feia fallar `alembic upgrade head` en arrencar | Fet |
 | v1.3.0 | Reserves simples — reserves de socis en espais compartits mitjançant un calendari setmanal, aforament per franja, llista d'espera FIFO amb promoció automàtica i correus de confirmació/llista d'espera | Fet |
+| v1.4.0 | Rols i permisos flexibles — assignació multi-rol i comprovacions granulars per permís en lloc dels quatre rols fixos, amb una API `/roles` de gestió i navegació i accés a pàgines guiats per permisos a tot el portal. També repara els stacks de desplegament publicats, que no executaven cap worker de Celery — de manera que tots els correus que envia el producte es perdien en silenci i les tasques nocturnes de facturació i de recordatoris de pagament no s'executaven mai — i no muntaven cap volum al servei d'API, de manera que una actualització destruïa els fitxers pujats i regenerava la clau secreta que xifra les credencials emmagatzemades d'SSO i dels proveïdors de pagament | Fet |
 
 ### Planificat
 
 Prioritzat, encara sense versió. Cada element esdevé un llançament versionat quan es publica, i el llançament pren el següent número semàntic per ordre.
 
-- **Rols i permisos flexibles** — multi-rol i permisos per rol més enllà dels 4 rols fixos
 - **Còpies de seguretat** — descarregar una còpia completa des de l'àrea d'administració, amb la base de dades i els fitxers pujats, i una restauració documentada i provada
 - **Convocatòries** — convocatòries formals d'Assemblea General amb confirmació del soci mitjançant token
 - **Biblioteca de documents** — estatuts, actes, formularis amb visibilitat per grup

--- a/README.es.md
+++ b/README.es.md
@@ -110,12 +110,12 @@ Memship sigue el [versionado semántico](https://semver.org/) y **los números d
 | v1.1.1 | Parche — reorganización de la navegación de configuración: ajustes de pagos y de socios agrupados en las pestañas Pagos y Socios | Hecho |
 | v1.2.2 | Integración SSO / identidad y configuración de correo — alta pública con verificación por correo, flujo de aprobación por la directiva, inicio de sesión con Google / Apple, configuración de proveedores SSO por el superadministrador y ajuste de Resend / Google SMTP desde una pestaña de Integraciones. También elimina una migración duplicada de configuración de correo cuyo identificador de revisión chocaba con otro existente, lo que hacía fallar `alembic upgrade head` al arrancar | Hecho |
 | v1.3.0 | Reservas simples — reservas de socios en espacios compartidos mediante un calendario semanal, aforo por franja, lista de espera FIFO con promoción automática y correos de confirmación/lista de espera | Hecho |
+| v1.4.0 | Roles y permisos flexibles — asignación multi-rol y comprobaciones granulares por permiso en lugar de los cuatro roles fijos, con una API `/roles` de gestión y navegación y acceso a páginas guiados por permisos en todo el portal. También repara los stacks de despliegue publicados, que no ejecutaban ningún worker de Celery — por lo que todos los correos que envía el producto se perdían en silencio y las tareas nocturnas de facturación y de recordatorios de pago no se ejecutaban nunca — y no montaban ningún volumen en el servicio de API, de modo que una actualización destruía los archivos subidos y regeneraba la clave secreta que cifra las credenciales almacenadas de SSO y de los proveedores de pago | Hecho |
 
 ### Planificado
 
 Priorizado, aún sin versión. Cada elemento se convierte en un lanzamiento versionado cuando se publica, y el lanzamiento toma el siguiente número semántico por orden.
 
-- **Roles y permisos flexibles** — multi-rol y permisos por rol más allá de los 4 roles fijos
 - **Copias de seguridad** — descargar una copia completa desde el área de administración, con la base de datos y los archivos subidos, y una restauración documentada y probada
 - **Convocatorias** — convocatorias formales de Asamblea General con confirmación del socio mediante token
 - **Biblioteca de documentos** — estatutos, actas, formularios con visibilidad por grupo

--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ Memship follows [semantic versioning](https://semver.org/), and **version number
 | v1.1.1 | Patch — settings navigation reorganised: payment and member settings grouped under Payments and Members tabs                                                                                                     | Done   |
 | v1.2.2 | SSO / identity integration and mailing configuration — public registration + email-verification onboarding, admin approval flow, Google / Apple sign-in, superadmin SSO provider configuration and Resend / Google SMTP setup from an Integrations tab. Also drops a duplicate mailing-config migration whose revision id collided with an existing one, which made `alembic upgrade head` fail on startup | Done   |
 | v1.3.0 | Simple Bookings — member reservations of shared spaces on a week calendar, per-slot capacity, FIFO waitlist with auto-promotion, and confirmation/waitlist emails | Done   |
+| v1.4.0 | Flexible roles & permissions — multi-role assignment and granular per-permission checks in place of the four fixed roles, with a `/roles` management API and permission-driven navigation and page access across the portal. Also repairs the shipped deployment stacks, which ran no Celery worker — so every email the product sends was dropped silently, and the nightly billing and payment-reminder jobs never ran at all — and mounted no volume on the API service, so an upgrade destroyed uploaded files and regenerated the secret key that encrypts stored SSO and payment-provider credentials | Done   |
 
 ### Planned
 
 Priority-ordered, not yet versioned. Each becomes a versioned release when it ships, and the release claims the next semver number in order.
 
-- **Flexible roles & permissions** — multi-role, per-role rights beyond the 4 fixed roles
 - **Data backups** — download a full backup from the admin area, covering the database and the uploaded files, with a documented and tested restore
 - **Convocations** — formal General Assembly calls with token-based member RSVP
 - **Document library** — statutes, minutes, forms with per-group visibility


### PR DESCRIPTION
Adds the `v1.4.0` Released row to the roadmap in all three locales and drops **Flexible roles & permissions** from Planned, now that it has shipped.

## Why this is needed before the release, not after

Flexible roles & permissions was item 1 on the Planned list and merged as **#37** on 2026-08-06, but no Released row went with it. `CONTRIBUTING.md#choosing-a-version` asks for the row *in the same PR as the feature code* — this catches that up.

It is also a hard gate, not just tidiness: `release.yml` greps `README.md` for `| v$VERSION ` and fails the workflow when the row is missing. Without this PR, `./scripts/release.sh 1.4.0` would tag and then fail rather than ship.

## Why v1.4.0 and not something larger

`main` carries 12 unreleased non-merge commits past `v1.3.0`. None of them changes the API, the data model, or the deployment contract, so by the existing rule this is a minor release: a new roadmap feature plus fixes.

The deployment change on **#38** is deliberately *not* part of it. That one drops `uv run` from the containers and needs a one-off `chown` on existing installs, which makes it a major under the same rule — it will be released separately as `v2.0.0`, after the staging environment validates it on a real host. Splitting them also means the #34 fix reaches self-hosters now instead of waiting behind a breaking change.

## The row

Headline feature plus the #34 deploy-stack fix, following the shape of the v1.2.2 row. The fix is described by what self-hosters actually experienced — silently dropped emails, and uploaded files and the secret key destroyed on upgrade — rather than by its mechanism, so a reader can tell whether it bit them.

The settings orphan-tab fix (#31) is on `main` and ships in this release too, but is left out of the row as small polish.

## Checks

- `grep -qF "| v1.4.0 " README.md` passes — the roadmap guard is satisfied.
- Row present once in each of `README.md`, `README.es.md`, `README.ca.md`.
- Each Planned list is now the same 5 items, so en/es/ca stay in parity.
- 1 insertion and 1 deletion per file; no other content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)