### PR TITLE
Fix five defects found by walking the install guide on a real server

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,8 +28,8 @@ sudo ~/memship-bootstrap/scripts/vps-bootstrap.sh --user deploy --ssh-key-file ~
 as (`--user "$USER"`) to use it instead of creating a separate `deploy`. `--ssh-key-file` takes a
 file containing an SSH **public** key — your own `~/.ssh/authorized_keys` is the reliable choice,
 since a fresh server has no `.pub` file lying around. Without a key you cannot log in as the new
-user. Note that `~` expands to **root's** home under `sudo`, so give an absolute path if you are
-not root.
+user. The `~` above is expanded by your own shell before `sudo` runs, so it is your home
+directory; from a **root shell** (`sudo -i`) it would be root's, so pass an absolute path there.
 
 It creates the deploy user, installs Docker from Docker's own repository, enables
 `unattended-upgrades`, `fail2ban` and `ufw`, sets the timezone, and adds a weekly image prune.
@@ -62,6 +62,11 @@ The bootstrap clone in your home directory has done its job now and can be delet
 That creates the data root, generates real secrets into `.env` (mode 600), pulls the published
 images and starts the stack.
 
+**Your install is pinned to a version.** `install.sh` sets `IMAGE_TAG` to the most recent release
+tag in the checkout, so the deployment stays on that version until you move it deliberately, and
+`/api/v1/health` reports which one it runs. Pass `--tag 2.2.0` to pin a different one. To upgrade,
+edit `IMAGE_TAG` in `.env` and re-run the script — see [Upgrading](../self-hosting/upgrading.md).
+
 **Point DNS at the server first.** `install.sh` refuses to start when the hostname does not
 resolve to this host, because Caddy validates over HTTP-01 and Let's Encrypt rate-limits *failed*
 validations at 5 per hostname per hour — a premature start can lock you out of certificates for
@@ -87,12 +92,19 @@ docker compose exec -it api python -m app.cli.seed
 The `-it` matters: the command prompts. See [First-time setup](first-setup.md) for what it
 asks and for the unattended flags an automated deployment uses instead.
 
-Open your domain (or **http://localhost** if you installed without one).
+Open your domain — or, if you installed without one, **http://&lt;server-address&gt;**, the hostname or
+IP you reach the box on. `localhost` only works when you are installing on the machine in front of
+you.
 
 ### Without a domain
 
 Omit `--domain`. Caddy then serves plain HTTP on port 80, which is what you want for a local or
 internal install.
+
+This is also how to rehearse an install on a real server without spending certificates: install
+with no `--domain`, confirm the stack works, then re-run with `--domain` to add HTTPS. Re-running
+updates `SITE_ADDRESS` and the public URLs together, so nothing is left pointing at the old
+address.
 
 ## The data root
 
@@ -174,9 +186,12 @@ See the [Configuration reference](../self-hosting/configuration.md) for every av
 
 ## Services
 
-The default Compose stack runs behind a Caddy reverse proxy:
+The default Compose stack runs behind a Caddy reverse proxy. These URLs are **as seen from the
+server itself** — the API and database are bound to `127.0.0.1`, so `localhost` is the only way to
+reach them. From anywhere else, use your domain or the server's address, which reaches the first
+two rows only:
 
-| Service    | URL                              | Description               |
+| Service    | URL (on the server)              | Description               |
 |------------|----------------------------------|---------------------------|
 | Frontend   | `http://localhost`               | Member portal (via Caddy) |
 | API        | `http://localhost/api/v1/health` | Backend API (via Caddy)   |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,6 +10,11 @@
 #   ./scripts/install.sh                                  # into ./data, plain HTTP
 #   ./scripts/install.sh --domain memship.example.com     # with automatic HTTPS
 #   ./scripts/install.sh --data-root /srv/openmemship --domain memship.example.com
+#   ./scripts/install.sh --tag 2.2.0                      # pin a specific version
+#
+# A new install pins IMAGE_TAG to this checkout's most recent release tag, so the
+# deployment states which version it runs instead of tracking a moving `latest`.
+# Pass --tag to choose another, or edit IMAGE_TAG in .env and re-run.
 #
 # Safe to re-run: it never overwrites an existing .env, and re-running is how you
 # pick up a new IMAGE_TAG. Everything it creates lives under one data root, so
@@ -29,7 +34,9 @@ step() { printf '\n==> %s\n' "$*"; }
 warn() { printf '\n!!  %s\n' "$*" >&2; }
 
 usage() {
-    sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    # Print the whole header block, stopping at the first non-comment line, so
+    # --help cannot silently truncate when the header grows.
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
     exit 0
 }
 
@@ -110,6 +117,25 @@ gen_secret() { openssl rand -hex 32; }
 # Fernet needs urlsafe base64 of exactly 32 bytes — see backend/app/core/config.py.
 gen_fernet() { openssl rand -base64 32 | tr '+/' '-_'; }
 
+# An empty IMAGE_TAG resolves to `latest`, which leaves a production install
+# tracking a moving target and — because APP_VERSION is baked from the tag —
+# reporting its own version as the literal string "latest". Neither is what you
+# want on a box you have to reason about.
+#
+# So default to this checkout's most recent release tag. Image tags carry no
+# leading `v` (the repository tags v2.2.0, the registry publishes 2.2.0). No
+# tags reachable — a shallow clone, a source tarball, a fork — falls back to
+# `latest`, which is the old behaviour rather than a hard failure.
+default_image_tag() {
+    local t
+    t="$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || true)"
+    case "$t" in
+        v[0-9]*) printf '%s' "${t#v}" ;;
+        [0-9]*)  printf '%s' "$t" ;;
+        *)       printf 'latest' ;;
+    esac
+}
+
 if [ -f "$ENV_FILE" ]; then
     info ".env exists — leaving it alone (edit it by hand to change settings)"
 else
@@ -122,6 +148,11 @@ else
         PUBLIC_URL="http://localhost"
     fi
 
+    # Only a fresh .env gets the resolved default. Re-running must never
+    # overwrite a tag the operator pinned by hand — that is the documented
+    # upgrade path, and the sed below still applies an explicit --tag.
+    NEW_TAG="${IMAGE_TAG:-$(default_image_tag)}"
+
     umask 077
     cat > "$ENV_FILE" <<EOF
 # Written by scripts/install.sh. Secrets below are randomly generated —
@@ -129,7 +160,7 @@ else
 
 MEMSHIP_DATA_ROOT=$DATA_ROOT
 SITE_ADDRESS=$SITE
-IMAGE_TAG=$IMAGE_TAG
+IMAGE_TAG=$NEW_TAG
 
 # The backend containers run as this uid/gid, so uploads written to
 # \$MEMSHIP_DATA_ROOT/storage belong to you and need no sudo to read.
@@ -161,6 +192,7 @@ EOF
     umask 022
     chmod 600 "$ENV_FILE"
     info "wrote .env with generated secrets (mode 600)"
+    info "IMAGE_TAG=$NEW_TAG"
 fi
 
 # Applying --domain or --tag to an existing .env, in place.
@@ -245,11 +277,32 @@ cat <<EOF
   Data root:  $DATA_ROOT
   Config:     $ENV_FILE  (contains your secrets — back it up)
   Address:    ${SITE_NOW:-http://localhost}
+  Version:    $(grep -E '^IMAGE_TAG=' "$ENV_FILE" | tail -1 | cut -d= -f2-)
+EOF
 
+# Re-running is the documented way to add a domain or move IMAGE_TAG, so this is
+# the normal path on an install that was seeded long ago. Telling its operator to
+# "create your super admin" invites a password reset nobody asked for. Ask the
+# database instead. Anything unreadable — migrations still running, db not up
+# yet — falls through to printing the instructions, which is the safe default.
+if docker compose exec -T db psql -U memship -d memship_db -tAc \
+        'select 1 from users limit 1' 2>/dev/null | grep -q 1; then
+    cat <<EOF
+  This instance is already set up. To reset the super admin password:
+
+    MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T -e MEMSHIP_ADMIN_PASSWORD \\
+      api python -m app.cli.seed --admin-email you@example.org
+EOF
+else
+    cat <<EOF
   Run the setup — it creates your super admin and your organization.
   It prompts, so keep the -it:
 
     docker compose exec -it api python -m app.cli.seed
+EOF
+fi
+
+cat <<EOF
 
   Then:  docker compose ps       # check everything is up
          docker compose logs -f  # watch it start

--- a/scripts/vps-bootstrap.sh
+++ b/scripts/vps-bootstrap.sh
@@ -34,7 +34,9 @@ warn() { printf '\n!!  %s\n' "$*" >&2; }
 skip() { printf '  - %s\n' "$*"; }
 
 usage() {
-    sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    # Print the whole header block, stopping at the first non-comment line, so
+    # --help cannot silently truncate when the header grows.
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
     exit 0
 }
 
@@ -220,6 +222,26 @@ EOF
 systemctl enable --now fail2ban >/dev/null 2>&1 || true
 info "sshd jail enabled (5 attempts, 1h ban)"
 
+# ------------------------------------------------------------------ sshd port
+#
+# Read sshd's effective config once, here rather than at the end, because the
+# firewall step below needs the port: opening a hardcoded 22 and then enabling
+# ufw drops the session on any host whose sshd has been moved — which is exactly
+# what step 1 of this script's own closing instructions tells operators to do.
+#
+# Do NOT pipe `sshd -T` into an awk that exits early: awk closes the pipe, sshd
+# takes SIGPIPE, and under `set -o pipefail` that is a 141 which `set -e` turns
+# into an abort — with everything already done and none of the instructions
+# below printed.
+SSHD_CONF="$(sshd -T 2>/dev/null || true)"
+sshd_val() { printf '%s\n' "$SSHD_CONF" | awk -v k="$1" '$1==k {print $2}' | tail -1; }
+
+# Every port sshd listens on, not just the first: a host mid-migration between
+# ports is precisely when locking yourself out is unrecoverable.
+SSH_PORTS="$(printf '%s\n' "$SSHD_CONF" | awk '$1=="port" {print $2}' | sort -un)"
+[ -n "$SSH_PORTS" ] || SSH_PORTS=22
+SSH_PORT="$(printf '%s\n' "$SSH_PORTS" | head -1)"
+
 # ---------------------------------------------------------------- firewall
 
 if [ "$DO_FIREWALL" -eq 1 ]; then
@@ -228,10 +250,15 @@ if [ "$DO_FIREWALL" -eq 1 ]; then
     apt-get install -y -qq ufw >/dev/null
 
     # Order matters: allow SSH BEFORE enabling, or enabling drops this session.
+    # 22 goes in unconditionally as well — if sshd is being moved off it, the
+    # old port is still how the current session got here.
     ufw allow 22/tcp >/dev/null
+    for p in $SSH_PORTS; do
+        [ "$p" = "22" ] || ufw allow "$p"/tcp >/dev/null
+    done
     ufw allow 80/tcp >/dev/null
     ufw allow 443/tcp >/dev/null
-    info "allowed 22, 80, 443/tcp"
+    info "allowed $(printf '%s, ' $SSH_PORTS | sed 's/, $//'), 80, 443/tcp"
 
     # "Status: inactive" contains "active" — match the whole field, not a substring.
     if ufw status | head -1 | grep -qi "^Status: active"; then
@@ -297,15 +324,8 @@ step "Done"
 # Report sshd's actual state rather than assuming it needs hardening. Cloud
 # images increasingly ship with all three already set, and telling someone to
 # fix what is already correct is how the real instructions get skimmed past.
-# Read the effective config once. Do NOT pipe `sshd -T` into an awk that exits
-# early: awk closes the pipe, sshd takes SIGPIPE, and under `set -o pipefail`
-# that is a 141 which `set -e` turns into an abort right here — with everything
-# already done and none of the instructions below printed.
-SSHD_CONF="$(sshd -T 2>/dev/null || true)"
-sshd_val() { printf '%s\n' "$SSHD_CONF" | awk -v k="$1" '$1==k {print $2}' | tail -1; }
-
-SSH_PORT="$(sshd_val port)"
-SSH_PORT="${SSH_PORT:-22}"
+# SSHD_CONF, sshd_val and SSH_PORT were resolved before the firewall step, which
+# needs the port to avoid locking this session out.
 SSH_ROOT="$(sshd_val permitrootlogin)"
 SSH_PASSWD="$(sshd_val passwordauthentication)"
 


### PR DESCRIPTION
Rebuilt staging from scratch by following `docs/getting-started/installation.md` literally. The box is up at https://staging.openmemship.com/ — these are the five things the walk turned up.

## The two that matter

**D1 — `vps-bootstrap.sh` could lock you out of the server.** It opened a hardcoded `22/tcp` and then enabled ufw. It already resolved sshd's effective port at the bottom of the script — but only to *print* it in the closing instructions, never to open it. On any host whose sshd has been moved, `ufw --force enable` drops the running session, and a VPS may have no console to recover from.

The sting: **moving sshd is exactly what step 1 of the script's own closing instructions tells you to do.** So a first run set up the condition that made a second run dangerous. It missed this rebuild only because ufw was already active, so the enable branch was skipped.

Now resolves every port sshd listens on, before the firewall step, and opens all of them — keeping 22 unconditionally, since a host mid-migration between ports is precisely when getting this wrong is unrecoverable.

**D2 — a production install tracked a moving `latest` and could not name its own version.** `install.sh` left `IMAGE_TAG` empty, so Compose resolved `latest`. Two consequences: any later `docker compose pull` silently moved the deployment, and since `APP_VERSION` is baked from the image tag, the health endpoint reported `{"version":"latest"}`. For a box whose job is to be the release gate, not being able to name its own version is the worse half.

A new install now pins `IMAGE_TAG` to the checkout's most recent release tag (`v2.2.0` → `2.2.0`; the registry publishes without the `v`). No reachable tags — shallow clone, tarball, fork — falls back to `latest` rather than failing.

**Only a fresh `.env` gets the default.** Re-running must never overwrite a tag pinned by hand, since that is the documented upgrade path. An explicit `--tag` still applies either way. That flag already existed but appeared nowhere in the guide; it is now in the Install section and in `--help`.

## The three smaller ones

**D3 — the guide's `~` warning was wrong.** It claimed `~` expands to root's home under `sudo`, so the very command it printed looked broken. The calling shell expands it first; verified this run, the literal command works. Narrowed to the case where it is true — a root shell (`sudo -i`).

**D4 — every URL said `localhost`** in a guide whose whole premise is a remote server. Someone installing without a domain and following "Open your domain (or http://localhost)" opens their own laptop. The Services table keeps `localhost`, correctly — the API and DB are bound to `127.0.0.1`, so that is the only way to reach them — but now says it is from the server's point of view.

**D5 — `install.sh` told every re-run to "create your super admin"**, including installs seeded long ago. Re-running is the *documented* way to add a domain or move `IMAGE_TAG`, so the normal path ended by inviting a password reset nobody asked for. It now asks the database and prints a reset hint instead. Anything unreadable — migrations still running, db not up — falls through to the setup instructions, which is the safe default.

Plus a bug found while fixing the others: `--help` truncated silently in **both** scripts, because `usage()` printed a hardcoded line range the header had outgrown. Same class of defect as D1 — a hardcoded value that drifts — so both now stop at the first non-comment line.

## Verified on the rebuilt box, not just locally

- Port detection returns **51337** against staging's real `sshd -T`, and would open it alongside 22.
- The tag default resolves to **2.2.0** on this checkout.
- The seeded check reads **true** against staging's live database.
- `--help` prints the full header in both scripts; both pass `bash -n`.

## Not fixed here

Creating a super admin from the host writes no audit row — only *resets* do (`seed.py:1614`). The v2.2.0 notes are accurate as published, and this is a design question rather than a bug, so it is left alone.

Full log: `staging-rebuild-defects-2026-08-12.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)