### PR TITLE
Fix what a self-hosting walkthrough found, from install to restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,70 +298,21 @@ are a contract with the test suite rather than a seeding choice, so they live wi
 
 ## Installation (Docker)
 
-### Prerequisites
+Production self-hosting lives in the docs, so there is one copy of it to keep correct:
 
-- Docker and Docker Compose installed
-- Git (to clone the repo)
+- **[Installation](docs/getting-started/installation.md)** — `vps-bootstrap.sh` on a bare server,
+  then `install.sh`, which generates real secrets, pins a version and puts your data under one
+  backed-up directory
+- **[First-time setup](docs/getting-started/first-setup.md)** — create the super admin and the
+  organization
+- **[Configuration reference](docs/self-hosting/configuration.md)** — every environment variable
+- **[Backups & restore](docs/self-hosting/backups-and-restore.md)** — set this up before going live
+- **[Upgrading](docs/self-hosting/upgrading.md)** — moving to a new release
+- **[Troubleshooting](docs/self-hosting/troubleshooting.md)** — when something will not start
 
-### Option A: Pre-built images (recommended)
+The [Quick Start](#quick-start-docker) above is for evaluation only: it ships a signing key that is
+published in this repository and keeps data in throwaway volumes.
 
-Uses published images from [GitHub Container Registry](https://github.com/marcandreuf/memship/pkgs/container/memship-backend).
-
-```bash
-git clone https://github.com/marcandreuf/memship.git
-cd memship
-
-# Configure
-cp .env.example .env
-# Edit .env — at minimum change SECRET_KEY and DB_PASSWORD
-# Set the image version:
-#   IMAGE_TAG=0.1.3
-
-# Pull and start all services (Caddy + API + Frontend + PostgreSQL)
-docker compose pull
-docker compose up -d
-
-# Run the setup: super admin, club data reset, club setup
-docker compose exec -it api python -m app.cli.seed
-
-# Open http://localhost
-```
-
-### Option B: Build from source
-
-Builds the Docker images locally from the repo source code.
-
-```bash
-git clone https://github.com/marcandreuf/memship.git
-cd memship
-cp .env.example .env
-docker compose up -d --build
-docker compose exec -it api python -m app.cli.seed
-```
-
-### Services
-
-| Service | URL | Description |
-|---------|-----|-------------|
-| Frontend | http://localhost | Member portal (via Caddy) |
-| API | http://localhost/api/v1/health | Backend API (via Caddy) |
-| API Direct | http://localhost:8003 | Backend API (direct) |
-| API Docs | http://localhost:8003/api/docs | Swagger UI (dev mode only) |
-
-### Backups
-
-```bash
-# Create a backup
-./scripts/db-backup.sh
-
-# List and restore from a backup (dry-run by default)
-./scripts/db-restore.sh
-
-# Restore with confirmation
-./scripts/db-restore.sh --confirm
-```
-
-Backups are stored in the `backups/` directory. Old backups are cleaned up after 10 days.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,9 +24,11 @@ Running Memship on your own server.
 - [Email delivery](self-hosting/email.md) — SMTP or Resend _(EN)_
 - [Backups & restore](self-hosting/backups-and-restore.md) _(EN)_
 - [Upgrading](self-hosting/upgrading.md) — image tags and migrations _(EN)_
-- Reverse proxy & TLS — _planned_
+- [Troubleshooting](self-hosting/troubleshooting.md) — when something will not start _(EN)_
+- Reverse proxy & TLS — the stack ships a Caddy that obtains and renews certificates on its own.
+  Set up in [Installation](getting-started/installation.md), tuned via `SITE_ADDRESS` in the
+  [Configuration reference](self-hosting/configuration.md)
 - Payment providers (Stripe, Redsys/Bizum) — _planned_
-- Troubleshooting — _planned_
 
 ## Guía del administrador (admin guide)
 
@@ -58,9 +60,9 @@ Para las personas socias que usan el portal.
 - FAQ — _planned_
 - Glossary — _planned_
 
-> **Simple Bookings** (reserva de espacios) is not yet part of a released version — it ships on
-> its own feature branch. Its admin and member pages will be added **with that feature's PR**,
-> per the "docs live with the code" rule below.
+> **Simple Bookings** (reserva de espacios) ships in the released images — `/api/v1/bookings` is
+> in the API and the setup command seeds spaces, slots and a waitlist — but it has **no admin or
+> member guide page yet**. That is a documentation gap, not a missing feature.
 
 ---
 

--- a/docs/getting-started/first-setup.md
+++ b/docs/getting-started/first-setup.md
@@ -99,7 +99,7 @@ club setup — a reset changes nothing else.
 Unattended, for a scripted recovery:
 
 ```bash
-MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T api \
+MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T -e MEMSHIP_ADMIN_PASSWORD api \
   python -m app.cli.seed --admin-email you@example.org
 ```
 
@@ -117,9 +117,15 @@ read from the environment, never from the command line, where it would land in t
 history and in `ps`:
 
 ```bash
-MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T api \
+MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T -e MEMSHIP_ADMIN_PASSWORD api \
   python -m app.cli.seed --admin-email you@example.org --club-name "Your Club"
 ```
+
+**The `-e MEMSHIP_ADMIN_PASSWORD` is not optional.** `docker compose exec` does not pass the
+calling shell's environment into the container, so without it the variable is set on your host
+and unset where the command runs — and setup stops with
+`--admin-email needs the password in MEMSHIP_ADMIN_PASSWORD`. Naming the variable after `-e`,
+with no `=value`, is what forwards it without putting the password in `ps` output.
 
 | Flag | Effect |
 |------|--------|

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,6 +11,12 @@ This guide covers a **production** self-hosted install. For a quick local evalua
   `sudo apt-get update && sudo apt-get install -y git`
 - A domain name, with a DNS A record already pointing at the server, if you want automatic HTTPS
 
+> **One memship instance per host.** The Compose file names its containers explicitly
+> (`memship-db`, `memship-api`, …), which is what makes the scripts and the docs able to refer to
+> them. Names are global to the Docker daemon, so a second instance — even from another directory,
+> with its own data root and its own Compose project — fails part-way with
+> `Conflict. The container name "/memship-db" is already in use`. Use a second host, or a VM.
+
 ### Starting from a bare server
 
 `scripts/vps-bootstrap.sh` does the root half of the preparation. Run it **once, as root**, on a
@@ -64,8 +70,11 @@ images and starts the stack.
 
 **Your install is pinned to a version.** `install.sh` sets `IMAGE_TAG` to the most recent release
 tag in the checkout, so the deployment stays on that version until you move it deliberately, and
-`/api/v1/health` reports which one it runs. Pass `--tag 2.2.0` to pin a different one. To upgrade,
-edit `IMAGE_TAG` in `.env` and re-run the script — see [Upgrading](../self-hosting/upgrading.md).
+`/api/v1/health` reports which one it runs. Pass `--tag 2.2.0` to pin a different one.
+
+**To upgrade later, follow [Upgrading](../self-hosting/upgrading.md).** Moving `IMAGE_TAG` on its
+own is not enough — part of a release ships in the git checkout rather than in the images, so an
+upgrade starts with `git pull`.
 
 **Point DNS at the server first.** `install.sh` refuses to start when the hostname does not
 resolve to this host, because Caddy validates over HTTP-01 and Let's Encrypt rate-limits *failed*
@@ -131,9 +140,11 @@ Three things worth knowing about it:
 - `postgres/` is mode `0700` owned by uid 70 — visible as a path but not readable by you. That is
   correct and expected. Read the database with `scripts/db-backup.sh`, not with `ls`.
 
-> **Do not put the data root inside a `0700` home directory.** Containers running as other users
-> (Postgres uses uid 70) cannot traverse into it, and Postgres will refuse to start. `/srv` is the
-> FHS location for service data and survives deleting the user.
+> **Put the data root in `/srv`, not in a home directory.** `/srv` is the FHS location for service
+> data, it survives deleting the user, and it stays reachable when a home directory's permissions
+> change. A data root under `$HOME` does work with ordinary Docker — the daemon resolves bind-mount
+> sources as root, so a `0700` home does not stop Postgres from starting — but it does break under
+> **rootless Docker and Podman**, where the container's own uid has to traverse the path.
 
 ### SELinux hosts (RHEL, Fedora, Rocky, AlmaLinux)
 
@@ -176,13 +187,18 @@ Then set, at minimum:
 - **`SITE_ADDRESS`** — your hostname for automatic HTTPS, or leave empty for plain HTTP
 - **`IMAGE_TAG`** — pin a released version; see [Upgrading](../self-hosting/upgrading.md)
 
-Create the directory tree, then start the stack:
+Create the directory tree, then start the stack. `.env` is read by Compose, not by your shell, so
+export the path here too — or write it out in full:
 
 ```bash
+export MEMSHIP_DATA_ROOT=/srv/openmemship/data
 mkdir -p "$MEMSHIP_DATA_ROOT"/{postgres,storage,celerybeat,caddy/data,caddy/config,backups}
 docker compose pull
 docker compose up -d
 ```
+
+Do not skip the `mkdir`. Docker creates a missing bind-mount source itself, but as **root** — and
+the backend runs as your uid, so it then cannot write its own uploads.
 
 See the [Configuration reference](../self-hosting/configuration.md) for every available setting.
 

--- a/docs/self-hosting/backups-and-restore.md
+++ b/docs/self-hosting/backups-and-restore.md
@@ -35,8 +35,9 @@ protecting its own files, not a misconfiguration.
 ./scripts/db-backup.sh
 ```
 
-The dump is written to `$MEMSHIP_DATA_ROOT/backups/` as a timestamped `.sql.gz`. Dumps older than
-10 days are removed automatically.
+The dump is written to `$MEMSHIP_DATA_ROOT/backups/` as a timestamped `.sql.gz`, mode `600` and
+owned by the account that runs the script — it is a complete copy of your members' data, so it is
+not left world-readable. Dumps older than 10 days are removed automatically.
 
 For unattended backups, schedule it — nightly at 03:30, for example:
 
@@ -55,11 +56,29 @@ default**, so you can confirm the target before anything changes:
 
 ```bash
 ./scripts/db-restore.sh            # dry-run: shows what would happen
-./scripts/db-restore.sh --confirm  # actually restore
+./scripts/db-restore.sh --confirm  # actually restore, asking you to type a confirmation
 ```
 
-> **Restoring overwrites the current database.** Take a fresh backup first, and check you are
-> pointed at the environment you think you are.
+Both of those need a terminal — the picker and the confirmation both read from one. For a restore
+run from a script, a cron job or a non-interactive `ssh host '…'`, name the dump and pass `--yes`:
+
+```bash
+./scripts/db-restore.sh --confirm --yes memship_20260819_141405.sql.gz
+```
+
+> **Restoring overwrites the current database.** Check you are pointed at the environment you
+> think you are.
+
+Before it drops anything the script checks that the archive is readable and looks like a
+`pg_dump` file, and dumps the current database to `memship_pre-restore_<timestamp>.sql.gz` in the
+same directory. If the restore then fails part-way it says so, exits non-zero, and **leaves the API
+stopped on purpose** — starting it would run migrations against the half-restored database and
+leave you with an instance that answers "healthy" and contains nothing. Put back what you had with
+the pre-restore dump it names.
+
+> When several restores fail in a row, each one writes its own pre-restore dump — and the newest is
+> the one taken from the already-damaged database. Restore the file the failure message named, not
+> whichever is most recent.
 
 ## Restoring onto a new server
 

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -1,0 +1,176 @@
+# Troubleshooting
+
+Symptoms an operator actually hits, and what causes them. If something here is wrong or missing,
+[open an issue](https://github.com/marcandreuf/memship/issues) — this page is built from real
+installs, not from theory.
+
+First, two commands worth running before anything else:
+
+```bash
+docker compose ps                       # what is up, and what is restarting
+curl -s http://localhost/api/v1/health  # {"status":"healthy","version":"2.3.0",...}
+```
+
+`version` is the image tag you are on. If it reads `latest` you are on an unpinned install and
+cannot tell what is running — set `IMAGE_TAG` in `.env` to a release and re-run
+`./scripts/install.sh`.
+
+## The stack will not start
+
+### `Conflict. The container name "/memship-db" is already in use`
+
+Another memship instance is already running on this host. The Compose file names its containers
+explicitly, and those names are global to the Docker daemon, so a second copy collides even from a
+different directory with a different data root and a different Compose project name.
+
+```bash
+docker ps -a --filter name=memship-      # find the other instance
+```
+
+Run the second instance on another host or VM. If the other one is dead and you want its name back,
+`docker rm` the leftover containers.
+
+### Containers restart in a loop, logs say permission denied
+
+Almost always the data root. Docker creates a missing bind-mount source **as root**, and the
+backend runs as your uid, so it cannot write into a directory Docker made for it:
+
+```bash
+ls -l "$MEMSHIP_DATA_ROOT"     # storage/ and celerybeat/ should be yours, postgres/ uid 70
+sudo chown -R "$(id -u):$(id -g)" "$MEMSHIP_DATA_ROOT"/{storage,celerybeat,caddy,backups}
+```
+
+`postgres/` is different: mode `0700` owned by uid 70, unreadable by you. That is correct — read
+the database with `./scripts/db-backup.sh`, not with `ls`.
+
+If you are upgrading from a release where the backend ran as root, see the note in
+[Upgrading](upgrading.md).
+
+### Postgres will not start on RHEL, Fedora, Rocky or AlmaLinux
+
+SELinux. Bind mounts need relabelling — see the SELinux section of
+[Installation](../getting-started/installation.md).
+
+### `port is already allocated`
+
+Something else holds 80 or 443:
+
+```bash
+sudo ss -ltnp | grep -E ':(80|443)\b'
+```
+
+Stop it, or set `HTTP_PORT` / `HTTPS_PORT` in `.env` and recreate. Note that automatic HTTPS needs
+port 80 reachable from the internet — Let's Encrypt validates over HTTP-01.
+
+## It is running but I cannot reach it
+
+**Check where you are looking from.** Every `localhost` URL in the docs is *from the server*. The
+API and database are deliberately bound to `127.0.0.1`, so from your laptop only the frontend and
+`/api/...` through the proxy are reachable, at the server's domain or IP.
+
+**`ufw` does not constrain Docker.** Docker writes its iptables rules ahead of the firewall's, so a
+port published on `0.0.0.0` stays internet-reachable even while `ufw` denies it. Verify from
+another machine rather than trusting `ufw status`:
+
+```bash
+nmap -Pn -p 22,80,443,5433,8003 your-host
+```
+
+8003 and 5433 should be closed. If they are open, something set `API_BIND` or `DB_BIND` to
+`0.0.0.0`, or added a `ports:` entry.
+
+## HTTPS and certificates
+
+### No certificate is issued
+
+Caddy validates over HTTP-01, so the hostname must already resolve to this server and port 80 must
+be open. `install.sh` refuses to start when DNS does not match, because failed validations are
+rate-limited at 5 per hostname per hour.
+
+### "Too many certificates already issued"
+
+Let's Encrypt allows **5 certificates per week for the same set of hostnames**. The issued
+certificate lives in `<data-root>/caddy/data`; deleting that directory — as a full teardown does —
+makes the next start request a *new* certificate instead of renewing. Preserve `caddy/data` across
+rebuilds, and rehearse installs without `--domain`.
+
+### Security headers are missing after an upgrade
+
+The `Caddyfile` is bind-mounted, so changing its contents does not change the running container's
+configuration, and `docker compose up -d` sees no reason to recreate it:
+
+```bash
+docker compose ps caddy                          # "Up 3 days" after an upgrade is the tell
+docker compose up -d --force-recreate caddy
+curl -sI https://your-host/api/v1/health | grep -i -E 'content-security|x-frame|strict-transport'
+```
+
+Check the headers on an **API** path, not just the homepage. The frontend sets some of its own, so
+`/` can look protected while every API response is bare.
+
+## Setup and login
+
+### `--admin-email needs the password in MEMSHIP_ADMIN_PASSWORD`
+
+`docker compose exec` does not forward your shell's environment into the container. Name the
+variable after `-e`:
+
+```bash
+MEMSHIP_ADMIN_PASSWORD='...' docker compose exec -T -e MEMSHIP_ADMIN_PASSWORD \
+  api python -m app.cli.seed --admin-email you@example.org
+```
+
+### Nobody can log in / the super admin password is lost
+
+Reset it from the host with the same command. It is deliberately the only way in — there is no
+recovery through the web interface for a super admin, and every reset is written to the audit log
+with no acting user, since whoever ran it had shell access.
+
+### The API refuses to start, complaining about `SECRET_KEY`
+
+The placeholder key shipped in `.env.example` and the Compose default are published in this
+repository, and they sign the session token, the member-card QR HMAC and the OAuth state — so they
+are refused. Generate one:
+
+```bash
+openssl rand -hex 32
+```
+
+Leaving `SECRET_KEY` empty is allowed — the server generates and persists one — but setting it
+explicitly is what lets a rebuilt host keep working sessions.
+
+## Backups and restore
+
+### A restore failed
+
+The script leaves the API stopped on purpose. Starting it would run migrations against the
+half-restored database and give you an instance that reports `"healthy"` and contains nothing.
+
+Restore the pre-restore dump named in the failure message — not simply the newest one, which after
+a second failed attempt is a copy of the already-damaged database.
+
+### A restore says there is no terminal
+
+The backup picker and the typed confirmation both need one. From a script or cron, name the dump
+and pass `--yes`:
+
+```bash
+./scripts/db-restore.sh --confirm --yes memship_20260819_141405.sql.gz
+```
+
+### "Restore complete" but the data is gone
+
+Releases before 2.3.0 could report success after a failed restore — `psql` ran without
+`ON_ERROR_STOP`, so a corrupt or truncated dump emptied the database and still printed a green
+result. Upgrade, and re-test your restores. A backup you have never restored is a guess.
+
+## Logs
+
+```bash
+docker compose logs -f api             # backend, including migrations on startup
+docker compose logs -f celery-worker   # scheduled jobs and email sending
+docker compose logs -f caddy           # TLS issuance and proxying
+docker compose logs --since 10m        # everything, recent
+```
+
+Celery is the component that fails quietly — if reminders or emails stop, look there first.

--- a/docs/self-hosting/upgrading.md
+++ b/docs/self-hosting/upgrading.md
@@ -23,18 +23,34 @@ IMAGE_TAG=1.2.0
 2. **Review the release notes** for the target version (breaking changes, new required
    settings) on the [releases page](https://github.com/marcandreuf/memship/releases).
 
-3. **Bump the tag** in `.env`:
+3. **Pull the repository, not only the image tag:**
+
+   ```bash
+   cd /path/to/memship
+   git pull
+   ```
+
+   Part of a release ships in the git checkout rather than in the images — `docker-compose.yml`,
+   the `Caddyfile`, `scripts/install.sh`. Bumping `IMAGE_TAG` alone leaves an install
+   half-upgraded: the new backend running behind the old proxy configuration.
+
+4. **Bump the tag** in `.env`:
 
    ```bash
    IMAGE_TAG=1.3.0
    ```
 
-4. **Pull and recreate:**
+5. **Pull and recreate:**
 
    ```bash
    docker compose pull
    docker compose up -d
+   docker compose up -d --force-recreate caddy
    ```
+
+   The last line matters. The `Caddyfile` is bind-mounted, so changing its contents does not
+   change the container's configuration — `docker compose up -d` sees no reason to recreate
+   Caddy and leaves it serving the old one.
 
 ## Upgrading from a release before the non-root backend
 

--- a/scripts/db-backup.sh
+++ b/scripts/db-backup.sh
@@ -49,11 +49,26 @@ if ! docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -q
     exit 1
 fi
 
+# The db container runs as postgres, not as the deploy user, so anything it
+# writes into the bind mount lands root-owned and world-readable — a full copy of
+# the database that only the directory's mode is protecting. Hand each dump to
+# the account that owns the install, and take the read bit off the world.
+HOST_UID_VAL="${HOST_UID:-}"
+HOST_GID_VAL="${HOST_GID:-}"
+if [[ -f "$REPO_ROOT/.env" ]]; then
+    HOST_UID_VAL="${HOST_UID_VAL:-$(grep -E '^HOST_UID=' "$REPO_ROOT/.env" | tail -1 | cut -d= -f2- || true)}"
+    HOST_GID_VAL="${HOST_GID_VAL:-$(grep -E '^HOST_GID=' "$REPO_ROOT/.env" | tail -1 | cut -d= -f2- || true)}"
+fi
+HOST_UID_VAL="${HOST_UID_VAL:-$(id -u)}"
+HOST_GID_VAL="${HOST_GID_VAL:-$(id -g)}"
+
 # Run pg_dump inside the container and write to the bind-mounted /backups dir
 BACKUP_NAME="memship_${TIMESTAMP}.sql.gz"
 echo -e "${BLUE}i${NC} Creating backup..."
 docker compose -f "$COMPOSE_FILE" exec -T db \
-    sh -c "pg_dump -U memship -d memship_db --clean --if-exists | gzip > /backups/${BACKUP_NAME}"
+    sh -c "pg_dump -U memship -d memship_db --clean --if-exists | gzip > /backups/${BACKUP_NAME} \
+           && chown ${HOST_UID_VAL}:${HOST_GID_VAL} /backups/${BACKUP_NAME} \
+           && chmod 600 /backups/${BACKUP_NAME}"
 BACKUP_FILE="$BACKUP_DIR/$BACKUP_NAME"
 
 # Verify backup was created and has content

--- a/scripts/db-restore.sh
+++ b/scripts/db-restore.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 # Memship Database Restore
 # Restores a PostgreSQL backup from the backups/ directory
-# Usage: ./scripts/db-restore.sh [--dry-run|--confirm] [backup-file]
+# Usage: ./scripts/db-restore.sh [--dry-run|--confirm] [--yes] [backup-file]
+#
+# A restore drops the live database before it reads the dump, so a dump that
+# turns out to be unreadable would leave nothing behind. Three things guard
+# against that, in order: the archive is tested before anything is dropped, a
+# pre-restore dump of the current database is taken, and psql runs with
+# ON_ERROR_STOP=1 under `pipefail` so a failed load is reported as a failure
+# instead of being announced as success.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -32,13 +39,36 @@ NC='\033[0m'
 
 MODE="dry-run"
 BACKUP_FILE=""
+ASSUME_YES=0
 
-# Parse arguments
+usage() {
+    cat <<'EOF'
+memship — restore the database from a dump in the data root's backups/ directory.
+
+  ./scripts/db-restore.sh                        # dry run: pick a dump, show what would happen
+  ./scripts/db-restore.sh --confirm              # restore, asking for typed confirmation
+  ./scripts/db-restore.sh --confirm --yes FILE   # restore unattended (cron, scripted SSH)
+
+  --dry-run   Show what would happen and exit. The default.
+  --confirm   Actually restore.
+  --yes       Skip the typed confirmation. Required when there is no terminal,
+              and only meaningful together with --confirm and a named file.
+  FILE        A dump in the backups directory, or an absolute path. Without one
+              the script lists what it has and asks — which needs a terminal.
+
+The current database is dumped to memship_pre-restore_<timestamp>.sql.gz before
+anything is dropped, so a restore that goes wrong is recoverable.
+EOF
+}
+
 for arg in "$@"; do
     case "$arg" in
-        --dry-run)  MODE="dry-run" ;;
-        --confirm)  MODE="confirm" ;;
-        *)          BACKUP_FILE="$arg" ;;
+        --dry-run)      MODE="dry-run" ;;
+        --confirm)      MODE="confirm" ;;
+        --yes|--force)  ASSUME_YES=1 ;;
+        -h|--help)      usage; exit 0 ;;
+        -*)             echo "Unknown option: $arg" >&2; usage >&2; exit 2 ;;
+        *)              BACKUP_FILE="$arg" ;;
     esac
 done
 
@@ -68,10 +98,24 @@ if [[ -z "$BACKUP_FILE" ]]; then
     done < <(ls -t "$BACKUP_DIR"/memship_*.sql.gz)
 
     echo ""
-    read -p "Select backup number [1]: " choice < /dev/tty
+
+    # The picker needs somewhere to read from. A scripted SSH command, a cron job
+    # and a CI step all have no terminal, and a restore is exactly the kind of
+    # thing that gets run that way — so say what to do instead of dying on
+    # /dev/tty with a device error.
+    # Testing -r /dev/tty is not enough: the device node exists and looks
+    # readable even with no controlling terminal, and only the open fails.
+    if ! : 2>/dev/null < /dev/tty; then
+        echo -e "${RED}x${NC} No terminal to ask which backup to use."
+        echo "Name one on the command line instead:"
+        echo "  ./scripts/db-restore.sh --confirm --yes $(basename "${BACKUPS[1]}")"
+        exit 1
+    fi
+
+    read -r -p "Select backup number [1]: " choice < /dev/tty
     choice=${choice:-1}
 
-    BACKUP_FILE="${BACKUPS[$choice]}"
+    BACKUP_FILE="${BACKUPS[$choice]:-}"
     if [[ -z "$BACKUP_FILE" ]]; then
         echo -e "${RED}x${NC} Invalid selection"
         exit 1
@@ -100,10 +144,12 @@ if [[ "$MODE" == "dry-run" ]]; then
     echo -e "${YELLOW}DRY RUN — no changes will be made${NC}"
     echo ""
     echo "This would:"
-    echo "  1. Stop the API container"
-    echo "  2. Drop and recreate the memship_db database"
-    echo "  3. Restore from: $(basename "$BACKUP_FILE")"
-    echo "  4. Restart all containers"
+    echo "  1. Check the archive is readable"
+    echo "  2. Dump the current database alongside it, as a fallback"
+    echo "  3. Stop the API container"
+    echo "  4. Drop and recreate the memship_db database"
+    echo "  5. Restore from: $(basename "$BACKUP_FILE")"
+    echo "  6. Restart all containers"
     echo ""
     echo "To execute, run:"
     echo "  ./scripts/db-restore.sh --confirm $(basename "$BACKUP_FILE")"
@@ -111,13 +157,23 @@ if [[ "$MODE" == "dry-run" ]]; then
 fi
 
 # Confirm mode — require explicit confirmation
-echo -e "${RED}${BOLD}WARNING: This will DELETE all current data and restore from backup.${NC}"
-echo ""
-read -p "Type 'yes-restore-now' to confirm: " confirmation < /dev/tty
+if [[ "$ASSUME_YES" -eq 1 ]]; then
+    echo -e "${YELLOW}!${NC} --yes given: restoring without confirmation."
+else
+    echo -e "${RED}${BOLD}WARNING: This will DELETE all current data and restore from backup.${NC}"
+    echo ""
 
-if [[ "$confirmation" != "yes-restore-now" ]]; then
-    echo -e "${YELLOW}Restore cancelled${NC}"
-    exit 0
+    if ! : 2>/dev/null < /dev/tty; then
+        echo -e "${RED}x${NC} No terminal to confirm at. Pass --yes to restore unattended."
+        exit 1
+    fi
+
+    read -r -p "Type 'yes-restore-now' to confirm: " confirmation < /dev/tty
+
+    if [[ "$confirmation" != "yes-restore-now" ]]; then
+        echo -e "${YELLOW}Restore cancelled${NC}"
+        exit 0
+    fi
 fi
 
 echo ""
@@ -127,6 +183,55 @@ if ! docker compose -f "$COMPOSE_FILE" ps --status running 2>/dev/null | grep -q
     echo -e "${RED}x${NC} Database container is not running"
     echo "Start it with: docker compose up -d db"
     exit 1
+fi
+
+# Check the archive BEFORE dropping anything. A truncated or half-copied dump is
+# the common case, and finding out after the drop is what turns a bad backup
+# into a lost database.
+echo -e "${BLUE}i${NC} Checking the archive..."
+if ! gunzip -t "$BACKUP_FILE" 2>/dev/null; then
+    echo -e "${RED}x${NC} $(basename "$BACKUP_FILE") is not a readable gzip archive."
+    echo "Nothing has been changed. Pick another dump."
+    exit 1
+fi
+# Read the head into a variable rather than piping straight into grep: `head`
+# closing the pipe early kills gunzip with SIGPIPE, and under `pipefail` that
+# would fail the check on a perfectly good dump.
+DUMP_HEAD="$(gunzip -c "$BACKUP_FILE" 2>/dev/null | head -c 65536 || true)"
+if ! grep -q "PostgreSQL database dump" <<<"$DUMP_HEAD"; then
+    echo -e "${RED}x${NC} $(basename "$BACKUP_FILE") does not look like a pg_dump file."
+    echo "Nothing has been changed."
+    exit 1
+fi
+
+# Take a fallback dump of what is about to be destroyed. Named memship_* so
+# db-backup.sh's retention sweep ages it out like any other dump.
+SAFETY_NAME="memship_pre-restore_$(date +"%Y%m%d_%H%M%S").sql.gz"
+echo -e "${BLUE}i${NC} Dumping the current database first (${SAFETY_NAME})..."
+
+# Same ownership dance as db-backup.sh: the db container writes as root, and this
+# script has to be able to read the dump back off the host to undo a bad restore.
+HOST_UID_VAL="${HOST_UID:-}"
+HOST_GID_VAL="${HOST_GID:-}"
+if [[ -f "$REPO_ROOT/.env" ]]; then
+    HOST_UID_VAL="${HOST_UID_VAL:-$(grep -E '^HOST_UID=' "$REPO_ROOT/.env" | tail -1 | cut -d= -f2- || true)}"
+    HOST_GID_VAL="${HOST_GID_VAL:-$(grep -E '^HOST_GID=' "$REPO_ROOT/.env" | tail -1 | cut -d= -f2- || true)}"
+fi
+HOST_UID_VAL="${HOST_UID_VAL:-$(id -u)}"
+HOST_GID_VAL="${HOST_GID_VAL:-$(id -g)}"
+
+if docker compose -f "$COMPOSE_FILE" exec -T db \
+        sh -c "pg_dump -U memship -d memship_db --clean --if-exists | gzip > /backups/${SAFETY_NAME} \
+               && chown ${HOST_UID_VAL}:${HOST_GID_VAL} /backups/${SAFETY_NAME} \
+               && chmod 600 /backups/${SAFETY_NAME}" \
+   && [[ -s "$BACKUP_DIR/$SAFETY_NAME" ]]; then
+    echo -e "${GREEN}+${NC} Fallback saved: $SAFETY_NAME"
+    SAFETY_FILE="$BACKUP_DIR/$SAFETY_NAME"
+else
+    # An unreadable current database is a reason to restore, not to refuse.
+    echo -e "${YELLOW}!${NC} Could not dump the current database — continuing without a fallback."
+    rm -f "$BACKUP_DIR/$SAFETY_NAME"
+    SAFETY_FILE=""
 fi
 
 # Stop API to prevent connections during restore
@@ -140,10 +245,29 @@ docker compose -f "$COMPOSE_FILE" exec -T db \
 docker compose -f "$COMPOSE_FILE" exec -T db \
     psql -U memship -d postgres -c "CREATE DATABASE memship_db OWNER memship;"
 
-# Restore from backup
+# Restore from backup. ON_ERROR_STOP makes psql exit non-zero on the first failed
+# statement; pipefail (set above) makes that the pipeline's status rather than
+# gunzip's. Without both, a dump that fails every statement still reports success.
 echo -e "${BLUE}i${NC} Restoring from backup..."
-gunzip -c "$BACKUP_FILE" | docker compose -f "$COMPOSE_FILE" exec -T db \
-    psql -U memship -d memship_db --quiet
+if ! gunzip -c "$BACKUP_FILE" | docker compose -f "$COMPOSE_FILE" exec -T db \
+        psql -U memship -d memship_db --quiet -v ON_ERROR_STOP=1; then
+    echo ""
+    echo -e "${RED}${BOLD}=== RESTORE FAILED ===${NC}"
+    echo -e "  The dump did not load. The database is now incomplete."
+    echo ""
+    echo -e "  The API has been left stopped on purpose. Starting it would run"
+    echo -e "  migrations against the half-restored database and leave you with a"
+    echo -e "  healthy-looking, empty instance."
+    echo ""
+    if [[ -n "$SAFETY_FILE" ]]; then
+        echo -e "  Put back what you had before this run:"
+        echo -e "    ./scripts/db-restore.sh --confirm $(basename "$SAFETY_FILE")"
+    else
+        echo -e "  There is no fallback dump from this run — restore from another backup."
+    fi
+    echo ""
+    exit 1
+fi
 
 # Restart all services
 echo -e "${BLUE}i${NC} Restarting services..."
@@ -152,4 +276,7 @@ docker compose -f "$COMPOSE_FILE" up -d
 echo ""
 echo -e "${GREEN}=== Restore complete ===${NC}"
 echo -e "  Restored from: $(basename "$BACKUP_FILE")"
+if [[ -n "$SAFETY_FILE" ]]; then
+    echo -e "  Previous database kept as: $(basename "$SAFETY_FILE")"
+fi
 echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -290,6 +290,14 @@ docker compose pull
 step "Starting"
 docker compose up -d
 
+# Caddy's configuration is a bind-mounted file, not part of its image, so Compose
+# sees nothing to change when the Caddyfile's contents change and leaves the
+# container running the old one. That makes re-running this script — the
+# documented way to upgrade — silently skip any proxy change a release ships,
+# which is how a 2.3.0 upgrade could end up serving no security headers.
+step "Reloading the proxy"
+docker compose up -d --force-recreate caddy
+
 step "Done"
 cat <<EOF
 
@@ -328,7 +336,8 @@ cat <<EOF
   Then:  docker compose ps       # check everything is up
          docker compose logs -f  # watch it start
 
-  Upgrading later: set IMAGE_TAG in .env and re-run this script.
+  Upgrading later: git pull, set IMAGE_TAG in .env, re-run this script.
+                   Full procedure: docs/self-hosting/upgrading.md
   Backups: docs/self-hosting/backups-and-restore.md
 
 EOF


### PR DESCRIPTION
**Base is #61**, which this stacks on — the walkthrough tested `upgrading.md` as that PR rewrote it. GitHub will retarget to `main` once #61 merges.

Walked the whole self-hosting story on a clean Docker host: fresh clone at **v2.2.0** → `install.sh` → seed with demo data → `db-backup.sh` → `db-restore.sh` → upgrade to **v2.3.0** by both documented paths → "Installing by hand". Every defect below was **reproduced by running it**. Full log: `projects/tmp/selfhost-walkthrough-defects-2026-08-19.md`.

## A failed restore reported success and left the database empty

The one that matters. `db-restore.sh` had `set -e` but not `pipefail`, ran `psql` without `ON_ERROR_STOP=1`, and dropped the database *before* reading the dump. Fed a corrupt dump:

```
ERROR:  syntax error at or near "this"
=== Restore complete ===          <- green, exit 0
```

`docker compose up -d` then restarted the API, which ran migrations against the dropped database and recreated all 42 tables **empty**. Final state: `/api/v1/health` → `"healthy"`, login → **401**, no members. An operator restoring under pressure from a truncated dump got a green light and an empty club.

Now: the archive is checked before anything is dropped, the current database is dumped to `memship_pre-restore_<ts>.sql.gz` first, `psql` runs with `ON_ERROR_STOP=1` under `pipefail`, and a failure says so, exits 1 and **leaves the API stopped** — starting it is what turned a failure into a healthy-looking empty instance. Verified: corrupt dump refused before the drop with data intact; a dump failing mid-load reported failure and its fallback restored cleanly.

Also adds `--yes`. The script read `/dev/tty` twice with no bypass, so a restore could never run from cron or a scripted `ssh` — which is exactly how restores get run.

## The recommended upgrade path left the API unprotected

`install.sh` never recreated Caddy, and both its own banner and `installation.md:68` said *"set `IMAGE_TAG` and re-run this script"*. Upgrading 2.2.0 → 2.3.0 that way:

| Endpoint | Security headers |
|---|---|
| `/` | 4 — but they come from the **frontend image**, not Caddy |
| `/api/v1/health` | **none** |

So the homepage looks protected while every API response is bare. Caddy sat at `Up 30 minutes` throughout. After the fix it goes to `Up Less than a second` and the API serves 5/5.

## Docs that could not work

- **The unattended setup command was broken in both snippets.** `docker compose exec` does not forward the calling shell's environment, so `MEMSHIP_ADMIN_PASSWORD` arrived unset and setup stopped immediately. Needs `-e`.
- **"Installing by hand"** told you to set `MEMSHIP_DATA_ROOT` in `.env`, then used `$MEMSHIP_DATA_ROOT` in a `mkdir` the shell had never read it into — `mkdir: cannot create directory '/postgres'`. The rest of that path is sound; it now works end to end.
- **The `0700`-home warning was false.** Ran the whole install with the data root under a `0750` home; Postgres was fine. Bind-mount sources are resolved by the daemon as root and ancestor permissions are not re-checked in the container. Rewritten to keep the `/srv` recommendation and give the real reason — rootless Docker and Podman.
- **`README.md` carried a third, diverging copy of the install guide**: no `install.sh`, no data root, `IMAGE_TAG=0.1.3`, and *"at minimum change `SECRET_KEY`"* when #56 made that placeholder a hard refusal. Collapsed to pointers.
- **Two contradictory upgrade procedures** now have one canonical home.

## New and corrected

- **`docs/self-hosting/troubleshooting.md`** — was listed as _planned_. Covers what this walkthrough hit: container-name conflicts, root-owned bind mounts, missing headers after an upgrade, restores that fail or want a terminal, and how to tell which version is running.
- **Two memship stacks cannot share a host** — `container_name` is global to the daemon, so a second instance fails with `Conflict. The container name "/memship-db" is already in use` even from another directory with its own data root. Nothing said so.
- **Docs index corrected both ways**: reverse proxy & TLS have shipped; **Simple Bookings is released**, not on a branch — `/api/v1/bookings` is in the image and the seeder creates spaces, slots and a waitlist. It still has no guide page, now recorded as a gap.
- Backup dumps were root-owned and world-readable; now `600` and owned by the deploy user.

## Verified working, not just changed

`install.sh` on a clean host first try; the data-root layout; `db-backup.sh`; **`db-restore.sh` on the happy path — its first exercise ever**, 68 receipts destroyed and recovered with login returning 200; the by-hand install with exactly the six documented variables; and `--force-recreate caddy` being genuinely required.

## Not covered

SELinux `:z` (needs a RHEL-family host), TLS issuance (deliberately, to avoid spending Let's Encrypt certificates), and upgrades across a schema migration — 2.2.0 → 2.3.0 has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D54Bvm9wPe6bfF8Y5b9sti