### PR TITLE
Add user invitations to the roadmap, in three locales

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -114,6 +114,7 @@ Memship segueix el [versionat semàntic](https://semver.org/) i **els números d
 
 Prioritzat, encara sense versió. Cada element esdevé un llançament versionat quan es publica, i el llançament pren el següent número semàntic per ordre.
 
+- **Invitacions d'usuaris** — convidar un nou superadministrador, administrador del club o soci indicant la seva adreça de correu i el seu rol; la persona tria el seu propi nom i contrasenya. S'envien per correu quan el correu està configurat, i com a enllaç copiable quan no ho està, de manera que una instal·lació acabada de crear pugui afegir un segon administrador sense accés per consola
 - **Còpies de seguretat** — descarregar una còpia completa des de l'àrea d'administració, amb la base de dades i els fitxers pujats, i una restauració documentada i provada
 - **Convocatòries** — convocatòries formals d'Assemblea General amb confirmació del soci mitjançant token
 - **Biblioteca de documents** — estatuts, actes, formularis amb visibilitat per grup

--- a/README.es.md
+++ b/README.es.md
@@ -114,6 +114,7 @@ Memship sigue el [versionado semántico](https://semver.org/) y **los números d
 
 Priorizado, aún sin versión. Cada elemento se convierte en un lanzamiento versionado cuando se publica, y el lanzamiento toma el siguiente número semántico por orden.
 
+- **Invitaciones de usuarios** — invitar a un nuevo superadministrador, administrador del club o socio indicando su dirección de correo y su rol; la persona elige su propio nombre y contraseña. Se envían por correo cuando el correo está configurado, y como enlace copiable cuando no lo está, de modo que una instalación recién creada pueda añadir un segundo administrador sin acceso por consola
 - **Copias de seguridad** — descargar una copia completa desde el área de administración, con la base de datos y los archivos subidos, y una restauración documentada y probada
 - **Convocatorias** — convocatorias formales de Asamblea General con confirmación del socio mediante token
 - **Biblioteca de documentos** — estatutos, actas, formularios con visibilidad por grupo

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Memship follows [semantic versioning](https://semver.org/), and **version number
 
 Priority-ordered, not yet versioned. Each becomes a versioned release when it ships, and the release claims the next semver number in order.
 
+- **User invitations** — invite a new super admin, club admin or member by email address and role; they set their own name and password. Sent by email where email is configured, and as a copyable link where it is not, so a freshly installed instance can add a second administrator without shell access
 - **Data backups** — download a full backup from the admin area, covering the database and the uploaded files, with a documented and tested restore
 - **Convocations** — formal General Assembly calls with token-based member RSVP
 - **Document library** — statutes, minutes, forms with per-group visibility


### PR DESCRIPTION
Closing #40 exposed a gap worth a roadmap line of its own: a super admin can be **promoted** but not **created** from inside the product. The only account-creating path outside the seed CLI is public self-registration, so an instance that turns public registration off — which is what a private club wants — cannot onboard a second administrator at all. One super admin is a single point of failure whose only mitigation is shell access to the host.

Added to **Planned** in all three locales, six items each, in parity.

**Placement is a judgement call worth checking.** I put it first, ahead of Data backups: it is small next to everything below it and it removes a failure mode that bites on day one. If data backups matter more for the first real deployment, reorder — the list is priority-ordered and nothing else depends on this position.

The design note and its eleven settled decisions live in the private docs repo; nothing here points at them, per the docs separation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjR611NnXb5kQFTixxPrB