### PR TITLE
Give celery beat a writable schedule path in the dev stack

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -53,10 +53,16 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 # Storage is normally a bind mount from the host; create it anyway so a bare
 # `docker run` with no mount still starts. The app writes subdirectories here.
+#
+# /var/lib/celery holds celery beat's schedule database. It has to exist in the
+# image, owned by the runtime user: Docker creates a mountpoint that is missing
+# from the image as root:root, which is exactly the permission error this
+# directory is here to avoid. /app itself stays root-owned, so beat cannot fall
+# back to the working directory.
 RUN groupadd -g 1001 memship \
     && useradd -u 1001 -g 1001 -m -d /home/memship memship \
-    && mkdir -p /app/storage \
-    && chown -R 1001:1001 /app/storage
+    && mkdir -p /app/storage /var/lib/celery \
+    && chown -R 1001:1001 /app/storage /var/lib/celery
 
 # Default to non-root. Compose overrides this with the host user's ids so files
 # written to the bind mount belong to the operator rather than to uid 1001.

--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -66,7 +66,11 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     container_name: memship-celery-beat
-    command: celery -A app.core.celery_app beat --loglevel=info
+    # --schedule is not optional: without it beat writes `celerybeat-schedule`
+    # into the working directory, which is root-owned /app, and the container
+    # runs as uid 1001. That is a permission error on every start, not just on a
+    # clean volume. The production compose has always passed this path.
+    command: celery -A app.core.celery_app beat --loglevel=info --schedule=/var/lib/celery/celerybeat-schedule
     environment:
       - DATABASE_URL=postgresql://memship:memship@db:5432/memship_db
       - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-in-production}
@@ -75,6 +79,8 @@ services:
     volumes:
       - ../app:/app/app
       - memship-storage:/app/storage
+      # Survives a restart, so beat does not re-fire a job it already ran.
+      - memship-celerybeat:/var/lib/celery
     depends_on:
       redis:
         condition: service_healthy
@@ -131,3 +137,4 @@ services:
 volumes:
   pgdata:
   memship-storage:
+  memship-celerybeat:


### PR DESCRIPTION
`memship-celery-beat` crash-loops in the local dev stack. What looks like a wall of warnings in `docker logs` is a traceback celery prints one character per line through its WARNING logger.

## Cause

`backend/docker/docker-compose.yml` ran `celery -A app.core.celery_app beat` with **no `--schedule`**, so beat wrote its schedule database to `celerybeat-schedule` relative to the working directory — `/app`, which is `root:root`. The container runs as `USER 1001:1001`. Result: `[Errno 13] Permission denied`, exit, `restart: unless-stopped`, repeat.

This was previously recorded as a clean-volume race. It is not — it failed on **every** start. The production `docker-compose.yml` has always passed `--schedule=/var/lib/celery/celerybeat-schedule`; only the dev stack missed the flag.

Impact was dev-only: no scheduled jobs ran locally (the 02:00 billing run and 03:00 payment reminders in `celery_app.beat_schedule`). The worker was unaffected, since tasks dispatched by the API need no schedule file.

## Fix

- `backend/docker/Dockerfile` — create `/var/lib/celery` owned by 1001. This matters: a mountpoint that does not exist in the image is created `root:root` by Docker, which would reproduce the same error one directory along.
- `backend/docker/docker-compose.yml` — pass the same `--schedule` path production uses, on a named volume so a restart does not re-fire a job that already ran.

## Verification

Rebuilt and restarted: beat reaches `beat: Starting...` with no traceback, `RestartCount` is 0, and `/var/lib/celery/celerybeat-schedule` is written owned by `memship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjR611NnXb5kQFTixxPrB