### PR TITLE
Report every port ufw opened, and space the install banner

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -288,6 +288,7 @@ EOF
 if docker compose exec -T db psql -U memship -d memship_db -tAc \
         'select 1 from users limit 1' 2>/dev/null | grep -q 1; then
     cat <<EOF
+
   This instance is already set up. To reset the super admin password:
 
     MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T -e MEMSHIP_ADMIN_PASSWORD \\
@@ -295,6 +296,7 @@ if docker compose exec -T db psql -U memship -d memship_db -tAc \
 EOF
 else
     cat <<EOF
+
   Run the setup — it creates your super admin and your organization.
   It prompts, so keep the -it:
 

--- a/scripts/vps-bootstrap.sh
+++ b/scripts/vps-bootstrap.sh
@@ -252,13 +252,18 @@ if [ "$DO_FIREWALL" -eq 1 ]; then
     # Order matters: allow SSH BEFORE enabling, or enabling drops this session.
     # 22 goes in unconditionally as well — if sshd is being moved off it, the
     # old port is still how the current session got here.
+    ALLOWED="22"
     ufw allow 22/tcp >/dev/null
     for p in $SSH_PORTS; do
-        [ "$p" = "22" ] || ufw allow "$p"/tcp >/dev/null
+        [ "$p" = "22" ] && continue
+        ufw allow "$p"/tcp >/dev/null
+        ALLOWED="$ALLOWED, $p"
     done
     ufw allow 80/tcp >/dev/null
     ufw allow 443/tcp >/dev/null
-    info "allowed $(printf '%s, ' $SSH_PORTS | sed 's/, $//'), 80, 443/tcp"
+    # Report every port actually opened. Under-reporting the firewall's state is
+    # the same class of mistake as opening the wrong port in the first place.
+    info "allowed $ALLOWED, 80, 443/tcp"
 
     # "Status: inactive" contains "active" — match the whole field, not a substring.
     if ufw status | head -1 | grep -qi "^Status: active"; then


### PR DESCRIPTION
Two follow-ups to #53, both caught by running the merged code on the staging box rather than trusting the local checks.

**The firewall step under-reported itself.** It printed `allowed 51337, 80, 443/tcp` while also opening 22 unconditionally. Misreporting the firewall's state is the same class of mistake as opening the wrong port — which is exactly what #53 set out to fix — so the message is now built from the ports actually allowed.

**The banner ran the Version line straight into the setup block** with no blank line between them.

Verified on staging: bootstrap re-run reports `allowed 22, 51337, 80, 443/tcp`, and `ufw status` shows both rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)