### PR TITLE
Build every service on every main commit, and refuse to release without an RC

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -6,6 +6,20 @@
 # PROMOTES the exact RC image for the validated commit to `:X.Y.Z` + `:latest`
 # (see release.yml) — build once, promote, so staging and prod ship identical bytes.
 #
+# EVERY service is built on EVERY main commit, deliberately. This used to filter
+# by changed path, which left a commit touching only `backend/**` with no frontend
+# RC — and release.yml then fell back to rebuilding the frontend from the tag, so
+# what shipped was not what staging validated. Confirmed on v2.0.0: the backend
+# was promoted, the frontend was rebuilt.
+#
+# Retagging the unchanged service's `:main` image under the new sha would be
+# cheaper, but it is only correct if that service really is unchanged since the
+# image `:main` points at. The filter compared `HEAD~1..HEAD`, which sees one
+# commit — so a push of several commits could retag stale bytes under a fresh sha
+# and ship the wrong frontend silently. Building both is correct by construction,
+# the jobs run in parallel so it costs a couple of minutes of wall clock, and
+# Actions minutes are free on a public repository.
+#
 name: Build Images
 
 on:
@@ -21,23 +35,15 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  changes:
+  resolve:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
       sha: ${{ steps.sha.outputs.sha }}
       short_sha: ${{ steps.sha.outputs.short_sha }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 2
-
       - name: Resolve commit SHA
         id: sha
         run: |
@@ -45,32 +51,8 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHA:0:12}" >> "$GITHUB_OUTPUT"
 
-      - name: Detect changed images
-        id: filter
-        run: |
-          # Manual dispatch rebuilds both RC images.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-            echo "frontend=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          CHANGED="$(git diff --name-only HEAD~1 HEAD)"
-          echo "Changed files:"
-          echo "$CHANGED"
-
-          backend=false
-          frontend=false
-          if echo "$CHANGED" | grep -qE '^backend/'; then backend=true; fi
-          if echo "$CHANGED" | grep -qE '^frontend/'; then frontend=true; fi
-
-          echo "backend=$backend" >> "$GITHUB_OUTPUT"
-          echo "frontend=$frontend" >> "$GITHUB_OUTPUT"
-          echo "Build backend: $backend | Build frontend: $frontend"
-
   build-backend:
-    needs: changes
-    if: ${{ needs.changes.outputs.backend == 'true' }}
+    needs: resolve
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,7 +61,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.changes.outputs.sha }}
+          ref: ${{ needs.resolve.outputs.sha }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -91,11 +73,14 @@ jobs:
       - name: Build and push backend RC
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/memship-backend
-          SHORT_SHA: ${{ needs.changes.outputs.short_sha }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+          SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
         run: |
           cd backend
           docker build -f docker/Dockerfile \
             --build-arg APP_VERSION=sha-$SHORT_SHA \
+            --label org.opencontainers.image.revision=$SHA \
+            --label org.opencontainers.image.source=https://github.com/${{ github.repository }} \
             -t $IMAGE:sha-$SHORT_SHA \
             -t $IMAGE:main \
             .
@@ -103,8 +88,7 @@ jobs:
           docker push $IMAGE:main
 
   build-frontend:
-    needs: changes
-    if: ${{ needs.changes.outputs.frontend == 'true' }}
+    needs: resolve
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -113,7 +97,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.changes.outputs.sha }}
+          ref: ${{ needs.resolve.outputs.sha }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -125,34 +109,55 @@ jobs:
       - name: Build and push frontend RC
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/memship-frontend
-          SHORT_SHA: ${{ needs.changes.outputs.short_sha }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+          SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
         run: |
           cd frontend
           docker build -f docker/Dockerfile \
+            --label org.opencontainers.image.revision=$SHA \
+            --label org.opencontainers.image.source=https://github.com/${{ github.repository }} \
             -t $IMAGE:sha-$SHORT_SHA \
             -t $IMAGE:main \
             .
           docker push $IMAGE:sha-$SHORT_SHA
           docker push $IMAGE:main
 
+  # A release can only promote what exists, so an incomplete RC set is a failure,
+  # not a footnote — release.yml refuses to rebuild and would stop dead.
   summary:
-    needs: [changes, build-backend, build-frontend]
-    if: ${{ always() && (needs.build-backend.result == 'success' || needs.build-frontend.result == 'success') }}
+    needs: [resolve, build-backend, build-frontend]
+    if: ${{ always() && needs.resolve.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: RC summary
+        env:
+          OWNER: ${{ github.repository_owner }}
+          SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
+          BACKEND: ${{ needs.build-backend.result }}
+          FRONTEND: ${{ needs.build-frontend.result }}
         run: |
-          echo "### Release-candidate images (deploy to staging)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Commit: \`${{ needs.changes.outputs.short_sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ needs.build-backend.result }}" == "success" ]]; then
-            echo "- backend: \`ghcr.io/${{ github.repository_owner }}/memship-backend:sha-${{ needs.changes.outputs.short_sha }}\` (also \`:main\`)" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Release-candidate images (deploy to staging)"
+            echo ""
+            echo "Commit: \`$SHORT_SHA\`"
+            echo ""
+            echo "| Service | Result | Tag |"
+            echo "|---|---|---|"
+            echo "| backend | $BACKEND | \`ghcr.io/$OWNER/memship-backend:sha-$SHORT_SHA\` |"
+            echo "| frontend | $FRONTEND | \`ghcr.io/$OWNER/memship-frontend:sha-$SHORT_SHA\` |"
+            echo ""
+          } >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$BACKEND" != "success" || "$FRONTEND" != "success" ]]; then
+            {
+              echo "**This commit has an incomplete RC set and cannot be released.**"
+              echo ""
+              echo "Re-run this workflow (Actions → Build Images → Run workflow) once the"
+              echo "failure is fixed, then release."
+            } >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
-          if [[ "${{ needs.build-frontend.result }}" == "success" ]]; then
-            echo "- frontend: \`ghcr.io/${{ github.repository_owner }}/memship-frontend:sha-${{ needs.changes.outputs.short_sha }}\` (also \`:main\`)" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
+
           echo "Release with: \`./scripts/release.sh <version>\` on the validated commit." >> $GITHUB_STEP_SUMMARY
 
   ci-failed:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,22 +2,27 @@
 # Runs backend tests and frontend checks on push to main and PRs.
 # Each suite only runs when its own paths changed (see the `changes` job).
 #
+# The workflow itself runs on EVERY push and PR, with the path filtering done per
+# job rather than at the trigger. Two reasons:
+#
+#   - build-images.yml keys off this workflow completing on main. Filtering at the
+#     trigger meant a commit touching only docs never ran CI, so it never got RC
+#     images either — and release.yml refuses to release a commit without them.
+#     That would leave a docs-only commit at the tip of main unreleasable.
+#   - A PR that changes neither backend nor frontend used to report no checks at
+#     all, which is indistinguishable from checks that have not started yet.
+#
+# The cost is the `changes` job on runs that then skip everything else.
+#
 name: CI
 
 on:
   push:
     branches:
       - main
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - '.github/workflows/ci.yml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,17 @@
 # Triggered by pushing an annotated git tag `vX.Y.Z` (git tags are the single source
 # of truth for the version — there is no VERSION file). This PROMOTES the RC image
 # already built for the tagged commit (build-images.yml) to `:X.Y.Z` + `:latest`
-# WITHOUT rebuilding — the exact bytes staging validated. If no RC image exists for
-# the commit (e.g. it was never built on main), it falls back to building from the tag.
+# WITHOUT rebuilding — the exact bytes staging validated.
+#
+# A missing RC image FAILS the release rather than rebuilding from the tag. Rebuilding
+# looks like it worked and quietly breaks the guarantee: what ships is then a fresh
+# build nobody validated, differing from staging by whatever moved in the base image
+# or the dependency tree since. That is what happened to the frontend in v2.0.0.
+# build-images.yml now builds every service on every main commit, so an absent RC
+# means something genuinely went wrong and is worth stopping for.
+#
+# `allow_rebuild` is the escape hatch, for re-promoting a tag old enough that its RC
+# images have been cleaned up.
 #
 # Release a validated commit with: ./scripts/release.sh <version>
 #
@@ -19,6 +28,10 @@ on:
       tag:
         description: 'Existing version tag to (re)promote, e.g. v1.3.0'
         required: true
+      allow_rebuild:
+        description: 'Build from the tag if no RC image exists (breaks build-once-promote)'
+        type: boolean
+        default: false
 
 env:
   REGISTRY: ghcr.io
@@ -75,6 +88,52 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Checked for every service before anything is promoted, so a half-released
+      # version — backend at the new tag, frontend still at the old one — is not
+      # reachable. Operators upgrade by moving one IMAGE_TAG.
+      - name: Check the RC set is complete
+        id: rc
+        env:
+          OWNER: ${{ github.repository_owner }}
+          SHORT_SHA: ${{ steps.sha.outputs.short_sha }}
+        run: |
+          missing=()
+          for svc in backend frontend; do
+            RC="$REGISTRY/$OWNER/memship-$svc:sha-$SHORT_SHA"
+            if docker buildx imagetools inspect "$RC" >/dev/null 2>&1; then
+              echo "found $RC"
+            else
+              echo "MISSING $RC"
+              missing+=("$svc")
+            fi
+          done
+
+          if [ ${#missing[@]} -eq 0 ]; then
+            echo "complete=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "complete=false" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event.inputs.allow_rebuild }}" == "true" ]]; then
+            echo "::warning::No RC image for: ${missing[*]}. Rebuilding from the tag because allow_rebuild was set — the released bytes will not be the ones staging validated."
+            exit 0
+          fi
+
+          echo "::error::No RC image for: ${missing[*]} at commit $SHORT_SHA."
+          {
+            echo "### Release aborted — incomplete RC set"
+            echo ""
+            echo "No release-candidate image for: **${missing[*]}** at \`$SHORT_SHA\`."
+            echo ""
+            echo "A release promotes the images staging validated; it does not build new"
+            echo "ones. Build the missing RC first (Actions → **Build Images** → Run"
+            echo "workflow, on this commit), then re-run this release."
+            echo ""
+            echo "To release anyway, re-run with \`allow_rebuild\` — the published images"
+            echo "will then be a fresh build that nothing has validated."
+          } >> $GITHUB_STEP_SUMMARY
+          exit 1
+
       - name: Promote RC images (build once, promote)
         env:
           OWNER: ${{ github.repository_owner }}
@@ -88,7 +147,7 @@ jobs:
               echo "Promoting $RC -> $IMAGE:$VERSION + :latest (no rebuild)"
               docker buildx imagetools create -t "$IMAGE:$VERSION" -t "$IMAGE:latest" "$RC"
             else
-              echo "::warning::No RC image $RC for this commit — building $svc from the tag instead."
+              echo "::warning::Rebuilding $svc from the tag (allow_rebuild)."
               if [[ "$svc" == "backend" ]]; then
                 docker build -f "$svc/docker/Dockerfile" --build-arg APP_VERSION="$VERSION" \
                   -t "$IMAGE:$VERSION" -t "$IMAGE:latest" "$svc"
@@ -104,8 +163,17 @@ jobs:
       - name: Summary
         env:
           VERSION: ${{ steps.ver.outputs.version }}
+          COMPLETE: ${{ steps.rc.outputs.complete }}
         run: |
-          echo "### Released v$VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository_owner }}/memship-backend:$VERSION\` + \`:latest\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository_owner }}/memship-frontend:$VERSION\` + \`:latest\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Released v$VERSION"
+            echo ""
+            echo "- \`ghcr.io/${{ github.repository_owner }}/memship-backend:$VERSION\` + \`:latest\`"
+            echo "- \`ghcr.io/${{ github.repository_owner }}/memship-frontend:$VERSION\` + \`:latest\`"
+            echo ""
+            if [[ "$COMPLETE" == "true" ]]; then
+              echo "Promoted from the release candidates staging validated — no rebuild."
+            else
+              echo "⚠ Rebuilt from the tag (\`allow_rebuild\`). These are not the bytes staging validated."
+            fi
+          } >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Because features are built in parallel, **the number is claimed at release, not 
 
 The flow is **build once, promote**:
 
-1. A PR merges to `main`. CI runs, then the Build Images workflow pushes **release-candidate images** tagged `sha-<commit>` and `main` to GHCR.
+1. A PR merges to `main`. CI runs, then the Build Images workflow pushes **release-candidate images** tagged `sha-<commit>` and `main` to GHCR. **Every service is built on every commit**, even one it did not touch, so each commit on `main` has a complete RC set and any of them can be released.
 2. The staging environment deploys that RC image and it is validated there.
 3. To release the validated commit, a maintainer tags it and pushes the tag:
 
@@ -132,6 +132,8 @@ The flow is **build once, promote**:
 
    This creates an annotated `v1.3.0` tag and pushes it.
 4. The Release workflow **promotes the exact RC image** for that commit to `:1.3.0` and `:latest` — it does not rebuild, so staging and production ship identical bytes. It also checks that the released version has a row in the README roadmap's **Released** table.
+
+   If an RC image is missing for the tagged commit, the release **fails** instead of building one from the tag. A rebuild would look like it worked while quietly shipping bytes nobody validated, differing from staging by whatever moved in the base image or the dependency tree in the meantime. Build the missing RC first (Actions → **Build Images** → Run workflow on that commit), then re-run the release. `allow_rebuild` overrides this for tags old enough that their RC images have been cleaned up.
 
 The version the running app reports comes from the `APP_VERSION` environment variable (set from the image tag at deploy time); running from source, it falls back to `git describe`.
 


### PR DESCRIPTION
Closes the build-once-promote gap, so the Caddyfile can be baked into an image
without making the problem worse.

## The bug

`build-images.yml` filtered by changed path, so a commit touching only
`backend/**` produced no frontend release candidate. `release.yml` then hit its
fallback and rebuilt the frontend from the tag — which looks like a clean release
while quietly breaking the guarantee `CONTRIBUTING.md` makes. What shipped was a
fresh build nobody validated, differing from staging by whatever moved in the
base image or the dependency tree in between.

Confirmed on **v2.0.0**: the backend was promoted (config digest `c2a1a84efc26`,
identical to `sha-0deab701f0de`); the frontend was rebuilt.

## Why build both rather than retag

Retagging the unchanged service's `:main` image under the new sha is cheaper, and
was the obvious fix. It is only sound if that service really is unchanged *since
the image `:main` points at* — and the filter compared `HEAD~1..HEAD`, which sees
one commit. A push of several commits could retag stale bytes under a fresh sha
and ship the wrong frontend **with no warning at all**, which is a worse failure
than the one being fixed.

Making the retag safe needs revision labels on every image and a base-sha lookup
before the diff. Building both services is correct by construction, deletes the
filter entirely, and costs a couple of minutes of wall clock — the jobs already
run in parallel, and Actions minutes are free on a public repository.

## Changes

**Build Images**
- Both services build on every main commit; the path filter is gone
- An incomplete RC set fails the workflow instead of being a line in the summary,
  since nothing downstream can use one
- Images carry `org.opencontainers.image.revision` and `.source`, so a running
  container traces back to its commit

**Release**
- A missing RC image **aborts the release** with instructions, rather than
  silently building a substitute
- The check covers every service *before* anything is promoted, so a half-released
  version — backend at the new tag, frontend still at the old one — is
  unreachable. Operators upgrade by moving one `IMAGE_TAG`
- `allow_rebuild` is the explicit escape hatch for re-promoting tags whose RC
  images have been cleaned up; the run summary says plainly when it was used

**CONTRIBUTING.md** — documents the completeness guarantee and the new failure
mode. It already promised "it does not rebuild"; that is now true.

## Verification

Workflow YAML parses and the job graph resolves. The RC-completeness check is
pure bash, so I ran its logic against a stubbed `docker` across all four cases —
including the empty-array edge under `bash -e`, where GitHub Actions runs
`run:` steps:

| Case | Exit | Output |
|---|---|---|
| both present | 0 | `complete=true` |
| frontend missing | 1 | `complete=false`, `::error::No RC image for: frontend` |
| frontend missing + `allow_rebuild` | 0 | `complete=false`, warning |
| both missing | 1 | `complete=false`, `::error::No RC image for: backend frontend` |

The end-to-end behaviour can only really be confirmed on the next merge to
`main`, when both images should build for a commit that touches one side.

## Follow-up commit: CI now runs on every push and PR

Opening this PR surfaced a defect in the change itself — it reported **no checks
at all**, because `ci.yml` only triggered on paths under `backend/**` or
`frontend/**`.

That became load-bearing with this PR. `build-images.yml` keys off CI completing
on `main`, so a commit touching only docs never ran CI and never got RC images —
and `release.yml` now refuses to release a commit without them. **A docs-only
commit at the tip of `main` would have been unreleasable.** The silent rebuild
was covering that up until now.

The trigger-level `paths:` filters are gone; the per-job filters already skip the
real work. `changes` still runs unconditionally, so the workflow concludes
`success` rather than `skipped` — which is what `build-images.yml` requires to
fire at all. Cost is one trivial job on runs that skip everything else, and
docs-only PRs now report checks instead of nothing.

