### PR TITLE
Draft the GitHub release as part of the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write is for creating the release draft, nothing else — the
+      # workflow pushes no commits and moves no tags.
+      contents: write
       packages: write
     steps:
       - name: Resolve tag and version
@@ -60,6 +62,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ steps.ver.outputs.tag }}
+          # Full history and every tag: the release draft needs the previous tag
+          # to list what changed, and the tag set to decide whether this version
+          # is the newest line or a patch to an older one.
+          fetch-depth: 0
 
       - name: Resolve commit SHA
         id: sha
@@ -160,10 +166,91 @@ jobs:
             fi
           done
 
+      # Promotion used to be the last step, so publishing notes was a separate
+      # manual one that got forgotten — only 3 of the first 18 tags have any.
+      #
+      # This drafts the release rather than publishing it, and seeds it from the
+      # version's Released row in README.md, which the roadmap guard above has
+      # already proved exists and which a human wrote and reviewed. Deliberately
+      # NOT --generate-notes: the value in the existing notes is prose a
+      # generator cannot produce — why an exposure mattered, what a default used
+      # to hand out — and a commit changelog in its place would quietly lower the
+      # bar while looking like the step was done.
+      #
+      # So: the workflow removes the excuse for forgetting. A person still writes
+      # the release.
+      - name: Draft the GitHub release
+        id: draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Re-promotion via workflow_dispatch must never touch notes that already
+          # exist — overwriting a published release with a seeded draft would lose
+          # the prose this whole step exists to protect.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::$TAG already has a release. Left untouched."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ROW="$(grep -F "| v$VERSION " README.md | head -1)"
+          SUMMARY="$(printf '%s' "$ROW" | sed -E "s/^\| v${VERSION} \| //; s/ \| [^|]*\|[[:space:]]*$//")"
+          if [[ -z "$SUMMARY" || "$SUMMARY" == "$ROW" ]]; then
+            echo "::error::Could not parse the v$VERSION row out of README.md. The roadmap guard found the row, so the table's shape has changed — fix the parsing here rather than releasing without notes."
+            exit 1
+          fi
+
+          # "Feature name — the rest of the sentence" → the part before the first
+          # em dash, matching the vX.Y.Z — Feature name title convention.
+          HEADLINE="${SUMMARY%% — *}"
+
+          PREV="$(git tag -l 'v*.*.*' --sort=v:refname | grep -B1 -x -F "$TAG" | head -1 || true)"
+          if [[ -n "$PREV" && "$PREV" != "$TAG" ]]; then
+            RANGE="$PREV..$TAG"
+          else
+            RANGE="$TAG"
+          fi
+
+          # Newest line, or a patch to an older one? Only the former claims Latest.
+          HIGHEST="$(git tag -l 'v*.*.*' --sort=v:refname | tail -1)"
+
+          {
+            echo "<!-- Draft seeded from the README roadmap row. Replace this summary with the"
+            echo "     real notes before publishing: lead on why the change matters, not what"
+            echo "     changed. Body starts at ##, no H1. Delete the commit list below. -->"
+            echo ""
+            echo "## Summary"
+            echo ""
+            echo "$SUMMARY"
+            echo ""
+            echo "---"
+            echo ""
+            echo "### Commits in $RANGE — raw material, delete before publishing"
+            echo ""
+            git log --no-merges --format='- %s' "$RANGE"
+          } > release-notes.md
+
+          LATEST_FLAG="--latest=false"
+          if [[ "$HIGHEST" == "$TAG" ]]; then LATEST_FLAG="--latest"; fi
+
+          gh release create "$TAG" \
+            --draft \
+            $LATEST_FLAG \
+            --title "$TAG — $HEADLINE" \
+            --notes-file release-notes.md
+
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Drafted $TAG — $HEADLINE. Finish the notes and publish it."
+
       - name: Summary
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           COMPLETE: ${{ steps.rc.outputs.complete }}
+          DRAFTED: ${{ steps.draft.outputs.created }}
         run: |
           {
             echo "### Released v$VERSION"
@@ -175,5 +262,12 @@ jobs:
               echo "Promoted from the release candidates staging validated — no rebuild."
             else
               echo "⚠ Rebuilt from the tag (\`allow_rebuild\`). These are not the bytes staging validated."
+            fi
+            echo ""
+            if [[ "$DRAFTED" == "true" ]]; then
+              echo "📝 **The release notes are a draft** — finish and publish them at"
+              echo "<https://github.com/${{ github.repository }}/releases>. The images are already live."
+            else
+              echo "The release already existed; its notes were left alone."
             fi
           } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Closes #46.

Promotion was the last step of `release.yml`, so publishing release notes was a separate manual step that got forgotten — only 3 of the first 19 tags have any, and **v2.2.0 is the newest example**.

## What this does

Adds a **Draft the GitHub release** step between image promotion and the summary. It:

- Opens a **draft** release (not published) seeded from the version's `Done` row in `README.md` — already human-written, and already mandatory since the roadmap guard fails without it.
- Titles it `vX.Y.Z — Feature name`, taking the headline from the text before the row's first em dash, matching the existing convention.
- Appends the commits in `<prev tag>..<tag>` as clearly-marked raw material to delete before publishing.
- Marks `--latest` only when the tag is the highest in the tag set, so a patch to an older line doesn't steal the Latest badge.
- **Leaves an existing release completely untouched**, so re-promotion via `workflow_dispatch` can never overwrite published prose with a seeded draft.

Also bumps the job to `contents: write` (for creating the release, nothing else — the workflow pushes no commits and moves no tags) and sets `fetch-depth: 0` so the previous tag and the full tag set are available.

## Why not `--generate-notes`

The value in the existing notes is prose a generator cannot produce — why an exposure mattered, what a default used to hand out. A commit changelog in its place would quietly lower the bar while looking like the step was done.

So the split is deliberate: **the workflow removes the excuse for forgetting; a person still writes the release.**

## Open question deliberately not addressed

Backfilling the 15 tags that have no notes. This only affects releases from here on.

## Validation

The step only runs on tag push, so the logic was exercised locally against the real repository state:

- README row parsing on the actual v2.2.0 row → headline `Super admin recovery from the host`, summary intact, `PARSE FAIL` guard correctly distinguishes a match from a no-op.
- Tag resolution → `PREV=v2.1.0`, `HIGHEST=v2.2.0`, 5 non-merge commits in range, `--latest` correctly applied.
- `gh release create --latest=false` confirmed valid on gh 2.96.0.
- Workflow YAML parses and the step lands after promotion, before the summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)