### PR TITLE
Make the super admin's password recoverable only from the host

### DIFF
--- a/backend/app/cli/seed.py
+++ b/backend/app/cli/seed.py
@@ -38,6 +38,7 @@ from sqlalchemy import text
 from app.cli.reset import preview_club_data, reset_club_data
 from app.core.permissions import ADMIN_SLUG, SUPER_ADMIN_SLUG
 from app.db.session import SessionLocal
+from app.domains.audit.models import AuditLog
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Address, AddressType, Contact, ContactType, Person
 from app.domains.auth.models import Role, RolePermission, User
@@ -1599,7 +1600,27 @@ def restore_member_records(db, users: list[User], membership_type: MembershipTyp
 
 
 def set_password(db, user: User, password: str) -> None:
+    """Replace a password, and record that it happened.
+
+    The audit row is the only trace this leaves. A reset run from the host is
+    indistinguishable afterwards from the password the account was created with,
+    so without it the log shows an account whose credentials silently changed.
+    `user_id` stays NULL because there is no logged-in actor — whoever ran this
+    had shell access to the machine, which the audit log has no way to name.
+    """
     user.password_hash = ph.hash(password)
+    db.flush()
+    db.add(
+        AuditLog(
+            table_name="users",
+            record_id=user.id,
+            action="update",
+            user_id=None,
+            changed_fields=["password_hash"],
+            # Provenance, in the absence of a request to attribute this to.
+            user_agent="app.cli.seed",
+        )
+    )
     db.flush()
 
 
@@ -1769,11 +1790,18 @@ def _run_interactive(db, membership_type: MembershipType) -> list[tuple[str, str
         listed = ", ".join(u.email for u in existing_supers)
         print(f"This instance already has a super admin: {listed}")
         if prompt_yes_no("Reset the password for one of them?"):
-            email = input("Which address? ").strip()
-            reset_target = next((u for u in existing_supers if u.email == email), None)
-            if reset_target is None:
-                print(f"  No super admin with address {email!r} — skipping.")
-            else:
+            # This is the recovery path for an operator who is locked out, so a
+            # typo asks again rather than dropping them back to a prompt that
+            # looks like it worked. Blank backs out.
+            while reset_target is None:
+                email = input("Which address? (blank to skip) ").strip()
+                if not email:
+                    print("  Skipping the password reset.")
+                    break
+                reset_target = next((u for u in existing_supers if u.email == email), None)
+                if reset_target is None:
+                    print(f"  No super admin with address {email!r}. Try again.")
+            if reset_target is not None:
                 reset_password = prompt_password("New password")
     else:
         print("No super admin exists yet. This is the account that owns the")
@@ -1901,6 +1929,19 @@ def _run_unattended(db, membership_type: MembershipType, args) -> list[tuple[str
 
         existing = db.query(User).filter_by(email=args.admin_email).first()
         if existing:
+            # An address already in use by an ordinary account is not a super
+            # admin to recover — it is somebody else. Resetting it here would
+            # hand out their password while reporting a super admin reset, and
+            # would not grant the role either, so the flag would silently do
+            # neither of the two things it looks like it does.
+            if not any(r.slug == SUPER_ADMIN_SLUG for r in existing.roles):
+                print(
+                    f"\nERROR: {args.admin_email} already belongs to an account that is not a\n"
+                    "super admin. Refusing to reset it — pass an address that is a super admin,\n"
+                    "or promote this account from Settings > Users while signed in as one.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             set_password(db, existing, password)
             print(f"\n  super admin: password reset ({args.admin_email})")
         else:

--- a/backend/app/domains/auth/service.py
+++ b/backend/app/domains/auth/service.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
+from app.core.permissions import SUPER_ADMIN_SLUG
 from app.core.security.password import hash_password, verify_password
 from app.domains.auth.models import User
 from app.domains.auth.roles import assign_roles
@@ -170,9 +171,26 @@ def resend_verification(db: Session, email: str) -> tuple[User, str] | None:
     return user, token
 
 
+def is_super_admin(user: User) -> bool:
+    return any(role.slug == SUPER_ADMIN_SLUG for role in user.roles)
+
+
 def request_password_reset(db: Session, email: str) -> str | None:
+    """Issue a reset token, or ``None`` when this address cannot use the flow.
+
+    Super admins are excluded. The account holds ``RESERVED_KEYS`` — roles and
+    credentials — so letting an email inbox stand in for it makes mailbox access
+    equivalent to owning the instance. Their password is reset from the host
+    instead, with `python -m app.cli.seed`, which needs shell access to the
+    machine running the containers. That also keeps recovery working on an
+    install where SMTP was never configured, which is every install on day one.
+    """
     user = db.query(User).filter(User.email == email, User.is_active == True).first()
     if not user:
+        return None
+    if is_super_admin(user):
+        # Same `None` as an unknown address, so the endpoint's generic response
+        # stays generic and the flow does not disclose who the super admins are.
         return None
 
     token = secrets.token_urlsafe(32)
@@ -193,6 +211,12 @@ def reset_password(db: Session, token: str, new_password: str) -> bool:
         .first()
     )
     if not user:
+        return False
+
+    # No token is ever issued for a super admin now, but one issued before that
+    # rule existed would still be live and inside its hour. Refusing here means
+    # the rule holds for tokens already in flight, not just future ones.
+    if is_super_admin(user):
         return False
 
     if (

--- a/backend/tests/integration/api/v1/test_auth.py
+++ b/backend/tests/integration/api/v1/test_auth.py
@@ -213,6 +213,38 @@ class TestPasswordReset:
         # Should not reveal whether email exists
         assert response.json()["reset_token"] is None
 
+    def test_super_admin_cannot_request_a_reset(self, client, db):
+        """Email must not stand in for the account that owns the instance.
+
+        The response has to be the same one an unknown address gets, or the
+        endpoint turns into a way to ask which accounts are super admins.
+        """
+        _create_test_user(db, email="owner@test.com", role="super_admin")
+
+        response = client.post(
+            "/api/v1/auth/password-reset-request",
+            json={"email": "owner@test.com"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["reset_token"] is None
+
+    def test_super_admin_token_issued_before_the_rule_is_refused(self, client, db):
+        """A token already in flight when this shipped must stop working too."""
+        from datetime import datetime, timedelta, timezone
+
+        user = _create_test_user(db, email="owner2@test.com", role="super_admin")
+        user.reset_token = "still-inside-its-hour"
+        user.reset_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        db.flush()
+
+        response = client.post(
+            "/api/v1/auth/password-reset",
+            json={"token": "still-inside-its-hour", "new_password": "newpassword1"},
+        )
+
+        assert response.status_code == 400
+
 
 class TestLogout:
     def test_logout(self, client):

--- a/backend/tests/integration/test_seed_reset.py
+++ b/backend/tests/integration/test_seed_reset.py
@@ -6,12 +6,15 @@ and the payment provider credentials that live in the database rather than in
 `.env` — the whole reason this exists instead of "delete the postgres volume".
 """
 
+import argparse
+
 import pytest
 
 from app.cli import reset as reset_module
 from app.cli.reset import KNOWN_TABLES, preview_club_data, reset_club_data
 from app.cli.seed import (
     DEMO_ORG,
+    _run_unattended,
     any_admin_user_id,
     create_org_settings,
     create_user_with_member,
@@ -22,9 +25,12 @@ from app.cli.seed import (
     seed_groups,
     seed_membership_types,
     seed_narrow_role,
+    set_password,
     super_admin_users,
 )
+from app.core.permissions import MEMBER_SLUG, SUPER_ADMIN_SLUG
 from app.db.base import Base
+from app.domains.audit.models import AuditLog
 from app.domains.auth.models import Role, User
 from app.domains.billing.models import PaymentProvider
 from app.domains.members.models import Member
@@ -36,6 +42,12 @@ def _base_install(db):
     seed_address_types(db)
     seed_contact_types(db)
     return seed_membership_types(db, seed_groups(db))
+
+
+def _args(**overrides):
+    """The parsed flags `_run_unattended` reads, defaulted to off."""
+    defaults = {"reset_club_data": False, "admin_email": None, "club_name": None, "demo": False}
+    return argparse.Namespace(**{**defaults, **overrides})
 
 
 def _account(email, role, membership_type, db):
@@ -224,6 +236,60 @@ class TestOrganizationDetails:
         create_org_settings(db, {"name": "Second"})
 
         assert db.query(OrganizationSettings).one().name == "First"
+
+
+class TestPasswordRecovery:
+    """The host-side recovery path — the only one a super admin has.
+
+    The web flow refuses them (see `domains/auth/service.request_password_reset`),
+    so these are not a convenience: they are how an operator gets back into an
+    instance whose SMTP was never configured.
+    """
+
+    def test_reset_is_recorded_in_the_audit_log(self, db):
+        membership_type = _base_install(db)
+        user = _account("owner@test.com", SUPER_ADMIN_SLUG, membership_type, db)
+
+        set_password(db, user, "a whole new password")
+
+        entry = (
+            db.query(AuditLog)
+            .filter(AuditLog.table_name == "users", AuditLog.record_id == user.id)
+            .one()
+        )
+        assert entry.action == "update"
+        assert entry.changed_fields == ["password_hash"]
+        # Nobody was signed in — the actor was whoever holds shell on the host.
+        assert entry.user_id is None
+        assert entry.user_agent == "app.cli.seed"
+
+    def test_unattended_resets_a_super_admin(self, db, monkeypatch):
+        membership_type = _base_install(db)
+        user = _account("owner@test.com", SUPER_ADMIN_SLUG, membership_type, db)
+        before = user.password_hash
+        monkeypatch.setenv("MEMSHIP_ADMIN_PASSWORD", "a whole new password")
+
+        _run_unattended(db, membership_type, _args(admin_email="owner@test.com"))
+
+        assert user.password_hash != before
+
+    def test_unattended_refuses_an_address_that_is_not_a_super_admin(self, db, monkeypatch):
+        """The flag would otherwise reset a stranger and report a super admin.
+
+        `--admin-email` on an ordinary member's address used to reset that
+        member's password, print "super admin: password reset", and not grant
+        the role — handing out somebody else's credentials while doing neither
+        of the two things the output claimed.
+        """
+        membership_type = _base_install(db)
+        member = _account("member@test.com", MEMBER_SLUG, membership_type, db)
+        before = member.password_hash
+        monkeypatch.setenv("MEMSHIP_ADMIN_PASSWORD", "a whole new password")
+
+        with pytest.raises(SystemExit):
+            _run_unattended(db, membership_type, _args(admin_email="member@test.com"))
+
+        assert member.password_hash == before
 
 
 class TestUnknownTableGuard:

--- a/docs/getting-started/first-setup.md
+++ b/docs/getting-started/first-setup.md
@@ -19,10 +19,8 @@ The setup asks three independent questions, so one command covers every situatio
 The account that owns the instance. You choose the address and the password — nothing is
 preset, and no credentials for it exist anywhere in this repository.
 
-If a super admin already exists, the setup offers to reset its password instead. That is the
-supported recovery path today; see
-[issue #40](https://github.com/marcandreuf/memship/issues/40) for the standalone command that
-will replace it.
+If a super admin already exists, the setup offers to reset its password instead. That is how a
+locked-out operator gets back in — see [Recovering the super admin password](#recovering-the-super-admin-password).
 
 ### 2. Club data
 
@@ -62,6 +60,56 @@ Narrower roles — a treasurer who only sees billing, for example — are create
 admin from **Settings → Roles**. See
 [Roles y permisos](../reference/roles-and-permissions.es.md).
 
+### A second super admin
+
+One super admin is a single point of failure: if that person leaves, the only way back in is
+shell access to the server. Promote a second one early.
+
+A super admin does it from **Settings → Users**: pick the account and tick **Super admin**.
+Only a super admin sees that box enabled — for anyone else it is disabled and labelled as
+super-admin-only, because an account cannot grant a role it does not hold. Memship also
+refuses to remove the last super admin, so you cannot lock the instance out by demoting
+yourself.
+
+The account has to exist first. Today that means the person either signed up themselves
+(when public registration is on) or was created by the setup command — there is no
+admin-side "invite a user" flow yet.
+
+## Recovering the super admin password
+
+**Only from the host, with `python -m app.cli.seed`.** The browser's forgot-password flow
+deliberately refuses super admins: that account holds the roles-and-credentials permissions,
+so allowing an email inbox to reset it would make mailbox access equivalent to owning the
+instance. It also would not work on most installs — a fresh one has no SMTP configured, which
+is exactly when you need recovery.
+
+The request returns the same "if the email exists…" response it gives an unknown address, so
+the login page never reveals which accounts are super admins. Nothing arrives by email.
+
+Instead, on the machine running the containers:
+
+```bash
+docker compose exec -it api python -m app.cli.seed
+```
+
+Answer **yes** to "Reset the password for one of them?", give the address, and type the new
+password twice. Answer *no* to the club-data question and choose **3) Skip for now** for the
+club setup — a reset changes nothing else.
+
+Unattended, for a scripted recovery:
+
+```bash
+MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T api \
+  python -m app.cli.seed --admin-email you@example.org
+```
+
+Every reset is written to the audit log as an update to the account, with no acting user —
+whoever ran it had shell access to the host, which the log cannot name. If you find one you
+did not run, treat it as you would any other unexplained root-level access.
+
+Ordinary members and club admins are unaffected: they use the normal forgot-password flow,
+which needs [email delivery](../self-hosting/email.md) working.
+
 ## Unattended setup
 
 For automated deployments, the same three steps take flags instead of prompts. The password is
@@ -75,7 +123,7 @@ MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T api \
 
 | Flag | Effect |
 |------|--------|
-| `--admin-email EMAIL` | Create the super admin, or reset its password if it exists. Requires `MEMSHIP_ADMIN_PASSWORD`. |
+| `--admin-email EMAIL` | Create the super admin, or reset its password if it exists. Requires `MEMSHIP_ADMIN_PASSWORD`. Refuses an address that already belongs to an account which is *not* a super admin, rather than resetting a stranger's password. |
 | `--reset-club-data` | Delete all club data. No confirmation prompt — it is the explicit request. |
 | `--club-name NAME` | Create the organization with this name. |
 | `--demo` | Generate the demo club and its sample data instead. |
@@ -99,8 +147,9 @@ From the admin panel, go to **Settings** and complete:
 ## 4. Verify email delivery
 
 Welcome emails, password resets, and payment notifications all depend on email being
-configured. Set up [email delivery](../self-hosting/email.md) and send a test (for example, by
-triggering a password reset) before onboarding real members.
+configured. Set up [email delivery](../self-hosting/email.md) and send a test before
+onboarding real members — trigger a password reset from a **member or club admin** account,
+since the flow refuses super admins and would look like a delivery failure.
 
 ## Next steps
 

--- a/docs/self-hosting/email.md
+++ b/docs/self-hosting/email.md
@@ -55,6 +55,11 @@ Trigger a real send to confirm delivery — for example, request a **password re
 login page, or create a member and check the welcome email arrives. Emails are localized
 (ES/CA/EN) based on the recipient's language.
 
+Use a member or club admin account for the reset test. Super admins are excluded from that
+flow by design — their password is reset from the host with `python -m app.cli.seed`, see
+[Recovering the super admin password](../getting-started/first-setup.md#recovering-the-super-admin-password)
+— so testing with one looks like mail that never arrives.
+
 ## Troubleshooting
 
 - **No email at all** — confirm `RESEND_API_KEY` or `SMTP_HOST` is set; if neither is set,


### PR DESCRIPTION
Closes the substance of #40 without adding the standalone CLI it proposed — the recovery path already exists, it was just unsafe in one direction, wrong in another, and undocumented.

## Why not a new command

`python -m app.cli.seed` has reset a super admin's password since #41 (v2.1.0), interactively and unattended, with no SMTP involved. #40 was opened about 2.5 hours before that code was written and was never revisited. A second entry point over the same `set_password` would be one more thing to keep in sync.

## What changes

**The web flow now refuses super admins.** `request_password_reset` returns `None` for them — the same `None` an unknown address gets, so the generic response cannot be turned into a way to ask which accounts are super admins. `reset_password` refuses as well, so a token issued before this and still inside its hour stops working. The account holds `RESERVED_KEYS`; letting an inbox reset it made mailbox access equivalent to owning the instance, and it never worked anyway on an install with no SMTP configured.

**Resets are audited.** `set_password` writes a `users`/`update`/`["password_hash"]` row. `user_id` is NULL on purpose: there is no logged-in actor, only whoever has shell on the host, which the log has no way to name.

**`--admin-email` no longer resets a stranger.** It matched any account with that address, printed `super admin: password reset`, and did not grant the role — so aimed at a member's address it handed out their password while doing neither of the two things the output claimed. It now refuses an address that is not already a super admin.

**A mistyped address re-prompts** instead of skipping with a message that reads like success. Blank backs out.

## Docs

- `first-setup.md` — new **Recovering the super admin password** section (why the web flow refuses, both CLI forms, the audit note), and **A second super admin** covering Settings → Users, the last-super-admin guard, and that the account must exist first.
- Dropped the stale forward reference promising the standalone command from #40.
- Fixed both places advising operators to test SMTP by resetting a super admin's password (`first-setup.md`, `self-hosting/email.md`) — that now looks like mail silently failing.

## Verification

- Full backend suite: **1136 passed** (1131 before; 5 new tests).
- Exercised against the running dev stack rather than only in CI: interactive reset re-prompted after a wrong address, login with the new password succeeded, the audit row came out as expected, and `request_password_reset` returned `None` for the super admin. The dev account was restored to its seeded password afterwards.

## Not in scope

There is no admin-side way to create an account — the only `User(` outside the CLI is public self-registration — so a second super admin has to already have an account before it can be promoted. An invitation flow is planned as separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjR611NnXb5kQFTixxPrB