### PR TITLE
Fix the upgrade procedure to cover the git checkout and Caddy

### DIFF
--- a/docs/self-hosting/upgrading.md
+++ b/docs/self-hosting/upgrading.md
@@ -23,18 +23,34 @@ IMAGE_TAG=1.2.0
 2. **Review the release notes** for the target version (breaking changes, new required
    settings) on the [releases page](https://github.com/marcandreuf/memship/releases).
 
-3. **Bump the tag** in `.env`:
+3. **Pull the repository, not only the image tag:**
+
+   ```bash
+   cd /path/to/memship
+   git pull
+   ```
+
+   Part of a release ships in the git checkout rather than in the images — `docker-compose.yml`,
+   the `Caddyfile`, `scripts/install.sh`. Bumping `IMAGE_TAG` alone leaves an install
+   half-upgraded: the new backend running behind the old proxy configuration.
+
+4. **Bump the tag** in `.env`:
 
    ```bash
    IMAGE_TAG=1.3.0
    ```
 
-4. **Pull and recreate:**
+5. **Pull and recreate:**
 
    ```bash
    docker compose pull
    docker compose up -d
+   docker compose up -d --force-recreate caddy
    ```
+
+   The last line matters. The `Caddyfile` is bind-mounted, so changing its contents does not
+   change the container's configuration — `docker compose up -d` sees no reason to recreate
+   Caddy and leaves it serving the old one.
 
 ## Upgrading from a release before the non-root backend
 


### PR DESCRIPTION
`docs/self-hosting/upgrading.md` described an images-only upgrade — bump `IMAGE_TAG`, `docker compose pull`, `docker compose up -d`. Two problems, both found by doing the v2.3.0 staging deploy:

1. **Part of a release ships in the git checkout**, not in the images — `docker-compose.yml`, the `Caddyfile`, `scripts/install.sh`. Following the doc literally gives the new backend behind the old proxy configuration. For v2.3.0 that meant an operator would have upgraded and still had **no security headers**.

2. **`docker compose up -d` does not recreate Caddy.** The `Caddyfile` is bind-mounted, so changing its contents does not change the container's configuration. On staging, Caddy sat at "Up 2 days" with the headers silently absent until `--force-recreate caddy` was run.

Both were worked around in the published v2.3.0 release notes but never fixed in the doc itself. This adds `git pull` as a step and `docker compose up -d --force-recreate caddy` as the last command, each with the reason it exists — wording follows the Upgrading section of those notes, which is what the staging deploy actually ran.

Docs only; no code, no other file touched. `docs/getting-started/installation.md` links here rather than repeating the procedure, so nothing else needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D54Bvm9wPe6bfF8Y5b9sti