### PR TITLE
Fix the install guide's first two commands, which could not work

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,6 +7,8 @@ This guide covers a **production** self-hosted install. For a quick local evalua
 
 - A server running Docker Engine and the Compose plugin
 - An ordinary (non-root) user in the `docker` group — the stack is not installed as root
+- `git`, to clone this repository. Minimal server images often ship without it:
+  `sudo apt-get update && sudo apt-get install -y git`
 - A domain name, with a DNS A record already pointing at the server, if you want automatic HTTPS
 
 ### Starting from a bare server
@@ -14,10 +16,20 @@ This guide covers a **production** self-hosted install. For a quick local evalua
 `scripts/vps-bootstrap.sh` does the root half of the preparation. Run it **once, as root**, on a
 fresh Debian 12 or Ubuntu 24.04 box:
 
+Clone it somewhere you can already write — your own home directory. The final checkout lives
+under `/srv`, but nothing can write there until the bootstrap has run:
+
 ```bash
-git clone https://github.com/marcandreuf/memship.git /srv/openmemship/app
-sudo /srv/openmemship/app/scripts/vps-bootstrap.sh --ssh-key-file ~/id_ed25519.pub
+git clone https://github.com/marcandreuf/memship.git ~/memship-bootstrap
+sudo ~/memship-bootstrap/scripts/vps-bootstrap.sh --user deploy --ssh-key-file ~/.ssh/authorized_keys
 ```
+
+`--user` names the account that will own the install; pass the account you are already logged in
+as (`--user "$USER"`) to use it instead of creating a separate `deploy`. `--ssh-key-file` takes a
+file containing an SSH **public** key — your own `~/.ssh/authorized_keys` is the reliable choice,
+since a fresh server has no `.pub` file lying around. Without a key you cannot log in as the new
+user. Note that `~` expands to **root's** home under `sudo`, so give an absolute path if you are
+not root.
 
 It creates the deploy user, installs Docker from Docker's own repository, enables
 `unattended-upgrades`, `fail2ban` and `ufw`, sets the timezone, and adds a weekly image prune.
@@ -34,12 +46,18 @@ Log out and back in afterwards, so the deploy user's `docker` group membership t
 
 ## Install
 
-As the deploy user — **not** as root:
+As the deploy user — **not** as root. `/srv` belongs to root, so create the install directory and
+hand it to yourself before cloning into it; `install.sh` writes `.env` inside the checkout and
+needs to own it:
 
 ```bash
+sudo install -d -o "$USER" -g "$USER" /srv/openmemship
+git clone https://github.com/marcandreuf/memship.git /srv/openmemship/app
 cd /srv/openmemship/app
 ./scripts/install.sh --data-root /srv/openmemship/data --domain memship.example.com
 ```
+
+The bootstrap clone in your home directory has done its job now and can be deleted.
 
 That creates the data root, generates real secrets into `.env` (mode 600), pulls the published
 images and starts the stack.
@@ -51,6 +69,14 @@ an hour. Use `--skip-dns-check` only if you know why you are skipping it.
 
 The script is safe to re-run. It never overwrites an existing `.env`, and re-running is how you
 pick up a new `IMAGE_TAG` later.
+
+> **Reinstalling from scratch burns certificates.** The issued certificate lives in
+> `<data-root>/caddy/data`. Delete that directory — as a full teardown does — and the next start
+> requests a **new** certificate rather than renewing the old one. Let's Encrypt allows **5
+> certificates per week for the same set of hostnames**, so a handful of from-scratch reinstalls
+> against one domain will exhaust it and leave you without HTTPS until the window rolls forward.
+> When rehearsing an install, omit `--domain` and run on plain HTTP, then add the domain on the
+> final pass. Preserving `caddy/data` across a rebuild avoids the reissue entirely.
 
 Then run the setup — it creates your super admin and your organization:
 
@@ -157,9 +183,12 @@ The default Compose stack runs behind a Caddy reverse proxy:
 | API Direct | `http://localhost:8003`          | Backend API (direct)      |
 
 > **`ufw` does not constrain Docker.** Docker inserts its own iptables rules ahead of the
-> firewall's, so a port published with `ports:` stays reachable from the internet even while `ufw`
-> denies it — including the API on 8003 and Postgres on 5433. Verify from another machine with
-> `nmap -Pn -p 22,80,443,5433,8003 <your-host>` rather than trusting the firewall rules.
+> firewall's, so a port published to all interfaces stays reachable from the internet even while
+> `ufw` denies it. The shipped stack therefore publishes the API (8003) and Postgres (5433) on
+> **`127.0.0.1` only**, which is why they are reachable from the server itself and nowhere else.
+> Setting `API_BIND` or `DB_BIND` to `0.0.0.0` — or adding your own `ports:` entry — puts that
+> service on the public internet regardless of your firewall rules. Verify from another machine
+> with `nmap -Pn -p 22,80,443,5433,8003 <your-host>` rather than trusting `ufw status`.
 
 ## Next steps
 

--- a/scripts/vps-bootstrap.sh
+++ b/scripts/vps-bootstrap.sh
@@ -108,7 +108,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 step "Updating the package index"
 apt-get update -qq
-apt-get install -y -qq ca-certificates curl gnupg >/dev/null
+apt-get install -y -qq ca-certificates curl gnupg git >/dev/null
 
 # ---------------------------------------------------------------- deploy user
 
@@ -351,6 +351,7 @@ cat <<EOF
   2. INSTALL MEMSHIP as $DEPLOY_USER — not as root:
 
        su - $DEPLOY_USER          # or log in again over SSH, so the docker group applies
+       sudo install -d -o $DEPLOY_USER -g $DEPLOY_USER /srv/openmemship
        git clone https://github.com/marcandreuf/memship.git /srv/openmemship/app
        cd /srv/openmemship/app
        ./scripts/install.sh --data-root /srv/openmemship/data --domain <your-domain>


### PR DESCRIPTION
Found while preparing a from-scratch staging rebuild driven by the install docs. All three defects were **confirmed on a bare Ubuntu 24.04 host**, not inferred.

### 1. The first command fails for every non-root user

`/srv` is `root:root drwxr-xr-x`, so the guide's opening line:

```
git clone https://github.com/marcandreuf/memship.git /srv/openmemship/app
→ fatal: could not create leading directories of '/srv/openmemship/app': Permission denied
```

The guide and `vps-bootstrap.sh`'s closing text also disagreed on ordering — clone *before* the bootstrap (guide) vs *after* it as the deploy user (script). Neither worked, since neither created the directory. Now: clone into the operator's home so the bootstrap can run, then `sudo install -d -o "$USER" -g "$USER" /srv/openmemship` before the real clone. `install.sh` writes `.env` **inside** the checkout, so ownership is load-bearing.

### 2. `--ssh-key-file ~/id_ed25519.pub`

That file does not exist on a fresh server, and `~` under `sudo` is root's home. Now points at `~/.ssh/authorized_keys`, with the expansion trap called out and `--user` explained.

### 3. The firewall warning described an exposure that v2.0.0 fixed

It claimed the API (8003) and Postgres (5433) stay reachable from the internet. `docker-compose.yml:82,184` bind both to `127.0.0.1` by default. Rewritten to explain the default and name what re-opens it (`API_BIND`/`DB_BIND=0.0.0.0`, or your own `ports:`).

### Also

- Documents the Let's Encrypt **5 certificates per week per hostname set** limit. Deleting `caddy/data` forces a reissue rather than a renewal, so repeated from-scratch installs against one domain exhaust it.
- Adds `git` to the bootstrap's package list — the next thing it prints is a `git clone`, and minimal images ship without it.

Verified: `bash -n` clean, and both the failing and corrected sequences were run on the staging host, which was returned to its bare state afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfDcZ5j7ViW8rPWg5W85XM