### PR TITLE
Interactive setup on every environment, with no published credentials

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -21,6 +21,12 @@ La majoria d'eines de gestió de socis són plataformes SaaS cares o programari 
 
 ## Inici ràpid (Docker)
 
+> **Per provar Memship, no per fer-lo servir.** És la via més ràpida a una instància
+> funcionant a la vostra màquina: imatges publicades, volums llencívols i una clau
+> secreta que és en aquest repositori. Per gestionar una organització real, seguiu la
+> [Instal·lació](docs/getting-started/installation.md) — el mateix producte, configurat
+> per poder-lo copiar, actualitzar i conservar.
+
 Proveu Memship amb una sola comanda — sense necessitat de clonar el repositori:
 
 ```bash
@@ -29,39 +35,29 @@ docker compose pull        # descarrega les últimes imatges publicades
 PORT=8081 docker compose up -d
 ```
 
-A continuació, executeu la configuració inicial:
-
-**Opció A: Demostració ràpida amb comptes de prova (sense preguntes)**
+A continuació, executeu la configuració, que us fa tres preguntes:
 
 ```bash
-docker compose exec demo-memship-api python -m app.cli.seed --test
+docker compose exec -it demo-memship-api python -m app.cli.seed
 ```
 
-Això crea comptes de prova preconfigurats, socis d'exemple, activitats i inscripcions:
+1. **Superadministrador** — trieu l'adreça i la contrasenya. No hi ha res predefinit.
+2. **Dades del club** — només s'ofereix si n'hi ha, així que en una instal·lació nova no fa res.
+3. **Configuració del club** — introduïu les dades reals de la vostra organització, o genereu un club de demostració.
 
-| Rol | Correu electrònic | Contrasenya |
-|-----|-------------------|-------------|
-| Superadministrador | super@test.com | TestSuper1! |
-| Administrador | admin@test.com | TestAdmin1! |
-| Soci | member@test.com | TestMember1! |
+Trieu el club de demostració per explorar: crea un any complet de dades d'exemple
+realistes — ~60 socis en tots els estats, activitats, rebuts en tots els estats repartits
+pels mesos, mandats SEPA i recordatoris del tauler. També genera accessos per a un
+administrador de club i dos socis, i **mostra aquestes contrasenyes una sola vegada**, així
+que deseu la sortida. Es pot tornar a executar sense duplicar (idempotent).
 
-**Opció B: Configuració personalitzada (interactiva)**
+Obriu http://localhost:8081 i inicieu sessió com a superadministrador. Canvieu `PORT=8081`
+per qualsevol port que preferiu (per defecte és el 80).
 
-```bash
-docker compose exec demo-memship-api python -m app.cli.seed
-```
-
-Us demanarà que creeu els vostres propis comptes de superadministrador i administrador. No es generen dades d'exemple.
-
-**Opció C: Conjunt de dades demo realista**
-
-```bash
-docker compose exec demo-memship-api python -m app.cli.seed --demo
-```
-
-Crea els comptes d'administrador anteriors més un any complet de dades d'exemple realistes — ~60 socis en tots els estats, activitats, rebuts en tots els estats repartits pels mesos, mandats SEPA i recordatoris del tauler — ideal per avaluar el tauler financer i el resum anual. Es pot tornar a executar sense duplicar (idempotent).
-
-Obriu http://localhost:8081 i inicieu sessió amb les vostres credencials. Canvieu `PORT=8081` per qualsevol port que preferiu (per defecte és el 80).
+Quan acabeu d'avaluar-lo, torneu a executar la mateixa comanda i responeu *sí* a la
+pregunta sobre les dades del club: esborra el club de demostració conservant el vostre
+superadministrador i les passarel·les de pagament que hàgiu configurat. Consulteu
+[Configuració inicial](docs/getting-started/first-setup.md).
 
 ## Full de ruta
 
@@ -278,24 +274,23 @@ Atureu-ho tot:
 
 ### Primera configuració
 
-Després d'iniciar els serveis, executeu la comanda de seed per crear les dades inicials:
+Després d'iniciar els serveis, executeu la comanda de configuració per crear les dades inicials:
 
 ```bash
-./scripts/dev.sh seed          # Interactiu — demana les credencials d'administrador
-./scripts/dev.sh seed test     # Ràpid — crea comptes de prova (sense preguntes)
+./scripts/dev.sh seed          # Interactiu — la mateixa configuració que fa servir qualsevol entorn
+./scripts/dev.sh seed test     # Comptes de prova fixos + dades d'exemple, per a la suite e2e
 ```
 
-L'opció `seed test` crea comptes de prova i dades d'exemple per al desenvolupament:
+`seed test` crea els comptes amb què inicia sessió la suite de Cypress, a més de 4 activitats
+d'exemple amb modalitats i preus, inscripcions d'exemple i ~22 socis addicionals. Les adreces i
+contrasenyes són un contracte amb la suite de proves, no una decisió de configuració, així que
+viuen al seu costat, a
+[`e2e/cypress/support/commands.ts`](e2e/cypress/support/commands.ts).
 
-| Rol | Correu electrònic | Contrasenya |
-|-----|-------------------|-------------|
-| Superadministrador | super@test.com | TestSuper1! |
-| Administrador | admin@test.com | TestAdmin1! |
-| Soci | member@test.com | TestMember1! |
-
-A més, 5 comptes de soci addicionals (maria@test.com, joan@test.com, etc. / TestMember1!), 4 activitats d'exemple amb modalitats i preus, i inscripcions d'exemple.
-
-> **Avís:** No utilitzeu els comptes de prova en producció. Utilitzeu `./scripts/dev.sh seed` (interactiu) per a desplegaments reals.
+> **`seed test` es nega a executar-se fora de desenvolupament.** Crea contrasenyes fixes i
+> visibles al repositori, així que exigeix `APP_ENV=development` o `CI` i acaba en cas
+> contrari. Per a qualsevol ús real, feu servir la configuració interactiva — consulteu
+> [Configuració inicial](docs/getting-started/first-setup.md).
 
 ## Instal·lació (Docker)
 

--- a/README.es.md
+++ b/README.es.md
@@ -21,6 +21,12 @@ La mayoría de herramientas de gestión de socios son plataformas SaaS caras o s
 
 ## Inicio rápido (Docker)
 
+> **Para probar Memship, no para usarlo.** Es la vía más rápida a una instancia
+> funcionando en tu propia máquina: imágenes publicadas, volúmenes desechables y una
+> clave secreta que está en este repositorio. Para gestionar una organización real,
+> sigue la [Instalación](docs/getting-started/installation.md) — el mismo producto,
+> configurado para poder respaldarlo, actualizarlo y conservarlo.
+
 Prueba Memship con un solo comando, sin necesidad de clonar el repositorio:
 
 ```bash
@@ -29,39 +35,29 @@ docker compose pull        # descarga las últimas imágenes publicadas
 PORT=8081 docker compose up -d
 ```
 
-A continuación, ejecuta la configuración inicial:
-
-**Opción A: Demo rápida con cuentas de prueba (sin preguntas)**
+A continuación, ejecuta la configuración, que te hace tres preguntas:
 
 ```bash
-docker compose exec demo-memship-api python -m app.cli.seed --test
+docker compose exec -it demo-memship-api python -m app.cli.seed
 ```
 
-Esto crea cuentas de prueba preconfiguradas, socios de ejemplo, actividades e inscripciones:
+1. **Super admin** — eliges la dirección y la contraseña. No hay nada predefinido.
+2. **Datos del club** — solo se ofrece si los hay, así que en una instalación nueva no hace nada.
+3. **Configuración del club** — introduce los datos reales de tu organización, o genera un club de demostración.
 
-| Rol | Email | Contraseña |
-|-----|-------|------------|
-| Super Admin | super@test.com | TestSuper1! |
-| Admin de Org | admin@test.com | TestAdmin1! |
-| Socio | member@test.com | TestMember1! |
+Elige el club de demostración para explorar: crea un año completo de datos de ejemplo
+realistas — ~60 socios en todos los estados, actividades, recibos en todos los estados
+repartidos por los meses, mandatos SEPA y recordatorios del panel. También genera accesos
+para un administrador de club y dos socios, y **muestra esas contraseñas una sola vez**,
+así que guarda la salida. Se puede volver a ejecutar sin duplicar (idempotente).
 
-**Opción B: Configuración personalizada (interactiva)**
+Abre http://localhost:8081 e inicia sesión como super admin. Cambia `PORT=8081` por el
+puerto que prefieras (por defecto es el 80).
 
-```bash
-docker compose exec demo-memship-api python -m app.cli.seed
-```
-
-Te pedirá que crees tus propias cuentas de super admin y admin de organización. No se generan datos de ejemplo.
-
-**Opción C: Conjunto de datos demo realista**
-
-```bash
-docker compose exec demo-memship-api python -m app.cli.seed --demo
-```
-
-Crea las cuentas de administrador anteriores más un año completo de datos de ejemplo realistas — ~60 socios en todos los estados, actividades, recibos en todos los estados repartidos por los meses, mandatos SEPA y recordatorios del panel — ideal para evaluar el panel financiero y el resumen anual. Se puede volver a ejecutar sin duplicar (idempotente).
-
-Abre http://localhost:8081 e inicia sesión con tus credenciales. Cambia `PORT=8081` por el puerto que prefieras (por defecto es el 80).
+Cuando termines de evaluarlo, vuelve a ejecutar el mismo comando y responde *sí* a la
+pregunta sobre los datos del club: borra el club de demostración conservando tu super
+admin y las pasarelas de pago que hayas configurado. Consulta
+[Configuración inicial](docs/getting-started/first-setup.md).
 
 ## Hoja de ruta
 
@@ -278,24 +274,23 @@ Parar todo:
 
 ### Primera configuración
 
-Tras iniciar los servicios, ejecuta el comando seed para crear los datos iniciales:
+Tras iniciar los servicios, ejecuta el comando de configuración para crear los datos iniciales:
 
 ```bash
-./scripts/dev.sh seed          # Interactivo — te pide las credenciales de admin
-./scripts/dev.sh seed test     # Rápido — crea cuentas de prueba (sin preguntas)
+./scripts/dev.sh seed          # Interactivo — la misma configuración que usa cualquier entorno
+./scripts/dev.sh seed test     # Cuentas de prueba fijas + datos de ejemplo, para la suite e2e
 ```
 
-La opción `seed test` crea cuentas de prueba y datos de ejemplo para desarrollo:
+`seed test` crea las cuentas con las que inicia sesión la suite de Cypress, además de 4
+actividades de ejemplo con modalidades y precios, inscripciones de ejemplo y ~22 socios
+adicionales. Las direcciones y contraseñas son un contrato con la suite de pruebas, no una
+decisión de configuración, así que viven junto a ella, en
+[`e2e/cypress/support/commands.ts`](e2e/cypress/support/commands.ts).
 
-| Rol | Email | Contraseña |
-|-----|-------|------------|
-| Super Admin | super@test.com | TestSuper1! |
-| Admin de Org | admin@test.com | TestAdmin1! |
-| Socio | member@test.com | TestMember1! |
-
-Además, 5 cuentas de socio adicionales (maria@test.com, joan@test.com, etc. / TestMember1!), 4 actividades de ejemplo con modalidades y precios, e inscripciones de ejemplo.
-
-> **Aviso:** No utilices las cuentas de prueba en producción. Usa `./scripts/dev.sh seed` (interactivo) para despliegues reales.
+> **`seed test` se niega a ejecutarse fuera de desarrollo.** Crea contraseñas fijas y visibles
+> en el repositorio, así que exige `APP_ENV=development` o `CI` y termina en caso contrario.
+> Para cualquier uso real, usa la configuración interactiva — consulta
+> [Configuración inicial](docs/getting-started/first-setup.md).
 
 ## Instalación (Docker)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Most membership tools are either expensive SaaS platforms or outdated legacy sof
 
 ## Quick Start (Docker)
 
+> **For trying memship out, not for running it.** This is the fastest path to a
+> working instance on your own machine: published images, throwaway volumes, and
+> a secret key that is committed to this repository. To run memship for a real
+> organization, follow [Installation](docs/getting-started/installation.md)
+> instead — same product, set up so it can be backed up, upgraded and kept.
+
 Try memship with a single command — no cloning required:
 
 ```bash
@@ -29,39 +35,29 @@ docker compose pull        # fetch the latest published images
 PORT=8081 docker compose up -d
 ```
 
-Then run the initial setup:
-
-**Option A: Quick demo with test accounts (no prompts)**
+Then run the setup, which walks you through three questions:
 
 ```bash
-docker compose exec demo-memship-api python -m app.cli.seed --test
+docker compose exec -it demo-memship-api python -m app.cli.seed
 ```
 
-This creates pre-configured test accounts, sample members, activities, and registrations:
+1. **Super admin** — you choose the address and password. Nothing is preset.
+2. **Club data** — offered only if there is any, so it is a no-op on a fresh install.
+3. **Club setup** — enter your organization's real details, or generate a demo club.
 
-| Role | Email | Password |
-|------|-------|----------|
-| Super Admin | super@test.com | TestSuper1! |
-| Org Admin | admin@test.com | TestAdmin1! |
-| Member | member@test.com | TestMember1! |
+Choose the demo club to look around: it creates a full year of realistic sample
+data — ~60 members across all statuses, activities, receipts in every state
+spread across the months, SEPA mandates and dashboard reminders. It also
+generates logins for a club admin and two members and **prints those passwords
+once**, so keep the output. Safe to re-run (idempotent).
 
-**Option B: Custom setup (interactive)**
+Open http://localhost:8081 and log in as your super admin. Change `PORT=8081` to
+any port you prefer (default is 80).
 
-```bash
-docker compose exec demo-memship-api python -m app.cli.seed
-```
-
-Prompts you to create your own super admin and org admin accounts. No sample data is generated.
-
-**Option C: Realistic demo dataset**
-
-```bash
-docker compose exec demo-memship-api python -m app.cli.seed --demo
-```
-
-Creates the admin accounts above plus a full year of realistic sample data — ~60 members across all statuses, activities, receipts in every state spread across the months, SEPA mandates, and dashboard reminders — ideal for evaluating the finance dashboard and annual summary. Safe to re-run (idempotent).
-
-Open http://localhost:8081 and log in with your credentials. Change `PORT=8081` to any port you prefer (default is 80).
+Once you are done evaluating, re-run the same command and answer *yes* to the
+club-data question: it clears the demo club while keeping your super admin and
+any payment providers you configured. See
+[First-time setup](docs/getting-started/first-setup.md).
 
 ## Roadmap
 
@@ -279,24 +275,22 @@ Stop everything:
 
 ### First Time Setup
 
-After starting the services, run the seed command to create initial data:
+After starting the services, run the setup command to create initial data:
 
 ```bash
-./scripts/dev.sh seed          # Interactive — prompts for admin credentials
-./scripts/dev.sh seed test     # Quick — creates test accounts (no prompts)
+./scripts/dev.sh seed          # Interactive — the same setup every environment uses
+./scripts/dev.sh seed test     # Fixed test accounts + sample data, for the e2e suite
 ```
 
-The `seed test` option creates test accounts and sample data for development:
+`seed test` creates the accounts the Cypress suite signs in as, plus 4 sample activities with
+modalities and prices, sample registrations, and ~22 extra members. The addresses and passwords
+are a contract with the test suite rather than a seeding choice, so they live with it, in
+[`e2e/cypress/support/commands.ts`](e2e/cypress/support/commands.ts).
 
-| Role | Email | Password |
-|------|-------|----------|
-| Super Admin | super@test.com | TestSuper1! |
-| Org Admin | admin@test.com | TestAdmin1! |
-| Member | member@test.com | TestMember1! |
-
-Plus 5 extra member accounts (maria@test.com, joan@test.com, etc. / TestMember1!), 4 sample activities with modalities and prices, and sample registrations.
-
-> **Warning:** Do not use test accounts in production. Use `./scripts/dev.sh seed` (interactive) for real deployments.
+> **`seed test` refuses to run outside development.** It plants fixed, repository-visible
+> passwords, so it requires `APP_ENV=development` or `CI` and exits otherwise. For anything
+> real, use the interactive setup — see
+> [First-time setup](docs/getting-started/first-setup.md).
 
 ## Installation (Docker)
 
@@ -323,7 +317,7 @@ cp .env.example .env
 docker compose pull
 docker compose up -d
 
-# Run initial setup (creates admin accounts)
+# Run the setup: super admin, club data reset, club setup
 docker compose exec -it api python -m app.cli.seed
 
 # Open http://localhost

--- a/backend/app/cli/demo_data.py
+++ b/backend/app/cli/demo_data.py
@@ -79,7 +79,7 @@ def generate_members(
     """
     if db.query(Person).filter(Person.email.like("demo%@mediterrani.example")).first():
         print("  Demo members: already seeded")
-        return _demo_members(db)
+        return demo_members(db)
 
     types = db.query(MembershipType).filter(MembershipType.is_active.is_(True)).all()
     type_ids = [mt.id for mt in types] or [default_membership_type.id]
@@ -146,7 +146,7 @@ def generate_members(
     return members
 
 
-def _demo_members(db) -> list[Member]:
+def demo_members(db) -> list[Member]:
     return (
         db.query(Member)
         .join(Person, Member.person_id == Person.id)
@@ -198,7 +198,7 @@ def generate_billing(db, created_by: int | None) -> None:
         concepts.get("membership-full-member") or next(iter(concepts.values()))
     )
 
-    members = _demo_members(db)
+    members = demo_members(db)
     if not members:
         print("  Demo billing: no demo members to bill")
         return
@@ -381,7 +381,7 @@ def generate_bookings(db) -> None:
         )
         org.features = features
 
-    members = _demo_members(db)
+    members = demo_members(db)
     if not members:
         return
 

--- a/backend/app/cli/reset.py
+++ b/backend/app/cli/reset.py
@@ -1,0 +1,171 @@
+"""Club-data reset — return an instance to a clean state without losing the
+operator's own account or the instance-level configuration.
+
+Deleting the database volume is not a substitute. Payment provider credentials
+live in ``payment_providers.config`` (encrypted with the Fernet key), not in
+``.env``, so wiping the volume forces the operator to re-enter every secret they
+configured while evaluating. This clears the club and keeps the instance.
+
+What survives a reset:
+
+- the super admin accounts, and the people records behind them
+- the system roles and their permission grants
+- the address/contact type lookups
+- ``payment_providers``
+
+Everything else is club data and goes, including custom roles, which are
+authored by the club rather than shipped with the product.
+"""
+
+from sqlalchemy import bindparam, text
+
+from app.core.permissions import SUPER_ADMIN_SLUG
+from app.db import models_registry  # noqa: F401  — populates Base.metadata
+from app.db.base import Base
+
+# Every table this module knew about when it was written. Checked against the
+# live metadata before anything is deleted: a table added later is a decision
+# somebody has to make, not something to guess at. Getting it wrong in the
+# silent direction means a reset leaves club data behind, or wipes a second
+# credential store the way a volume wipe would.
+KNOWN_TABLES = frozenset({
+    "activities", "activity_attachment_types", "activity_consents",
+    "activity_modalities", "activity_prices", "addresses", "address_types",
+    "announcement_recipients", "announcements", "audit_logs", "billing_runs",
+    "bookings", "concepts", "contacts", "contact_types",
+    "custom_field_definitions", "custom_field_values", "discount_codes",
+    "groups", "members", "membership_types", "notifications",
+    "organization_settings", "payment_providers", "persons",
+    "receipt_reminders", "receipts", "registration_attachments",
+    "registration_consents", "registrations", "reminders", "remittances",
+    "role_permissions", "roles", "sepa_mandates", "spaces", "space_slots",
+    "user_identities", "user_roles", "users", "webhook_events",
+})
+
+# Instance-level configuration and lookups. A club reset never touches these.
+PRESERVED_TABLES = frozenset({
+    "address_types",
+    "contact_types",
+    # The reason this command exists instead of "delete the postgres volume".
+    "payment_providers",
+    # Cleared transitively: role_permissions.role_id is ON DELETE CASCADE, so
+    # dropping the custom roles takes their grants with them while the system
+    # roles keep theirs.
+    "role_permissions",
+})
+
+# Rows belonging to the surviving operator accounts stay; the rest go. Keyed by
+# table, valued by the WHERE clause that spares them. `:user_ids` and
+# `:person_ids` are bound as expanding lists.
+ACCOUNT_SCOPED_PREDICATES = {
+    "users": "id NOT IN :user_ids",
+    "persons": "id NOT IN :person_ids",
+    "user_roles": "user_id NOT IN :user_ids",
+    "user_identities": "user_id NOT IN :user_ids",
+    # Custom roles are club data. The system roles are the product.
+    "roles": "is_system = false",
+}
+
+
+def _check_metadata_is_classified() -> None:
+    live = set(Base.metadata.tables)
+    unknown = live - KNOWN_TABLES
+    if unknown:
+        raise RuntimeError(
+            "app/cli/reset.py does not know what to do with these tables: "
+            + ", ".join(sorted(unknown))
+            + ". Add each one to KNOWN_TABLES, and to PRESERVED_TABLES or "
+            "ACCOUNT_SCOPED_PREDICATES if a club reset must not clear it."
+        )
+
+
+def _preserved_ids(db) -> tuple[list[int], list[int]]:
+    """User and person ids for the super admins, who outlive a reset."""
+    rows = db.execute(
+        text(
+            "SELECT u.id, u.person_id FROM users u "
+            "JOIN user_roles ur ON ur.user_id = u.id "
+            "JOIN roles r ON r.id = ur.role_id "
+            "WHERE r.slug = :slug"
+        ),
+        {"slug": SUPER_ADMIN_SLUG},
+    ).all()
+    return [r[0] for r in rows], [r[1] for r in rows]
+
+
+def _where(table_name: str, user_ids: list[int], person_ids: list[int]) -> tuple[str, dict]:
+    """The WHERE clause sparing the preserved rows, and its parameters.
+
+    Returns an empty clause when the whole table goes — either because it holds
+    no preserved rows, or because there is nothing to preserve.
+    """
+    predicate = ACCOUNT_SCOPED_PREDICATES.get(table_name)
+    if predicate is None:
+        return "", {}
+
+    params: dict[str, list[int]] = {}
+    if "user_ids" in predicate:
+        # `NOT IN ()` is a syntax error, and with nothing to spare the predicate
+        # is vacuous anyway — clear the table.
+        if not user_ids:
+            return "", {}
+        params["user_ids"] = user_ids
+    if "person_ids" in predicate:
+        if not person_ids:
+            return "", {}
+        params["person_ids"] = person_ids
+    return f" WHERE {predicate}", params
+
+
+def _statement(sql: str, params: dict):
+    """A text() with every list parameter bound as expanding."""
+    stmt = text(sql)
+    for name in params:
+        stmt = stmt.bindparams(bindparam(name, expanding=True))
+    return stmt
+
+
+def preview_club_data(db) -> dict[str, int]:
+    """Row counts a reset would delete, per table. Only non-empty tables."""
+    _check_metadata_is_classified()
+    user_ids, person_ids = _preserved_ids(db)
+
+    counts: dict[str, int] = {}
+    for table in reversed(Base.metadata.sorted_tables):
+        if table.name in PRESERVED_TABLES:
+            continue
+        where, params = _where(table.name, user_ids, person_ids)
+        stmt = _statement(f"SELECT count(*) FROM {table.name}{where}", params)
+        count = db.execute(stmt, params).scalar_one()
+        if count:
+            counts[table.name] = count
+    return counts
+
+
+def reset_club_data(db) -> dict[str, int]:
+    """Delete every club-scoped row. Returns what was removed, per table.
+
+    Does not commit — the caller owns the transaction, so a failure part-way
+    through leaves the instance exactly as it was.
+    """
+    _check_metadata_is_classified()
+    user_ids, person_ids = _preserved_ids(db)
+
+    deleted: dict[str, int] = {}
+    # Dependency order, children first, so plain DELETEs never trip a foreign
+    # key and nothing needs CASCADE — which on a TRUNCATE would happily follow
+    # the references back into `users` and delete the operator too.
+    for table in reversed(Base.metadata.sorted_tables):
+        if table.name in PRESERVED_TABLES:
+            continue
+        where, params = _where(table.name, user_ids, person_ids)
+        result = db.execute(_statement(f"DELETE FROM {table.name}{where}", params), params)
+        if result.rowcount:
+            deleted[table.name] = result.rowcount
+
+    # The deletes went out as SQL, so the session's identity map still holds the
+    # objects they removed. Without this, re-creating the organization — same
+    # `id = 1`, since the table is single-row — collides with the stale instance
+    # and SQLAlchemy warns about a duplicate identity key.
+    db.expire_all()
+    return deleted

--- a/backend/app/cli/seed.py
+++ b/backend/app/cli/seed.py
@@ -1,31 +1,42 @@
-"""CLI seed command — populates initial data for a fresh Memship installation.
+"""CLI setup command — prepares a Memship installation for use.
 
-Creates:
-- Organization settings (defaults)
-- Address types (home, work, billing, legal, venue)
-- Contact types (phone_home, phone_mobile, phone_work, phone_emergency, email_work, email_other)
-- Groups (Adult Members, Youth Programs, Senior Members, Honorary Members)
-- Membership types (Full Member, Student, Family, Youth, Senior, Honorary)
-- Admin accounts (interactive prompts or --test for test accounts)
-- Sample activities with modalities and prices (--test only)
-- Extra member accounts for realistic data (--test only)
-- Sample registrations: confirmed, waitlisted, cancelled (--test only)
-- Discount codes, consents, and attachment types per activity (--test only)
-- SEPA mandates, payment provider, and batchable receipts (--test only)
+Interactive by default, and the same command on every environment. It asks
+three independent questions, so one script covers every situation:
+
+    1. Super admin      — create the operator account, or reset its password
+    2. Club data        — wipe what is there (see app/cli/reset.py)
+    3. Club setup       — enter the real club's details, or generate a demo club
+
+    going live for real          yes / yes / real details
+    fresh production install     yes / no  / real details
+    evaluating the product       yes / no  / demo
+    re-demoing before a call     no  / yes / demo
+
+Base data every install needs — address and contact types, the default groups
+and membership types — is seeded regardless of the answers.
+
+No credentials are published for any of this. The super admin is whatever the
+operator types; the demo club's accounts get generated passwords, printed once.
 
 Usage:
-    python -m app.cli.seed          # Interactive
-    python -m app.cli.seed --test   # Test accounts + sample data
+    python -m app.cli.seed                      # interactive (all environments)
+    python -m app.cli.seed --admin-email ...    # unattended, see _parse_args
+    python -m app.cli.seed --test               # fixed test accounts, CI only
 """
 
 import argparse
 import getpass
+import os
+import secrets
+import string
 import sys
 from pathlib import Path
 
 from argon2 import PasswordHasher
 from sqlalchemy import text
 
+from app.cli.reset import preview_club_data, reset_club_data
+from app.core.permissions import ADMIN_SLUG, SUPER_ADMIN_SLUG
 from app.db.session import SessionLocal
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Address, AddressType, Contact, ContactType, Person
@@ -40,23 +51,74 @@ from app.domains.billing.models import Concept, PaymentProvider, Receipt, Remitt
 
 ph = PasswordHasher()
 
+# Unambiguous alphabet: no 0/O, 1/l/I. These passwords get read off a terminal
+# and typed into a browser, sometimes off a screen share during a demo call.
+_PASSWORD_ALPHABET = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+
+def generate_password(length: int = 20) -> str:
+    """A password nobody chose, for the demo accounts."""
+    return "".join(secrets.choice(_PASSWORD_ALPHABET) for _ in range(length))
+
+
+def prompt_yes_no(question: str, default: bool = False) -> bool:
+    suffix = "[Y/n]" if default else "[y/N]"
+    while True:
+        answer = input(f"{question} {suffix} ").strip().lower()
+        if not answer:
+            return default
+        if answer in ("y", "yes"):
+            return True
+        if answer in ("n", "no"):
+            return False
+        print("Please answer y or n.")
+
+
+def prompt_password(label: str = "Password") -> str:
+    while True:
+        password = getpass.getpass(f"{label} (min 8 chars): ")
+        if len(password) < 8:
+            print("Password must be at least 8 characters.")
+            continue
+        if password != getpass.getpass("Confirm password: "):
+            print("Passwords do not match.")
+            continue
+        return password
+
+
+def prompt_club_details() -> dict:
+    """The real club's details, for an installation that is not a demo.
+
+    Only `name` is required by the schema; the rest can be filled in later from
+    Settings, so anything left blank stays blank rather than being invented. An
+    invented tax ID or IBAN is worse than an empty one — it looks configured.
+    """
+    print("\n--- Your organization ---")
+    print("Only the name is required. Leave the rest blank to fill in later")
+    print("from Settings.\n")
+
+    while True:
+        name = input("Organization name: ").strip()
+        if name:
+            break
+        print("The organization name is required.")
+
+    return {
+        "name": name,
+        "legal_name": input("Legal name: ").strip() or None,
+        "email": input("Contact email: ").strip() or None,
+        "phone": input("Phone: ").strip() or None,
+        "website": input("Website: ").strip() or None,
+        "tax_id": input("Tax ID (NIF/CIF): ").strip() or None,
+    }
+
 
 def prompt_user_details(role_label: str) -> dict:
     print(f"\n--- {role_label} Account ---")
     first_name = input("First name: ").strip()
     last_name = input("Last name: ").strip()
     email = input("Email: ").strip()
-
-    while True:
-        password = getpass.getpass("Password (min 8 chars): ")
-        if len(password) < 8:
-            print("Password must be at least 8 characters.")
-            continue
-        confirm = getpass.getpass("Confirm password: ")
-        if password != confirm:
-            print("Passwords do not match.")
-            continue
-        break
+    password = prompt_password()
 
     return {
         "first_name": first_name,
@@ -105,7 +167,38 @@ def seed_contact_types(db) -> None:
     print(f"  Contact types: created {len(types)} types")
 
 
-def seed_org_settings(db) -> None:
+# Only ever applied to a demo club. A real installation gets what the operator
+# types at the prompt — before this was split, every client inherited the name,
+# tax ID and IBAN below and had to notice in order to correct them.
+DEMO_ORG = {
+    "name": "Club Esportiu Mediterrani",
+    "legal_name": "Club Esportiu Mediterrani S.L.",
+    "email": "info@cemediterrani.cat",
+    "phone": "+34 933 001 234",
+    "website": "https://cemediterrani.cat",
+    "tax_id": "B12345678",
+    "bank_name": "CaixaBank",
+    "bank_iban": "ES9121000418450200051332",
+    "bank_bic": "CAIXESBBXXX",
+}
+
+DEMO_ORG_ADDRESS = {
+    "address_line1": "Carrer de la Marina 22",
+    "address_line2": "Local 3",
+    "city": "Barcelona",
+    "state_province": "Barcelona",
+    "postal_code": "08005",
+    "country": "ES",
+}
+
+
+def create_org_settings(db, details: dict, address: dict | None = None) -> None:
+    """Create the single organization row from `details`.
+
+    Single-tenant: `CHECK (id = 1)`. Bank details and address are only supplied
+    for a demo club, so a real install starts with those fields empty rather
+    than plausible-looking and wrong.
+    """
     existing = db.query(OrganizationSettings).first()
     if existing:
         print(f"  Organization settings: already configured ({existing.name})")
@@ -113,20 +206,20 @@ def seed_org_settings(db) -> None:
 
     org = OrganizationSettings(
         id=1,
-        name="Club Esportiu Mediterrani",
-        legal_name="Club Esportiu Mediterrani S.L.",
-        email="info@cemediterrani.cat",
-        phone="+34 933 001 234",
-        website="https://cemediterrani.cat",
-        tax_id="B12345678",
+        name=details["name"],
+        legal_name=details.get("legal_name"),
+        email=details.get("email"),
+        phone=details.get("phone"),
+        website=details.get("website"),
+        tax_id=details.get("tax_id"),
+        bank_name=details.get("bank_name"),
+        bank_iban=details.get("bank_iban"),
+        bank_bic=details.get("bank_bic"),
         locale="es",
         timezone="Europe/Madrid",
         currency="EUR",
         date_format="DD/MM/YYYY",
         brand_color="#0083ad",
-        bank_name="CaixaBank",
-        bank_iban="ES9121000418450200051332",
-        bank_bic="CAIXESBBXXX",
         invoice_prefix="FAC",
         invoice_next_number=1,
         invoice_annual_reset=True,
@@ -148,24 +241,25 @@ def seed_org_settings(db) -> None:
     db.add(org)
     db.flush()
 
-    # Add organization address
-    legal_type = db.query(AddressType).filter(AddressType.code == "legal").first()
-    org_address = Address(
-        entity_type="organization",
-        entity_id=1,
-        address_type_id=legal_type.id if legal_type else None,
-        address_line1="Carrer de la Marina 22",
-        address_line2="Local 3",
-        city="Barcelona",
-        state_province="Barcelona",
-        postal_code="08005",
-        country="ES",
-        is_primary=True,
-    )
-    db.add(org_address)
-    db.flush()
+    if address:
+        legal_type = db.query(AddressType).filter(AddressType.code == "legal").first()
+        db.add(
+            Address(
+                entity_type="organization",
+                entity_id=1,
+                address_type_id=legal_type.id if legal_type else None,
+                is_primary=True,
+                **address,
+            )
+        )
+        db.flush()
 
-    print("  Organization settings: created 'Club Esportiu Mediterrani' (address + bank details)")
+    print(f"  Organization settings: created '{org.name}'")
+
+
+def seed_demo_org_settings(db) -> None:
+    """The demo club, with the address and bank details a demo needs to look real."""
+    create_org_settings(db, DEMO_ORG, DEMO_ORG_ADDRESS)
 
 
 def seed_groups(db) -> dict[str, Group]:
@@ -266,19 +360,21 @@ def seed_membership_types(db, groups: dict[str, Group]) -> MembershipType:
 
 
 def next_member_number(db) -> str:
-    last = (
-        db.query(Member)
-        .filter(Member.member_number.isnot(None))
-        .order_by(Member.id.desc())
-        .first()
-    )
-    if last and last.member_number:
-        try:
-            num = int(last.member_number.replace("M-", ""))
-            return f"M-{num + 1:04d}"
-        except ValueError:
-            pass
-    return "M-0001"
+    """The next free `M-` number.
+
+    Only `M-` numbers count. The demo cohort carries its own `D-` namespace, so
+    taking the highest id instead would land on a demo member, fail to parse it
+    and restart the counter at M-0001 — which then collides with the account
+    that already holds it.
+    """
+    numbers = [
+        int(value[2:])
+        for (value,) in db.query(Member.member_number).filter(
+            Member.member_number.like("M-%")
+        )
+        if value[2:].isdigit()
+    ]
+    return f"M-{max(numbers) + 1 if numbers else 1:04d}"
 
 
 def create_user_with_member(
@@ -1441,36 +1537,437 @@ def seed_sepa_data(db) -> None:
     print("  SEPA seed: complete — ready for manual SEPA workflow testing")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Memship seed command")
+DEMO_CLUB_ADMIN_EMAIL = "admin@mediterrani.example"
+
+
+def any_admin_user_id(db) -> int | None:
+    """A user holding `admin` or `super_admin`, for `created_by` stamps.
+
+    Resolved by role rather than by a fixed address: the operator picks their
+    own super admin email, and the demo layer can be applied on top of any
+    account, so there is no address to look up.
+    """
+    user = (
+        db.query(User)
+        .join(User.roles)
+        .filter(Role.slug.in_((SUPER_ADMIN_SLUG, ADMIN_SLUG)))
+        .order_by(User.id)
+        .first()
+    )
+    return user.id if user else None
+
+
+def super_admin_users(db) -> list[User]:
+    return (
+        db.query(User)
+        .join(User.roles)
+        .filter(Role.slug == SUPER_ADMIN_SLUG)
+        .order_by(User.id)
+        .all()
+    )
+
+
+def restore_member_records(db, users: list[User], membership_type: MembershipType) -> None:
+    """Give the surviving super admins a member record again after a reset.
+
+    `members` is club data and goes with the rest of it, but every account the
+    setup creates has one — see `create_user_with_member`. Without this a super
+    admin comes out of a reset with a person record and no membership, which is
+    a shape nothing else in the app produces.
+    """
+    for user in users:
+        if db.query(Member).filter_by(person_id=user.person_id).first():
+            continue
+        db.add(
+            Member(
+                person_id=user.person_id,
+                user_id=user.id,
+                membership_type_id=membership_type.id,
+                member_number=next_member_number(db),
+                status="active",
+            )
+        )
+        db.flush()
+        print(f"  member record: restored for {user.email}")
+
+
+def set_password(db, user: User, password: str) -> None:
+    user.password_hash = ph.hash(password)
+    db.flush()
+
+
+def attach_login(db, member: Member, password: str) -> str:
+    """Give an existing demo member a login. Returns the email."""
+    person = db.query(Person).filter_by(id=member.person_id).one()
+    user = User(
+        person_id=person.id,
+        email=person.email,
+        password_hash=ph.hash(password),
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(user)
+    db.flush()
+    assign_roles(db, user, "member")
+    member.user_id = user.id
+    db.flush()
+    return person.email
+
+
+def create_demo_accounts(db, membership_type: MembershipType) -> list[tuple[str, str, str]]:
+    """The club admin and two member logins for a demo club.
+
+    Passwords are generated, printed once, and stored only as argon2 hashes —
+    there is nothing here for a search engine to find, unlike the fixed
+    credentials this replaced.
+    """
+    accounts: list[tuple[str, str, str]] = []
+
+    admin_password = generate_password()
+    existing = db.query(User).filter_by(email=DEMO_CLUB_ADMIN_EMAIL).first()
+    if existing:
+        set_password(db, existing, admin_password)
+        print(f"  club admin: password reset ({DEMO_CLUB_ADMIN_EMAIL})")
+    else:
+        create_user_with_member(
+            db,
+            {
+                "first_name": "Club",
+                "last_name": "Admin",
+                "email": DEMO_CLUB_ADMIN_EMAIL,
+                "password": admin_password,
+            },
+            ADMIN_SLUG,
+            membership_type,
+        )
+    accounts.append(("club admin", DEMO_CLUB_ADMIN_EMAIL, admin_password))
+
+    # Two of the generated cohort get logins, so the member portal can be shown
+    # without handing out an admin account. The rest stay login-less: a demo
+    # needs a couple of working sign-ins, not sixty.
+    from app.cli.demo_data import demo_members
+
+    for member in [m for m in demo_members(db) if m.user_id is None][:2]:
+        password = generate_password()
+        email = attach_login(db, member, password)
+        accounts.append(("member", email, password))
+        print(f"  member login: created ({email})")
+
+    return accounts
+
+
+def run_test_mode(db, membership_type: MembershipType) -> None:
+    """Fixed-credential dataset for the e2e suite. Never runs outside CI/dev.
+
+    The addresses and passwords below are load-bearing: e2e/cypress hard-codes
+    them across the spec files, so they are a contract with the test suite
+    rather than a seeding choice. They are deliberately absent from every
+    user-facing document.
+    """
+    # Before the accounts: `assign_roles` resolves by slug, so the treasurer
+    # role has to exist by the time its holder is created.
+    print("\nSeeding custom roles...")
+    seed_narrow_role(db)
+
+    print("\nCreating test accounts...")
+    for account in TEST_ACCOUNTS:
+        create_user_with_member(db, account, account["role"], membership_type)
+
+    admin_id = any_admin_user_id(db)
+    if admin_id:
+        print("\nSeeding activities...")
+        seed_activities(db, admin_id)
+
+    for label, fn in (
+        ("extra members", lambda: seed_extra_members(db, membership_type)),
+        ("member contacts", lambda: seed_member_contacts(db)),
+        ("registrations", lambda: seed_registrations(db)),
+        ("discount codes", lambda: seed_discount_codes(db)),
+        ("activity consents", lambda: seed_consents(db)),
+        ("attachment types", lambda: seed_attachment_types(db)),
+        ("registration consents", lambda: seed_registration_consents(db)),
+        ("billing data", lambda: seed_billing_data(db)),
+        ("SEPA data", lambda: seed_sepa_data(db)),
+    ):
+        print(f"\nSeeding {label}...")
+        fn()
+
+
+def guard_test_mode() -> None:
+    """`--test` plants known passwords. Refuse anywhere they could matter."""
+    if os.environ.get("CI") or os.environ.get("APP_ENV") == "development":
+        return
+    print(
+        "\nERROR: --test creates accounts with fixed, publicly-known passwords and\n"
+        "is only for the automated test suite. It refuses to run unless APP_ENV=development\n"
+        "or CI is set.\n\n"
+        "To set this installation up, run the same command with no flags:\n\n"
+        "    python -m app.cli.seed\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Memship setup — super admin, club data reset, and club setup.",
+        epilog=(
+            "Run with no arguments for the interactive setup. The flags below drive "
+            "the same three steps unattended, for automated deployments."
+        ),
+    )
     parser.add_argument(
-        "--test",
+        "--admin-email",
+        help="Create the super admin with this address, unattended. The password "
+        "is read from the MEMSHIP_ADMIN_PASSWORD environment variable, never from "
+        "the command line, where it would land in the shell history and `ps`.",
+    )
+    parser.add_argument(
+        "--reset-club-data",
         action="store_true",
-        help="Create test accounts with simple passwords instead of interactive prompts",
+        help="Delete all club data before setting up. Keeps the super admin "
+        "accounts, the system roles and the configured payment providers.",
+    )
+    parser.add_argument(
+        "--club-name",
+        help="Create the organization with this name, unattended.",
     )
     parser.add_argument(
         "--demo",
         action="store_true",
-        help="Layer a realistic year-spread demo dataset (members, billing, SEPA, reminders) for evaluation/screenshots",
+        help="Generate the demo club: organization, a year of members, billing, "
+        "SEPA and reminders, plus generated logins for a club admin and two members.",
     )
-    args = parser.parse_args()
+    # Fixed-credential mode for the e2e suite. Hidden: it is not something an
+    # operator should ever reach for, and `guard_test_mode` refuses it anyway.
+    parser.add_argument("--test", action="store_true", help=argparse.SUPPRESS)
+    return parser.parse_args()
 
-    print("\n=== Memship Seed ===\n")
-    print("This will set up initial data for a fresh installation.")
-    print("If data already exists, existing records will be skipped.\n")
+
+def _run_interactive(db, membership_type: MembershipType) -> list[tuple[str, str, str]]:
+    """Ask all three questions, then act on the answers.
+
+    Gathering first means the destructive step runs only once every question has
+    been answered — and since `main` commits once at the end, Ctrl-C at any
+    prompt rolls the whole thing back and leaves the instance untouched.
+    """
+    existing_supers = super_admin_users(db)
+    club_data = preview_club_data(db)
+
+    # --- 1. Super admin -----------------------------------------------------
+    print("\n--- 1/3  Super admin ---")
+    super_details = None
+    reset_target = None
+    if existing_supers:
+        listed = ", ".join(u.email for u in existing_supers)
+        print(f"This instance already has a super admin: {listed}")
+        if prompt_yes_no("Reset the password for one of them?"):
+            email = input("Which address? ").strip()
+            reset_target = next((u for u in existing_supers if u.email == email), None)
+            if reset_target is None:
+                print(f"  No super admin with address {email!r} — skipping.")
+            else:
+                reset_password = prompt_password("New password")
+    else:
+        print("No super admin exists yet. This is the account that owns the")
+        print("instance: it manages roles, credentials and custom fields.")
+        super_details = prompt_user_details("Super Admin")
+
+    # --- 2. Club data -------------------------------------------------------
+    print("\n--- 2/3  Club data ---")
+    do_reset = False
+    # The default groups and membership types are seeded on every install and
+    # would otherwise make a fresh database look like it holds club data. What
+    # makes a reset meaningful is an organization or actual members.
+    configured = (
+        db.query(OrganizationSettings).first() is not None
+        or db.query(Member).count() > 0
+    )
+    if configured and club_data:
+        total = sum(club_data.values())
+        print(f"This instance holds {total} rows of club data:")
+        for name, count in sorted(club_data.items(), key=lambda kv: -kv[1])[:8]:
+            print(f"    {count:>7,}  {name}")
+        if len(club_data) > 8:
+            print(f"    {'':>7}  ... and {len(club_data) - 8} more tables")
+        print(
+            "\nResetting deletes all of it. The super admin accounts, the system\n"
+            "roles and the configured payment providers are kept."
+        )
+        if prompt_yes_no("Reset club data?"):
+            org = db.query(OrganizationSettings).first()
+            expected = org.name if org else None
+            if expected:
+                typed = input(f'Type the organization name to confirm ("{expected}"): ').strip()
+                do_reset = typed == expected
+                if not do_reset:
+                    print("  Name did not match — club data will be kept.")
+            else:
+                do_reset = True
+    else:
+        print("Nothing to reset — this instance holds no club data yet.")
+
+    # --- 3. Club setup ------------------------------------------------------
+    print("\n--- 3/3  Club setup ---")
+    club_details = None
+    want_demo = False
+    org_exists = db.query(OrganizationSettings).first() is not None
+    if org_exists and not do_reset:
+        print("The organization is already configured — leaving it alone.")
+    else:
+        print("  1) Enter your organization's real details")
+        print("  2) Generate a demo club with sample data (evaluation, demos)")
+        print("  3) Skip for now")
+        while True:
+            choice = input("Choose [1/2/3]: ").strip()
+            if choice == "1":
+                club_details = prompt_club_details()
+                break
+            if choice == "2":
+                want_demo = True
+                break
+            if choice == "3":
+                break
+            print("Please choose 1, 2 or 3.")
+
+    # --- act ----------------------------------------------------------------
+    if do_reset:
+        print("\nResetting club data...")
+        deleted = reset_club_data(db)
+        print(f"  Deleted {sum(deleted.values()):,} rows across {len(deleted)} tables")
+        # The reset takes the base data with it; put it back before anything
+        # below tries to attach a member to a membership type.
+        seed_address_types(db)
+        seed_contact_types(db)
+        membership_type = seed_membership_types(db, seed_groups(db))
+        restore_member_records(db, super_admin_users(db), membership_type)
+
+    accounts: list[tuple[str, str, str]] = []
+    if super_details:
+        print("\nCreating super admin...")
+        create_user_with_member(db, super_details, SUPER_ADMIN_SLUG, membership_type)
+        accounts.append(("super admin", super_details["email"], "(the password you chose)"))
+    elif reset_target is not None:
+        set_password(db, reset_target, reset_password)
+        print(f"\n  super admin: password reset ({reset_target.email})")
+        accounts.append(("super admin", reset_target.email, "(the password you chose)"))
+    elif existing_supers:
+        accounts.append(("super admin", existing_supers[0].email, "(unchanged)"))
+
+    if club_details:
+        print("\nCreating organization...")
+        create_org_settings(db, club_details)
+    elif want_demo:
+        print("\nGenerating the demo club...")
+        seed_demo_org_settings(db)
+        from app.cli.demo_data import seed_demo_data
+
+        seed_demo_data(db, membership_type, any_admin_user_id(db))
+        accounts.extend(create_demo_accounts(db, membership_type))
+
+    return accounts
+
+
+def _run_unattended(db, membership_type: MembershipType, args) -> list[tuple[str, str, str]]:
+    if args.reset_club_data:
+        print("\nResetting club data...")
+        deleted = reset_club_data(db)
+        print(f"  Deleted {sum(deleted.values()):,} rows across {len(deleted)} tables")
+        seed_address_types(db)
+        seed_contact_types(db)
+        membership_type = seed_membership_types(db, seed_groups(db))
+        restore_member_records(db, super_admin_users(db), membership_type)
+
+    accounts: list[tuple[str, str, str]] = []
+    if args.admin_email:
+        password = os.environ.get("MEMSHIP_ADMIN_PASSWORD")
+        if not password:
+            print(
+                "\nERROR: --admin-email needs the password in MEMSHIP_ADMIN_PASSWORD.\n"
+                "Passing it as an argument would put it in the shell history and in `ps`.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if len(password) < 8:
+            print("\nERROR: MEMSHIP_ADMIN_PASSWORD must be at least 8 characters.", file=sys.stderr)
+            sys.exit(1)
+
+        existing = db.query(User).filter_by(email=args.admin_email).first()
+        if existing:
+            set_password(db, existing, password)
+            print(f"\n  super admin: password reset ({args.admin_email})")
+        else:
+            print("\nCreating super admin...")
+            create_user_with_member(
+                db,
+                {
+                    "first_name": "Super",
+                    "last_name": "Admin",
+                    "email": args.admin_email,
+                    "password": password,
+                },
+                SUPER_ADMIN_SLUG,
+                membership_type,
+            )
+        accounts.append(("super admin", args.admin_email, "(from MEMSHIP_ADMIN_PASSWORD)"))
+
+    if args.club_name:
+        print("\nCreating organization...")
+        create_org_settings(db, {"name": args.club_name})
+    elif args.demo:
+        print("\nGenerating the demo club...")
+        seed_demo_org_settings(db)
+        from app.cli.demo_data import seed_demo_data
+
+        seed_demo_data(db, membership_type, any_admin_user_id(db))
+        accounts.extend(create_demo_accounts(db, membership_type))
+
+    return accounts
+
+
+def _print_accounts(accounts: list[tuple[str, str, str]], footer: str = "") -> None:
+    if not accounts:
+        return
+    width = max(len(email) for _, email, _ in accounts)
+    print("\n  Accounts:\n")
+    for role, email, password in accounts:
+        print(f"    {role:12s} {email:{width}s}  {password}")
+    if footer:
+        print(f"\n{footer}")
+
+
+# Shown once, because the plaintext exists nowhere else afterwards.
+GENERATED_FOOTER = (
+    "  Generated passwords are shown once — store them now.\n"
+    "  Demo accounts are for evaluation. Do not use them in production."
+)
+
+TEST_FOOTER = (
+    "  Fixed test accounts, published in this repository and shared by every\n"
+    "  developer. Never expose an instance seeded this way."
+)
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.test:
+        guard_test_mode()
+
+    unattended = bool(
+        args.admin_email or args.reset_club_data or args.club_name or args.demo
+    )
+
+    print("\n=== Memship Setup ===\n")
 
     db = SessionLocal()
     try:
-        # Check database connectivity
         db.execute(text("SELECT 1"))
-        print("Database connection: OK\n")
+        print("Database connection: OK")
 
-        print("Seeding lookup tables...")
+        # Base data every installation needs, whatever the answers below.
+        print("\nSeeding lookup tables...")
         seed_address_types(db)
         seed_contact_types(db)
-
-        print("\nSeeding organization...")
-        seed_org_settings(db)
 
         print("\nSeeding groups...")
         groups = seed_groups(db)
@@ -1479,84 +1976,27 @@ def main() -> None:
         membership_type = seed_membership_types(db, groups)
 
         if args.test:
-            # Before the accounts: `assign_roles` resolves by slug, so the
-            # treasurer role has to exist by the time its holder is created.
-            print("\nSeeding custom roles...")
-            seed_narrow_role(db)
-
-            print("\nCreating test accounts...")
-            for account in TEST_ACCOUNTS:
-                create_user_with_member(
-                    db,
-                    account,
-                    account["role"],
-                    membership_type,
-                )
-            # Seed activities (need a user_id for created_by)
-            admin_user = db.query(User).filter_by(email="admin@test.com").first()
-            if admin_user:
-                print("\nSeeding activities...")
-                seed_activities(db, admin_user.id)
-
-            print("\nSeeding extra members...")
-            seed_extra_members(db, membership_type)
-
-            print("\nSeeding member contacts...")
-            seed_member_contacts(db)
-
-            print("\nSeeding registrations...")
-            seed_registrations(db)
-
-            print("\nSeeding discount codes...")
-            seed_discount_codes(db)
-
-            print("\nSeeding activity consents...")
-            seed_consents(db)
-
-            print("\nSeeding attachment types...")
-            seed_attachment_types(db)
-
-            print("\nSeeding registration consents...")
-            seed_registration_consents(db)
-
-            print("\nSeeding billing data...")
-            seed_billing_data(db)
-
-            print("\nSeeding SEPA data...")
-            seed_sepa_data(db)
-
-            print("\n  ⚠  TEST ACCOUNTS — do NOT use in production:")
-            for account in TEST_ACCOUNTS:
-                print(f"     {account['role']:15s} {account['email']:25s} / {account['password']}")
-            print(f"     {'member':15s} {'(+22 extra members)':25s} / TestMember1!")
-        elif args.demo:
-            # Non-interactive admin accounts so there's a login for the demo.
-            print("\nCreating admin accounts...")
-            for account in TEST_ACCOUNTS:
-                if account["role"] in ("super_admin", "admin"):
-                    create_user_with_member(db, account, account["role"], membership_type)
-            admin_user = db.query(User).filter_by(email="admin@test.com").first()
-
-            from app.cli.demo_data import seed_demo_data
-            seed_demo_data(db, membership_type, admin_user.id if admin_user else None)
-
-            print("\n  ⚠  DEMO ACCOUNTS — do NOT use in production:")
-            print(f"     {'admin':15s} {'admin@test.com':25s} / TestAdmin1!")
-            print(f"     {'super_admin':15s} {'super@test.com':25s} / TestSuper1!")
+            seed_demo_org_settings(db)
+            run_test_mode(db, membership_type)
+            accounts = [(a["role"], a["email"], a["password"]) for a in TEST_ACCOUNTS]
+            footer = TEST_FOOTER
         else:
-            # Interactive user creation
-            super_admin = prompt_user_details("Super Admin")
-            create_user_with_member(db, super_admin, "super_admin", membership_type)
-
-            org_admin = prompt_user_details("Organization Admin")
-            create_user_with_member(db, org_admin, "admin", membership_type)
+            if unattended:
+                accounts = _run_unattended(db, membership_type, args)
+            else:
+                accounts = _run_interactive(db, membership_type)
+            footer = GENERATED_FOOTER if any(
+                not password.startswith("(") for _, _, password in accounts
+            ) else ""
 
         db.commit()
-        print("\n=== Seed complete ===\n")
+        print("\n=== Setup complete ===")
+        _print_accounts(accounts, footer)
+        print()
 
     except KeyboardInterrupt:
         db.rollback()
-        print("\n\nSeed cancelled.")
+        print("\n\nCancelled — nothing was changed.")
         sys.exit(1)
     except Exception as e:
         db.rollback()

--- a/backend/app/cli/seed.py
+++ b/backend/app/cli/seed.py
@@ -698,6 +698,13 @@ def seed_extra_members(db, default_membership_type: MembershipType) -> list[Memb
         db.add(user)
         db.flush()
 
+        # Every account holds `member` permanently — permissions come from
+        # user_roles, so without this the account authenticates and then gets
+        # 403 on its own portal. Missed when roles & permissions replaced the
+        # users.role column: the migration backfilled existing rows, but this
+        # seeding path kept creating users with no assignment at all.
+        assign_roles(db, user)
+
         member_number = next_member_number(db)
         status = statuses[i % len(statuses)]
         member = Member(

--- a/backend/tests/integration/test_demo_data.py
+++ b/backend/tests/integration/test_demo_data.py
@@ -10,9 +10,9 @@ from app.cli import demo_data
 from app.cli.seed import (
     seed_address_types,
     seed_contact_types,
+    seed_demo_org_settings,
     seed_groups,
     seed_membership_types,
-    seed_org_settings,
 )
 from app.domains.billing.models import Receipt, SepaMandate
 from app.domains.members.models import Member
@@ -25,7 +25,7 @@ ALL_RECEIPT_STATUSES = {"paid", "emitted", "pending", "overdue", "returned", "ca
 def _base_install(db):
     seed_address_types(db)
     seed_contact_types(db)
-    seed_org_settings(db)
+    seed_demo_org_settings(db)
     groups = seed_groups(db)
     return seed_membership_types(db, groups)
 

--- a/backend/tests/integration/test_seed_reset.py
+++ b/backend/tests/integration/test_seed_reset.py
@@ -1,0 +1,233 @@
+"""Club-data reset and the setup helpers that survive it.
+
+The reset is the one destructive operation in the product, so what it *keeps*
+matters more than what it deletes: the operator's own account, the system roles,
+and the payment provider credentials that live in the database rather than in
+`.env` — the whole reason this exists instead of "delete the postgres volume".
+"""
+
+import pytest
+
+from app.cli import reset as reset_module
+from app.cli.reset import KNOWN_TABLES, preview_club_data, reset_club_data
+from app.cli.seed import (
+    DEMO_ORG,
+    any_admin_user_id,
+    create_org_settings,
+    create_user_with_member,
+    restore_member_records,
+    seed_address_types,
+    seed_contact_types,
+    seed_demo_org_settings,
+    seed_groups,
+    seed_membership_types,
+    seed_narrow_role,
+    super_admin_users,
+)
+from app.db.base import Base
+from app.domains.auth.models import Role, User
+from app.domains.billing.models import PaymentProvider
+from app.domains.members.models import Member
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+
+def _base_install(db):
+    seed_address_types(db)
+    seed_contact_types(db)
+    return seed_membership_types(db, seed_groups(db))
+
+
+def _account(email, role, membership_type, db):
+    create_user_with_member(
+        db,
+        {
+            "first_name": "Test",
+            "last_name": "Person",
+            "email": email,
+            "password": "correct horse battery staple",
+        },
+        role,
+        membership_type,
+    )
+    return db.query(User).filter_by(email=email).one()
+
+
+class TestTableClassification:
+    def test_every_mapped_table_is_known(self):
+        """A model added later must be classified deliberately.
+
+        The failure mode this guards is silent: an unclassified table is cleared
+        by default, so a second credential store would be wiped by a reset the
+        same way deleting the volume wipes it.
+        """
+        unknown = set(Base.metadata.tables) - KNOWN_TABLES
+        assert not unknown, (
+            f"unclassified tables: {sorted(unknown)} — add them to KNOWN_TABLES, "
+            "and to PRESERVED_TABLES/ACCOUNT_SCOPED_PREDICATES if a reset must keep them"
+        )
+
+    def test_preserved_and_account_scoped_tables_exist(self):
+        """Guards against a rename leaving a stale entry that silently stops applying."""
+        live = set(Base.metadata.tables)
+        assert reset_module.PRESERVED_TABLES <= live
+        assert set(reset_module.ACCOUNT_SCOPED_PREDICATES) <= live
+
+
+class TestResetKeeps:
+    def test_super_admin_account_survives(self, db):
+        membership_type = _base_install(db)
+        seed_demo_org_settings(db)
+        keeper = _account("owner@example.org", "super_admin", membership_type, db)
+        _account("club@example.org", "admin", membership_type, db)
+        keeper_person_id = keeper.person_id
+
+        reset_club_data(db)
+
+        remaining = db.query(User).all()
+        assert [u.email for u in remaining] == ["owner@example.org"]
+        assert db.query(Person).filter_by(id=keeper_person_id).one_or_none() is not None
+
+    def test_payment_provider_credentials_survive(self, db):
+        membership_type = _base_install(db)
+        _account("owner@example.org", "super_admin", membership_type, db)
+        db.add(
+            PaymentProvider(
+                provider_type="stripe",
+                display_name="Stripe",
+                status="active",
+                config={"secret_key": "sk_live_kept"},
+            )
+        )
+        db.flush()
+
+        reset_club_data(db)
+
+        provider = db.query(PaymentProvider).one()
+        assert provider.config["secret_key"] == "sk_live_kept"
+
+    def test_system_roles_survive_and_custom_roles_do_not(self, db):
+        membership_type = _base_install(db)
+        _account("owner@example.org", "super_admin", membership_type, db)
+        seed_narrow_role(db)
+        assert db.query(Role).filter_by(slug="treasurer").one_or_none() is not None
+
+        reset_club_data(db)
+
+        slugs = {r.slug for r in db.query(Role).all()}
+        assert {"super_admin", "admin", "member"} <= slugs
+        assert "treasurer" not in slugs
+
+    def test_system_role_permissions_survive(self, db):
+        membership_type = _base_install(db)
+        _account("owner@example.org", "super_admin", membership_type, db)
+        # `admin`, not `super_admin`: the super admin bypasses permission checks
+        # by slug (app/core/authorization.py) and holds no explicit grants.
+        before = len(db.query(Role).filter_by(slug="admin").one().permissions)
+        assert before > 0
+
+        reset_club_data(db)
+
+        after = len(db.query(Role).filter_by(slug="admin").one().permissions)
+        assert after == before
+
+
+class TestResetClears:
+    def test_club_data_and_organization_go(self, db):
+        membership_type = _base_install(db)
+        seed_demo_org_settings(db)
+        _account("owner@example.org", "super_admin", membership_type, db)
+        _account("member@example.org", "member", membership_type, db)
+
+        reset_club_data(db)
+
+        assert db.query(OrganizationSettings).count() == 0
+        # Only the super admin's own record would come back, and only via
+        # restore_member_records — the reset itself leaves none.
+        assert db.query(Member).count() == 0
+
+    def test_preview_matches_what_is_deleted(self, db):
+        membership_type = _base_install(db)
+        seed_demo_org_settings(db)
+        _account("owner@example.org", "super_admin", membership_type, db)
+        _account("member@example.org", "member", membership_type, db)
+
+        predicted = preview_club_data(db)
+        deleted = reset_club_data(db)
+
+        assert predicted == deleted
+
+    def test_reset_is_idempotent(self, db):
+        membership_type = _base_install(db)
+        _account("owner@example.org", "super_admin", membership_type, db)
+
+        reset_club_data(db)
+        second = reset_club_data(db)
+
+        assert second == {}
+
+    def test_survivors_get_their_member_record_back(self, db):
+        membership_type = _base_install(db)
+        keeper = _account("owner@example.org", "super_admin", membership_type, db)
+
+        reset_club_data(db)
+        membership_type = seed_membership_types(db, seed_groups(db))
+        restore_member_records(db, super_admin_users(db), membership_type)
+
+        member = db.query(Member).filter_by(person_id=keeper.person_id).one()
+        assert member.user_id == keeper.id
+        assert member.status == "active"
+
+
+class TestCreatedByResolution:
+    def test_resolves_by_role_not_by_address(self, db):
+        """The `--demo` layer used to look up a literal `admin@test.com`.
+
+        Applied on top of an operator-chosen super admin that returned None
+        silently, and every demo record was stamped with no creator.
+        """
+        membership_type = _base_install(db)
+        owner = _account("owner@example.org", "super_admin", membership_type, db)
+
+        assert db.query(User).filter_by(email="admin@test.com").first() is None
+        assert any_admin_user_id(db) == owner.id
+
+    def test_returns_none_when_no_admin_exists(self, db):
+        _base_install(db)
+        assert any_admin_user_id(db) is None
+
+
+class TestOrganizationDetails:
+    def test_real_club_gets_only_what_was_entered(self, db):
+        """The fake tax ID and IBAN are demo data, not install defaults."""
+        _base_install(db)
+        create_org_settings(db, {"name": "Agrupació Excursionista", "email": "hola@ae.example"})
+
+        org = db.query(OrganizationSettings).one()
+        assert org.name == "Agrupació Excursionista"
+        assert org.email == "hola@ae.example"
+        assert org.tax_id is None
+        assert org.bank_iban is None
+        assert org.legal_name is None
+
+    def test_demo_club_gets_the_full_sample(self, db):
+        _base_install(db)
+        seed_demo_org_settings(db)
+
+        org = db.query(OrganizationSettings).one()
+        assert org.name == DEMO_ORG["name"]
+        assert org.bank_iban == DEMO_ORG["bank_iban"]
+
+    def test_second_call_leaves_the_existing_organization_alone(self, db):
+        _base_install(db)
+        create_org_settings(db, {"name": "First"})
+        create_org_settings(db, {"name": "Second"})
+
+        assert db.query(OrganizationSettings).one().name == "First"
+
+
+class TestUnknownTableGuard:
+    def test_reset_refuses_when_a_table_is_unclassified(self, db, monkeypatch):
+        monkeypatch.setattr(reset_module, "KNOWN_TABLES", frozenset({"users"}))
+        with pytest.raises(RuntimeError, match="does not know what to do"):
+            reset_club_data(db)

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -3,10 +3,13 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/marcandreuf/memship/main/docker-compose.quickstart.yml -o docker-compose.yml
 #   PORT=8081 docker compose up -d
-#   docker compose exec demo-memship-api python -m app.cli.seed --test   # Quick demo with test accounts
-#   docker compose exec demo-memship-api python -m app.cli.seed --demo   # Realistic year of demo data (idempotent)
-#   docker compose exec demo-memship-api python -m app.cli.seed          # Custom setup (interactive)
+#   docker compose exec -it demo-memship-api python -m app.cli.seed
 #   Open http://localhost:8081
+#
+# EVALUATION ONLY. SECRET_KEY below is committed to the repository and the data
+# lives in throwaway Docker volumes. To run memship for a real organization use
+# scripts/install.sh and the root docker-compose.yml — see
+# docs/getting-started/installation.md.
 #
 
 # The API, the Celery worker and Celery beat run the same image with the same

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 #
 # Quick start:
 #   docker compose up -d
-#   docker compose exec api python -m app.cli.seed
+#   docker compose exec -it api python -m app.cli.seed
 #   Open http://localhost
 #
 # To use pre-built images from GHCR instead of building locally,

--- a/docs/getting-started/first-setup.md
+++ b/docs/getting-started/first-setup.md
@@ -1,33 +1,89 @@
 # First-time setup
 
-After [installing](installation.md) Memship and starting the services, you need to create the
-initial accounts and configure your organization. This is done with the **seed** command.
-
-## 1. Create accounts
-
-Run the interactive seed for a real deployment — it prompts you to create your own super admin
-and organization admin, and generates **no** sample data:
+After [installing](installation.md) Memship and starting the services, run the setup command to
+create your account and configure your organization. It is the same command on every
+environment, and it is interactive:
 
 ```bash
 docker compose exec -it api python -m app.cli.seed
 ```
 
-> **Do not use the `--test` / `--demo` seed modes in production.** They create publicly-known
-> credentials and fake data. Those modes are for evaluation only — see the
-> [Quick start](quickstart.md).
+Note the `-it`: the command prompts, so it needs a terminal attached.
 
-### The three roles
+## The three questions
+
+The setup asks three independent questions, so one command covers every situation.
+
+### 1. Super admin
+
+The account that owns the instance. You choose the address and the password — nothing is
+preset, and no credentials for it exist anywhere in this repository.
+
+If a super admin already exists, the setup offers to reset its password instead. That is the
+supported recovery path today; see
+[issue #40](https://github.com/marcandreuf/memship/issues/40) for the standalone command that
+will replace it.
+
+### 2. Club data
+
+Offered only when the instance already holds club data, which on a fresh install it does not.
+Answering *yes* deletes every member, activity, receipt, mandate and the organization itself,
+after showing you the row counts and asking you to type the organization name to confirm.
+
+It **keeps** the super admin accounts, the system roles, and any payment providers you have
+configured. That last one is the reason to use this rather than deleting the database volume:
+provider credentials live in the database, encrypted, not in `.env`, so a volume wipe means
+re-entering every secret.
+
+This is how you turn an instance you evaluated with demo data into the real thing.
+
+### 3. Club setup
+
+Either enter your organization's real details, or generate a demo club.
+
+For a real deployment, choose **1) real details**. Only the name is required; anything you
+leave blank stays blank and can be filled in from **Settings** later. Nothing is invented —
+an instance set up this way starts with no tax ID and no IBAN, rather than plausible-looking
+placeholders you would have to notice and correct.
+
+Choose **2) demo club** only for evaluation or for a demo you are preparing. It generates a
+year of sample data, plus logins for a club admin and two members whose generated passwords
+are printed once at the end of the run.
+
+## The three roles
 
 | Role            | What it can do                                                            |
 |-----------------|---------------------------------------------------------------------------|
-| **Super admin** | Platform-level administration, including payment provider configuration.   |
-| **Org admin**   | Runs the organization day-to-day: members, activities, billing, comms.     |
+| **Super admin** | Owns the instance: roles, credentials, custom fields, payment providers.   |
+| **Club admin**  | Runs the organization day-to-day: members, activities, billing, comms.     |
 | **Member**      | Uses the member portal: profile, activities, payments, card, bookings.     |
 
-## 2. Log in
+Narrower roles — a treasurer who only sees billing, for example — are created by the super
+admin from **Settings → Roles**. See
+[Roles y permisos](../reference/roles-and-permissions.es.md).
 
-Open your Memship URL and sign in as the organization admin you just created. Authentication
-is **email + password**.
+## Unattended setup
+
+For automated deployments, the same three steps take flags instead of prompts. The password is
+read from the environment, never from the command line, where it would land in the shell
+history and in `ps`:
+
+```bash
+MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T api \
+  python -m app.cli.seed --admin-email you@example.org --club-name "Your Club"
+```
+
+| Flag | Effect |
+|------|--------|
+| `--admin-email EMAIL` | Create the super admin, or reset its password if it exists. Requires `MEMSHIP_ADMIN_PASSWORD`. |
+| `--reset-club-data` | Delete all club data. No confirmation prompt — it is the explicit request. |
+| `--club-name NAME` | Create the organization with this name. |
+| `--demo` | Generate the demo club and its sample data instead. |
+
+## Log in
+
+Open your Memship URL and sign in as the super admin you just created. Authentication is
+**email + password**.
 
 ## 3. Configure your organization
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -52,11 +52,14 @@ an hour. Use `--skip-dns-check` only if you know why you are skipping it.
 The script is safe to re-run. It never overwrites an existing `.env`, and re-running is how you
 pick up a new `IMAGE_TAG` later.
 
-Then create the first admin account:
+Then run the setup — it creates your super admin and your organization:
 
 ```bash
-docker compose exec api python -m app.cli.seed
+docker compose exec -it api python -m app.cli.seed
 ```
+
+The `-it` matters: the command prompts. See [First-time setup](first-setup.md) for what it
+asks and for the unattended flags an automated deployment uses instead.
 
 Open your domain (or **http://localhost** if you installed without one).
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -18,50 +18,60 @@ PORT=8081 docker compose up -d
 
 Change `PORT=8081` to any port you prefer (default is `80`).
 
-## 2. Load initial data
+## 2. Run the setup
 
-Pick one of the three seed modes:
-
-**Option A — Quick demo with test accounts (no prompts)**
-
-```bash
-docker compose exec demo-memship-api python -m app.cli.seed --test
-```
-
-Creates pre-configured test accounts plus sample members, activities, and registrations:
-
-| Role        | Email            | Password      |
-|-------------|------------------|---------------|
-| Super Admin | super@test.com   | TestSuper1!   |
-| Org Admin   | admin@test.com   | TestAdmin1!   |
-| Member      | member@test.com  | TestMember1!  |
-
-**Option B — Custom setup (interactive)**
+The same command sets Memship up on every environment. It is interactive, and asks
+three independent questions:
 
 ```bash
-docker compose exec demo-memship-api python -m app.cli.seed
+docker compose exec -it demo-memship-api python -m app.cli.seed
 ```
 
-Prompts you to create your own super admin and org admin. No sample data.
+1. **Super admin** — you choose the address and password. Nothing is preset, and no
+   credentials are published anywhere.
+2. **Club data** — offered only when there is some, so on a fresh install it is a no-op.
+3. **Club setup** — enter your organization's real details, or generate a demo club.
 
-**Option C — Realistic demo dataset**
+Answer **2) demo club** to look around with realistic data: ~60 members across all
+statuses, activities, receipts in every state, SEPA mandates and dashboard reminders.
+Ideal for evaluating the finance dashboard and annual summary. Safe to re-run
+(idempotent).
 
-```bash
-docker compose exec demo-memship-api python -m app.cli.seed --demo
+The demo club also creates logins for a **club admin** and **two members**, with
+generated passwords. They are printed once, at the end of the run:
+
+```
+  Accounts:
+
+    super admin  you@example.org             (the password you chose)
+    club admin   admin@mediterrani.example   4hVqTmXeb9PkscYRt2Nu
+    member       demo0@mediterrani.example   pQ7yKdRfw3TgLmXaB6ns
+    member       demo1@mediterrani.example   Zj5rWnEcx8VbHtPqM4dy
 ```
 
-Creates the admin accounts plus a full year of realistic data — ~60 members across all
-statuses, activities, receipts in every state, SEPA mandates, and dashboard reminders. Ideal
-for evaluating the finance dashboard and annual summary. Safe to re-run (idempotent).
+Keep that output — the passwords are stored only as hashes and cannot be shown again.
 
 ## 3. Open the app
 
-Go to **http://localhost:8081** and log in with your credentials.
+Go to **http://localhost:8081** and log in as the super admin you created.
 
-> **Do not use the test accounts in production.** The quick-start compose file uses insecure
-> default secrets (`SECRET_KEY`, database password) and is for local evaluation only. See
-> [Installation](installation.md) and the [Configuration reference](../self-hosting/configuration.md)
-> before exposing Memship to a network.
+> **The quick-start stack is for evaluation, not for running a club.** Its compose file
+> ships insecure defaults — a `SECRET_KEY` committed to this repository and a fixed database
+> password — and keeps data in throwaway Docker volumes. Follow
+> [Installation](installation.md) and the
+> [Configuration reference](../self-hosting/configuration.md) before putting Memship on a
+> network or entering real member data.
+
+## Moving from evaluation to real use
+
+Do not carry the quick-start stack into production — install it properly with
+[Installation](installation.md), which generates real secrets and puts your data
+somewhere you can back up.
+
+If you only want to clear the demo club out of an instance you are keeping, re-run the
+setup and answer *yes* to the club-data question. It deletes the demo club while keeping
+your super admin, the system roles and any payment providers you configured — see
+[First-time setup](first-setup.md).
 
 ## Stop and clean up
 

--- a/e2e/cypress/e2e/roles/role-crud.cy.ts
+++ b/e2e/cypress/e2e/roles/role-crud.cy.ts
@@ -24,7 +24,10 @@ describe("Roles — authoring", { tags: ["@roles"] }, () => {
 
   it("renders each permission with its description", () => {
     cy.contains("button", "Create role").click();
-    cy.contains("Run bulk billing").should("be.visible");
+    // The catalog outgrew the dialog: `billing.runs.write` now sits below the
+    // fold in a scrollable, position-fixed panel, so it is present but not in
+    // view. Scroll to it rather than assert on where it happens to land.
+    cy.contains("Run bulk billing").scrollIntoView().should("be.visible");
     cy.contains("Generate fees across the whole club at once").should("be.visible");
   });
 

--- a/frontend/app/[locale]/(portal)/layout.tsx
+++ b/frontend/app/[locale]/(portal)/layout.tsx
@@ -71,7 +71,10 @@ export default function PortalLayout({
       <AppSidebar user={user} />
       <SidebarInset>
         <Header />
-        <main className="flex-1 p-4 md:p-6">{children}</main>
+        {/* A div, not a main: SidebarInset is already the <main> landmark, and
+            HTML forbids nesting one inside another. Two of them also made every
+            `cy.get("main")` in the suite ambiguous. */}
+        <div className="flex-1 p-4 md:p-6">{children}</div>
         <AppFooter />
       </SidebarInset>
     </SidebarProvider>

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -200,10 +200,10 @@ case "$ACTION" in
         ;;
     seed)
         if [ "$TARGET" = "test" ]; then
-            echo -e "${BLUE}i${NC} Running seed command with test accounts..."
+            echo -e "${BLUE}i${NC} Running setup with the fixed e2e test accounts..."
             docker compose -f "$BACKEND_COMPOSE" exec -it api python -m app.cli.seed --test
         else
-            echo -e "${BLUE}i${NC} Running seed command (interactive)..."
+            echo -e "${BLUE}i${NC} Running the interactive setup..."
             docker compose -f "$BACKEND_COMPOSE" exec -it api python -m app.cli.seed
         fi
         ;;
@@ -254,8 +254,8 @@ case "$ACTION" in
         echo "  restart [target]  - Restart services"
         echo "  status            - Show status of all services"
         echo "  logs [target]     - View logs (requires specific target)"
-        echo "  seed              - Run database seed command (interactive)"
-        echo "  seed test         - Seed with test accounts (no prompts)"
+        echo "  seed              - Run the interactive setup (same on every environment)"
+        echo "  seed test         - Seed the fixed e2e test accounts (development only)"
         echo "  reset             - Wipe DB, restart backend, and re-seed with test data"
         echo "  test              - Run backend tests"
         echo "  e2e               - Run Cypress E2E tests (headless)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -246,9 +246,10 @@ cat <<EOF
   Config:     $ENV_FILE  (contains your secrets — back it up)
   Address:    ${SITE_NOW:-http://localhost}
 
-  Create the first admin account:
+  Run the setup — it creates your super admin and your organization.
+  It prompts, so keep the -it:
 
-    docker compose exec api python -m app.cli.seed
+    docker compose exec -it api python -m app.cli.seed
 
   Then:  docker compose ps       # check everything is up
          docker compose logs -f  # watch it start


### PR DESCRIPTION
Replaces the three mutually exclusive seed modes with one interactive command
that is the same on every environment, and removes every published credential
from the READMEs and the docs.

## Why

`--test`, `--demo` and interactive were `if/elif/else` branches, so "a real super
admin **plus** sample data" was unreachable, and both non-interactive paths
planted credentials published in this repository's own README — including a
`super_admin` whose password is in the quick-start instructions. That is what
blocks automated staging deploys (#35), and it makes the quick start a liability
for anyone who follows it and then keeps the instance.

## What the setup asks now

```
1/3  Super admin   — create, or reset an existing one's password
2/3  Club data     — wipe it (offered only when there is any)
3/3  Club setup    — your real details, a demo club, or skip
```

Three independent answers cover every situation with one script:

| Situation | Answers |
|---|---|
| Going live for real | yes / yes / real details |
| Fresh production install | yes / no / real details |
| Evaluating the product | yes / no / demo club |
| Re-demoing before a client call | no / yes / demo club |

The demo club creates a club admin and two member logins with generated
passwords, printed once and stored only as argon2 hashes.

Questions are gathered before anything is written, and `main` commits once at the
end, so Ctrl-C at any prompt leaves the instance untouched.

### Unattended

The same three steps take flags, for automated deployments. The password comes
from the environment, never from argv, where it would land in shell history and
`ps`:

```bash
MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T api \
  python -m app.cli.seed --admin-email you@example.org --club-name "Your Club"
```

## Three defects this exposed

**Every real client inherited the sample club.** `seed_org_settings()` ran before
the mode branch, so an interactive production install got the organization name
`Club Esportiu Mediterrani`, tax ID `B12345678` and IBAN `ES9121000418450200051332`
— plausible enough to survive unnoticed. Club creation now belongs to the demo
layer; a real install prompts and leaves blank whatever the operator leaves blank.

**`created_by` was resolved by literal address.** The `--demo` branch looked up
`admin@test.com`; layered onto an operator-chosen admin it returned `None`
silently and stamped every demo record with no creator. Now resolved by role.

**`next_member_number()` collided.** It took the highest member id and parsed its
number; with the demo cohort's `D-` namespace present it failed to parse,
restarted at `M-0001` and violated the unique constraint against the account
already holding it. Found by running the command, not by reading it — it only
fires the first time a demo club and a real super admin coexist, which is exactly
what this PR makes possible.

## Club-data reset

New `backend/app/cli/reset.py`. Keeps the super admin accounts, the system roles
and the configured payment providers; clears everything else.

Deleting the database volume is not a substitute: provider credentials live in
`payment_providers.config`, encrypted, not in `.env`, so a volume wipe means
re-entering every secret configured during evaluation.

Table classification is checked against SQLAlchemy's metadata before anything is
deleted, so a model added later fails loudly instead of being silently wiped or
silently left behind. Deletes run in dependency order rather than
`TRUNCATE ... CASCADE`, which would follow the references back into `users` and
take the operator with it.

## `--test` and the e2e suite

`e2e/cypress` hard-codes the test credentials across 41 references, so they are a
contract with the test suite rather than a seeding choice. `--test` keeps them
exactly, but is now hidden from `--help`, absent from every user-facing document,
and exits 1 unless `APP_ENV=development` or `CI` is set.

## Verification

- 1131 backend tests pass, including 16 new ones covering reset preservation,
  preview/delete agreement, idempotence, and the unknown-table guard.
- Exercised end to end against a real stack: fresh install → demo club → all four
  generated logins return 200; reset → demo data gone, the planted provider
  secret intact, super admin still logs in; unattended install; `--test` with all
  five e2e accounts returning 200; `--test` correctly refused under
  `APP_ENV=production`.

## Also fixes the e2e suite, which was red on `main`

The suite was at **186/196** before this branch — confirmed pre-existing by
stashing it and re-running the same specs on `main` from a fresh seed (identical
failures both times). It is now **196/196 with no retries**, and 12m33s instead
of 17m07s, because every failure was a 10s timeout. Three separate causes:

**22 of the 26 seeded accounts held no role at all — 8 of the 10 failures.**
`seed_extra_members` created `User` rows and never called `assign_roles`, so
everyone outside the four `TEST_ACCOUNTS` authenticated normally and then got
403 on every request:

```
nuria@test.com   403  {"code":"forbidden","required":"self.activities.read"}
member@test.com  200  20 activities
```

Missed when roles & permissions replaced the `users.role` column in v1.4.0 — the
migration backfilled existing rows, but this path kept minting users with no
assignment. Seeding only: `auth/service.py:96` (registration) and
`oauth_service.py:107` (SSO) were already correct, so real users were never
affected. `eligibility-rules` goes from 2/9 to 9/9, and from 4m06s to 17s.

**Every portal page rendered two nested `<main>` elements — 1 failure.** A real
defect the test caught: `SidebarInset` is a `<main>` and the portal layout nested
another inside it. HTML forbids that, and it gives every page a broken landmark
structure for anyone navigating by landmark.

**The permission catalog outgrew its dialog — 1 failure.** `billing.runs.write`
now sits below the fold of a scrollable panel; the spec scrolls to it.

The suite runs locally on demand by design rather than in CI, so these were only
ever going to surface when someone ran it — which is what happened here.

Refs #40


