### PR TITLE
Harden and document the local dev environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ Full reference: [docs/development/local-environment.md](docs/development/local-e
 ./scripts/dev.sh logs backend    # View API logs
 ./scripts/dev.sh logs frontend   # View frontend logs
 ./scripts/dev.sh seed            # Run initial setup (interactive)
+./scripts/dev.sh seed demo       # Demo club with generated credentials (prefer this)
+./scripts/dev.sh passwd          # Replace the super admin password with a generated one
 ./scripts/dev.sh test            # Run backend tests
 ./scripts/dev.sh start backend   # Start only backend (Docker)
 ./scripts/dev.sh start frontend  # Start only frontend (local)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ When scoping any feature before v1.0.0:
 - Per-provider depth is sugar when another path already covers the same user need. Defer.
 - Don't add edge-case hardening that doesn't block normal flows.
 
-Full strategic context lives in `memship-definition/CLAUDE.md` and `docs/STATUS.md`.
+Full strategic context lives in the private `memship-context` repo (`docs/`, `STATUS.md`).
 
 **Tech stack:**
 - Backend: Python 3.12+ / FastAPI / SQLAlchemy 2.0 / Alembic
@@ -30,6 +30,9 @@ Full strategic context lives in `memship-definition/CLAUDE.md` and `docs/STATUS.
 ## Commands
 
 ### Dev Environment (recommended)
+
+Full reference: [docs/development/local-environment.md](docs/development/local-environment.md).
+
 ```bash
 ./scripts/dev.sh start all       # Start backend (Docker) + frontend (local)
 ./scripts/dev.sh stop all        # Stop everything
@@ -78,13 +81,18 @@ pnpm cypress:run --spec 'cypress/e2e/auth/login.cy.ts'   # Single spec
 route on first request; with 4 workers sharing one dev server that stall pushes
 navigations past their timeouts, so specs fail — or pass only on retry — and
 which ones fail changes between runs. `test:parallel:prod` builds, serves, runs
-and tears down. Measured on the same commit: 167/167 with no retries in 15m
-against a production build, versus 165–166/167 with ~12 retry-only passes in
-68m against the dev server.
+and tears down. Measured on one commit when the suite was 167 tests: a clean
+run with no retries in 15m against a production build, versus ~12 retry-only
+passes in 68m against the dev server. The suite has grown since, so treat the
+counts as historical and the conclusion as current.
 
 Retries mask this, so read the failure screenshots in `cypress/screenshots/`
 (gitignored, overwritten each run) — a screenshot with no "attempt N" suffix
 means a test failed once and passed on retry. A clean run leaves none.
+
+Intermittent retry-only passes under parallel load are a known open problem —
+see issue #58. Treat a run that only passes on retry as a failure to explain,
+not a pass.
 
 ### Docker (backend services)
 ```bash

--- a/README.ca.md
+++ b/README.ca.md
@@ -214,85 +214,20 @@ Les variacions complexes es construeixen sota demanda, quan una implementació r
 
 ## Desenvolupament
 
-### Inici ràpid
-
-Inicieu els serveis del backend (Docker) i el servidor de desenvolupament del frontend (local):
-
-```bash
-./scripts/dev.sh start all
-```
-
-Comproveu l'estat:
+El backend en Docker i el frontend en local amb recàrrega en calent de pnpm, governats per
+`scripts/dev.sh`:
 
 ```bash
+./scripts/dev.sh start all      # backend (Docker) + frontend (local)
 ./scripts/dev.sh status
+./scripts/dev.sh test           # tests del backend
 ```
 
-Atureu-ho tot:
+La instal·lació completa, totes les ordres, les URL dels serveis, la càrrega de dades inicial i les
+suites de tests són a
+**[Entorn de desenvolupament local](docs/development/local-environment.md)** _(en anglès)_.
 
-```bash
-./scripts/dev.sh stop all
-```
-
-### Comandes de desenvolupament
-
-| Comanda | Descripció |
-|---------|-----------|
-| `./scripts/dev.sh start all` | Iniciar backend (Docker) + frontend (local) |
-| `./scripts/dev.sh start backend` | Iniciar només el backend (API + BD en Docker) |
-| `./scripts/dev.sh start frontend` | Iniciar només el frontend (Next.js local) |
-| `./scripts/dev.sh stop all` | Aturar tots els serveis |
-| `./scripts/dev.sh restart all` | Reiniciar tots els serveis |
-| `./scripts/dev.sh status` | Mostrar l'estat de tots els serveis |
-| `./scripts/dev.sh logs backend` | Veure els registres de l'API |
-| `./scripts/dev.sh logs frontend` | Veure els registres del frontend (tail -f) |
-| `./scripts/dev.sh logs worker` | Veure els registres del worker de Celery |
-| `./scripts/dev.sh logs beat` | Veure els registres de Celery beat (planificador) |
-| `./scripts/dev.sh seed` | Executar la configuració inicial de la base de dades (interactiva) |
-| `./scripts/dev.sh seed test` | Inicialitzar amb comptes de prova (sense preguntes) |
-| `./scripts/dev.sh test` | Executar les proves del backend |
-
-`start all` aixeca el worker i el beat de Celery juntament amb l'API i la base de dades. `worker` i `beat` també són destinacions vàlides per a `start`, `stop` i `restart` si els necessites controlar per separat.
-
-> **Afegeixes una dependència del backend?** Les dependències de Python estan integrades a la imatge de Docker — `pyproject.toml` no es munta com a volum — així que una dependència nova no hi serà al contenidor en execució fins que el reconstrueixis:
->
-> ```bash
-> docker compose -f backend/docker/docker-compose.yml build --no-cache api
-> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
-> ```
-
-### URLs dels serveis
-
-- **Frontend**: http://localhost:3000
-- **API del backend**: http://localhost:8003
-- **Documentació de l'API (Swagger)**: http://localhost:8003/api/docs
-- **Base de dades**: localhost:5433
-- **Adminer** (UI de BD): http://localhost:8181 (iniciar amb `--profile tools`)
-
-### Fitxers de registre
-
-- Frontend: `frontend/logs/dev-server.log`
-- Backend: `docker compose -f backend/docker/docker-compose.yml logs -f api`
-
-### Primera configuració
-
-Després d'iniciar els serveis, executeu la comanda de configuració per crear les dades inicials:
-
-```bash
-./scripts/dev.sh seed          # Interactiu — la mateixa configuració que fa servir qualsevol entorn
-./scripts/dev.sh seed test     # Comptes de prova fixos + dades d'exemple, per a la suite e2e
-```
-
-`seed test` crea els comptes amb què inicia sessió la suite de Cypress, a més de 4 activitats
-d'exemple amb modalitats i preus, inscripcions d'exemple i ~22 socis addicionals. Les adreces i
-contrasenyes són un contracte amb la suite de proves, no una decisió de configuració, així que
-viuen al seu costat, a
-[`e2e/cypress/support/commands.ts`](e2e/cypress/support/commands.ts).
-
-> **`seed test` es nega a executar-se fora de desenvolupament.** Crea contrasenyes fixes i
-> visibles al repositori, així que exigeix `APP_ENV=development` o `CI` i acaba en cas
-> contrari. Per a qualsevol ús real, feu servir la configuració interactiva — consulteu
-> [Configuració inicial](docs/getting-started/first-setup.md).
+Consulta [CONTRIBUTING](CONTRIBUTING.md) per a branques, versionat i com es publica una versió.
 
 ## Instal·lació (Docker)
 

--- a/README.es.md
+++ b/README.es.md
@@ -214,85 +214,20 @@ Las variaciones complejas se construyen bajo demanda, cuando una implementación
 
 ## Desarrollo
 
-### Inicio rápido
-
-Arranca los servicios backend (Docker) y el servidor de desarrollo frontend (local):
-
-```bash
-./scripts/dev.sh start all
-```
-
-Comprobar estado:
+El backend en Docker y el frontend en local con recarga en caliente de pnpm, gobernados por
+`scripts/dev.sh`:
 
 ```bash
+./scripts/dev.sh start all      # backend (Docker) + frontend (local)
 ./scripts/dev.sh status
+./scripts/dev.sh test           # tests del backend
 ```
 
-Parar todo:
+La instalación completa, todos los comandos, las URL de los servicios, la carga de datos inicial y
+las suites de tests están en
+**[Entorno de desarrollo local](docs/development/local-environment.md)** _(en inglés)_.
 
-```bash
-./scripts/dev.sh stop all
-```
-
-### Comandos de desarrollo
-
-| Comando | Descripción |
-|---------|-------------|
-| `./scripts/dev.sh start all` | Iniciar backend (Docker) + frontend (local) |
-| `./scripts/dev.sh start backend` | Iniciar solo backend (API + BD en Docker) |
-| `./scripts/dev.sh start frontend` | Iniciar solo frontend (Next.js local) |
-| `./scripts/dev.sh stop all` | Parar todos los servicios |
-| `./scripts/dev.sh restart all` | Reiniciar todos los servicios |
-| `./scripts/dev.sh status` | Ver estado de todos los servicios |
-| `./scripts/dev.sh logs backend` | Ver logs de la API |
-| `./scripts/dev.sh logs frontend` | Ver logs del frontend (tail -f) |
-| `./scripts/dev.sh logs worker` | Ver logs del worker de Celery |
-| `./scripts/dev.sh logs beat` | Ver logs de Celery beat (planificador) |
-| `./scripts/dev.sh seed` | Ejecutar configuración inicial de la BD (interactivo) |
-| `./scripts/dev.sh seed test` | Seed con cuentas de prueba (sin preguntas) |
-| `./scripts/dev.sh test` | Ejecutar tests del backend |
-
-`start all` levanta el worker y el beat de Celery junto con la API y la base de datos. `worker` y `beat` también son destinos válidos para `start`, `stop` y `restart` si necesitas controlarlos por separado.
-
-> **¿Añades una dependencia del backend?** Las dependencias de Python están integradas en la imagen de Docker — `pyproject.toml` no se monta como volumen — así que una dependencia nueva no estará en el contenedor en ejecución hasta que lo reconstruyas:
->
-> ```bash
-> docker compose -f backend/docker/docker-compose.yml build --no-cache api
-> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
-> ```
-
-### URLs de los servicios
-
-- **Frontend**: http://localhost:3000
-- **API Backend**: http://localhost:8003
-- **Documentación API (Swagger)**: http://localhost:8003/api/docs
-- **Base de datos**: localhost:5433
-- **Adminer** (UI de BD): http://localhost:8181 (iniciar con `--profile tools`)
-
-### Archivos de log
-
-- Frontend: `frontend/logs/dev-server.log`
-- Backend: `docker compose -f backend/docker/docker-compose.yml logs -f api`
-
-### Primera configuración
-
-Tras iniciar los servicios, ejecuta el comando de configuración para crear los datos iniciales:
-
-```bash
-./scripts/dev.sh seed          # Interactivo — la misma configuración que usa cualquier entorno
-./scripts/dev.sh seed test     # Cuentas de prueba fijas + datos de ejemplo, para la suite e2e
-```
-
-`seed test` crea las cuentas con las que inicia sesión la suite de Cypress, además de 4
-actividades de ejemplo con modalidades y precios, inscripciones de ejemplo y ~22 socios
-adicionales. Las direcciones y contraseñas son un contrato con la suite de pruebas, no una
-decisión de configuración, así que viven junto a ella, en
-[`e2e/cypress/support/commands.ts`](e2e/cypress/support/commands.ts).
-
-> **`seed test` se niega a ejecutarse fuera de desarrollo.** Crea contraseñas fijas y visibles
-> en el repositorio, así que exige `APP_ENV=development` o `CI` y termina en caso contrario.
-> Para cualquier uso real, usa la configuración interactiva — consulta
-> [Configuración inicial](docs/getting-started/first-setup.md).
+Consulta [CONTRIBUTING](CONTRIBUTING.md) para ramas, versionado y cómo se publica una versión.
 
 ## Instalación (Docker)
 

--- a/README.md
+++ b/README.md
@@ -215,84 +215,18 @@ Complex variations are built on demand, when a real deployment needs them: GoCar
 
 ## Development
 
-### Quick Start
-
-Start backend services (Docker) and frontend dev server (local):
+Backend in Docker, frontend locally with pnpm hot reload — driven by `scripts/dev.sh`:
 
 ```bash
-./scripts/dev.sh start all
-```
-
-Check status:
-
-```bash
+./scripts/dev.sh start all      # backend (Docker) + frontend (local)
 ./scripts/dev.sh status
+./scripts/dev.sh test           # backend suite
 ```
 
-Stop everything:
+Full setup, every command, service URLs, seeding and the test suites are in
+**[Local development environment](docs/development/local-environment.md)**.
 
-```bash
-./scripts/dev.sh stop all
-```
-
-### Dev Commands
-
-| Command | Description |
-|---------|-------------|
-| `./scripts/dev.sh start all` | Start backend (Docker) + frontend (local) |
-| `./scripts/dev.sh start backend` | Start only backend (API + DB in Docker) |
-| `./scripts/dev.sh start frontend` | Start only frontend (Next.js local) |
-| `./scripts/dev.sh stop all` | Stop all services |
-| `./scripts/dev.sh restart all` | Restart all services |
-| `./scripts/dev.sh status` | Show status of all services |
-| `./scripts/dev.sh logs backend` | View API logs |
-| `./scripts/dev.sh logs frontend` | View frontend logs (tail -f) |
-| `./scripts/dev.sh logs worker` | View Celery worker logs |
-| `./scripts/dev.sh logs beat` | View Celery beat (scheduler) logs |
-| `./scripts/dev.sh seed` | Run initial database setup (interactive) |
-| `./scripts/dev.sh seed test` | Seed with test accounts (no prompts) |
-| `./scripts/dev.sh test` | Run backend tests |
-
-`start all` brings up the Celery worker and beat along with the API and database. `worker` and `beat` are also valid targets for `start`, `stop` and `restart` if you need to control them on their own.
-
-> **Adding a backend dependency?** Python dependencies are baked into the Docker image — `pyproject.toml` is not bind-mounted — so a new dependency will be missing from the running container until you rebuild it:
->
-> ```bash
-> docker compose -f backend/docker/docker-compose.yml build --no-cache api
-> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
-> ```
-
-### Service URLs
-
-- **Frontend**: http://localhost:3000
-- **Backend API**: http://localhost:8003
-- **API Docs (Swagger)**: http://localhost:8003/api/docs
-- **Database**: localhost:5433
-- **Adminer** (DB UI): http://localhost:8181 (start with `--profile tools`)
-
-### Log Files
-
-- Frontend: `frontend/logs/dev-server.log`
-- Backend: `docker compose -f backend/docker/docker-compose.yml logs -f api`
-
-### First Time Setup
-
-After starting the services, run the setup command to create initial data:
-
-```bash
-./scripts/dev.sh seed          # Interactive — the same setup every environment uses
-./scripts/dev.sh seed test     # Fixed test accounts + sample data, for the e2e suite
-```
-
-`seed test` creates the accounts the Cypress suite signs in as, plus 4 sample activities with
-modalities and prices, sample registrations, and ~22 extra members. The addresses and passwords
-are a contract with the test suite rather than a seeding choice, so they live with it, in
-[`e2e/cypress/support/commands.ts`](e2e/cypress/support/commands.ts).
-
-> **`seed test` refuses to run outside development.** It plants fixed, repository-visible
-> passwords, so it requires `APP_ENV=development` or `CI` and exits otherwise. For anything
-> real, use the interactive setup — see
-> [First-time setup](docs/getting-started/first-setup.md).
+See [CONTRIBUTING](CONTRIBUTING.md) for branching, versioning and how a release is cut.
 
 ## Installation (Docker)
 

--- a/backend/app/cli/seed.py
+++ b/backend/app/cli/seed.py
@@ -383,7 +383,15 @@ def create_user_with_member(
 ) -> None:
     existing = db.query(User).filter_by(email=details["email"]).first()
     if existing:
-        print(f"  {role} user: already exists ({details['email']})")
+        # These accounts and their passwords are a contract with the Cypress
+        # suite, so this has to converge on the known state rather than merely
+        # leave the row alone. Skipping meant that once the password had been
+        # changed — by `dev.sh passwd`, or by hand — reseeding never put it back
+        # and the suite failed on a login it had no reason to doubt. Development
+        # and CI only: the caller already refuses to run anywhere else.
+        existing.password_hash = ph.hash(details["password"])
+        db.flush()
+        print(f"  {role} user: exists, password set to the fixed test one")
         return
 
     person = Person(

--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -1,3 +1,8 @@
+# The dev stack ships weak-on-purpose settings: a fixed database password, Redis
+# with no auth, and — after `dev.sh seed test` — super admin credentials that are
+# published in this repository. Publishing those ports on 0.0.0.0 put all of it on
+# the local network. They bind to loopback instead; set DEV_BIND=0.0.0.0 for the
+# session when you deliberately need another device to reach the stack.
 services:
   api:
     build:
@@ -5,7 +10,7 @@ services:
       dockerfile: docker/Dockerfile
     container_name: memship-api
     ports:
-      - "8003:8000"
+      - "${DEV_BIND:-127.0.0.1}:8003:8000"
     environment:
       - DATABASE_URL=postgresql://memship:memship@db:5432/memship_db
       - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-in-production}
@@ -32,7 +37,7 @@ services:
     image: redis:7-alpine
     container_name: memship-redis
     ports:
-      - "6379:6379"
+      - "${DEV_BIND:-127.0.0.1}:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -92,7 +97,7 @@ services:
     image: postgres:15-alpine
     container_name: memship-db
     ports:
-      - "5433:5432"
+      - "${DEV_BIND:-127.0.0.1}:5433:5432"
     environment:
       - POSTGRES_USER=memship
       - POSTGRES_PASSWORD=memship
@@ -110,7 +115,7 @@ services:
     image: postgres:15-alpine
     container_name: memship-db-test
     ports:
-      - "5434:5432"
+      - "${DEV_BIND:-127.0.0.1}:5434:5432"
     environment:
       - POSTGRES_USER=memship
       - POSTGRES_PASSWORD=memship
@@ -129,7 +134,7 @@ services:
     image: adminer
     container_name: memship-adminer
     ports:
-      - "8181:8080"
+      - "${DEV_BIND:-127.0.0.1}:8181:8080"
     profiles:
       - tools
     restart: unless-stopped

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,14 @@ Running Memship on your own server.
   [Configuration reference](self-hosting/configuration.md)
 - Payment providers (Stripe, Redsys/Bizum) — _planned_
 
+## Development (contributors)
+
+Working on Memship itself.
+
+- [Local development environment](development/local-environment.md) — the dev stack, commands,
+  seeding and the test suites _(EN)_
+- [Contributing](../CONTRIBUTING.md) — branching, versioning and how a release is cut _(EN)_
+
 ## Guía del administrador (admin guide)
 
 Para el personal que gestiona la organización desde el panel de administración.

--- a/docs/development/local-environment.md
+++ b/docs/development/local-environment.md
@@ -1,0 +1,184 @@
+# Local development environment
+
+The backend runs in Docker (API, Celery worker and beat, PostgreSQL, Redis); the frontend runs
+locally with pnpm, so you get Next.js hot reload without a container in the way.
+
+`scripts/dev.sh` drives all of it.
+
+## Prerequisites
+
+| Tool | Why |
+|---|---|
+| Docker Engine + Compose plugin | The backend stack |
+| Node.js and **pnpm** | The frontend dev server |
+| **uv** | Backend dependencies and the test run, which happen on the host rather than in a container |
+
+## Start
+
+```bash
+./scripts/dev.sh start all      # backend in Docker + frontend locally
+./scripts/dev.sh status         # what is up
+./scripts/dev.sh stop all       # stop everything
+```
+
+> **The first `start all` on a clean machine can fail** with
+> `failed to mkdir /var/lib/docker/volumes/docker_memship-storage/_data/<dir>: file exists`.
+> The API, the Celery worker and beat all mount the same `memship-storage` volume and are created
+> at the same time, so Docker's own volume setup races with itself. It is not a memship error and
+> nothing is broken — **run the command again** and it starts cleanly. Only the first start on a
+> given volume is affected.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `./scripts/dev.sh start all` | Start backend (Docker) + frontend (local) |
+| `./scripts/dev.sh start backend` | Start only the backend — API, DB, Redis, worker, beat |
+| `./scripts/dev.sh start frontend` | Start only the Next.js dev server |
+| `./scripts/dev.sh stop all` | Stop all services |
+| `./scripts/dev.sh restart all` | Restart all services |
+| `./scripts/dev.sh status` | Status of every service |
+| `./scripts/dev.sh logs backend` | API logs |
+| `./scripts/dev.sh logs frontend` | Frontend logs (`tail -f`) |
+| `./scripts/dev.sh logs worker` | Celery worker logs |
+| `./scripts/dev.sh logs beat` | Celery beat (scheduler) logs |
+| `./scripts/dev.sh seed` | Interactive setup — the same one every environment uses |
+| `./scripts/dev.sh seed test` | Fixed e2e test accounts and sample data |
+| `./scripts/dev.sh test` | Backend test suite |
+| `./scripts/dev.sh e2e` | Cypress, headless |
+| `./scripts/dev.sh e2e:open` | Cypress GUI |
+| `./scripts/dev.sh e2e:parallel` | Cypress, 4 workers |
+| `./scripts/dev.sh reset` | **Destructive** — see below |
+
+`start`, `stop` and `restart` take `backend`, `frontend`, `worker`, `beat` or `all` (the default).
+`start all` brings up the worker and beat alongside the API and database.
+
+> **`reset` deletes your volumes.** It runs `docker compose down -v`, which destroys the dev
+> database *and* the storage volume — uploads and `storage/secret.key` with it. Losing that key
+> means any payment-provider or SSO credentials stored in that database can no longer be
+> decrypted. There is no confirmation prompt. Use it when you want a clean slate, not to fix a
+> stuck container.
+
+## Service URLs
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:3000 |
+| Backend API | http://localhost:8003 |
+| API docs (Swagger) | http://localhost:8003/api/docs |
+| Database | localhost:5433 |
+| Test database | localhost:5434 (started by `dev.sh test`) |
+| Redis | localhost:6379 |
+| Adminer (DB UI) | http://localhost:8181 — not started by `dev.sh`, see below |
+
+Adminer sits behind a Compose profile and has no `dev.sh` command:
+
+```bash
+docker compose -f backend/docker/docker-compose.yml --profile tools up -d adminer
+```
+
+## The dev stack is not hardened, and by default it is only on localhost
+
+The dev stack ships deliberately weak settings: a fixed database password (`memship`), Redis with
+no authentication, and — after `seed test` — **super admin credentials that are published in this
+repository**. That is fine for a laptop and disastrous on a shared network, so the published ports
+bind to `127.0.0.1` only.
+
+If you need to reach the stack from another device — a phone testing the mobile layout, a VM —
+override the bind address for that session:
+
+```bash
+DEV_BIND=0.0.0.0 ./scripts/dev.sh start backend
+```
+
+Do that only on a network you trust, and never on a stack seeded with `seed test`: those accounts
+are in this repository, so anyone who can reach port 8003 can sign in as a super admin. The
+frontend dev server binds to all interfaces on its own — that is Next.js's default and it serves no
+data without the API.
+
+## First-time setup
+
+```bash
+./scripts/dev.sh seed          # interactive, the same setup every environment uses
+./scripts/dev.sh seed test     # fixed test accounts + sample data, for the e2e suite
+```
+
+`seed test` creates the accounts the Cypress suite signs in as, plus 4 sample activities with
+modalities and prices, sample registrations, and ~22 extra members. Those addresses and passwords
+are a contract with the test suite rather than a seeding choice, so they live with it in
+[`e2e/cypress/support/commands.ts`](../../e2e/cypress/support/commands.ts).
+
+> **`seed test` refuses to run outside development.** It plants fixed, repository-visible
+> passwords, so it requires `APP_ENV=development` or `CI`. For anything real, use the interactive
+> setup — see [First-time setup](../getting-started/first-setup.md).
+
+## Tests
+
+```bash
+./scripts/dev.sh test     # backend suite: starts the test database, then pytest on the host
+```
+
+Roughly 1,270 tests, well under a minute. It runs `uv run pytest` from `backend/` against the
+test database on port 5434, so backend dependencies must be installed on the host — `uv sync` in
+`backend/` if it is a fresh checkout.
+
+For end-to-end tests, **run the full suite against a production build**:
+
+```bash
+cd e2e && pnpm test:parallel:prod
+```
+
+`next dev` compiles each route on first request, and with 4 workers sharing one dev server that
+stall pushes navigations past their timeouts — specs fail, or pass only on retry, and which ones
+varies between runs. `test:parallel:prod` builds, serves, runs and tears down.
+
+Retries mask failures, so read the screenshots in `e2e/cypress/screenshots/` (gitignored,
+overwritten each run): a screenshot with no `attempt N` suffix means a test failed once and passed
+on retry. A clean run leaves none. Intermittent retry-only passes under parallel load are a known
+open problem — see [issue #58](https://github.com/marcandreuf/memship/issues/58).
+
+## Adding a backend dependency
+
+Python dependencies are baked into the image — `pyproject.toml` is **not** bind-mounted — so a new
+dependency is missing from the running container until you rebuild:
+
+```bash
+docker compose -f backend/docker/docker-compose.yml build --no-cache api
+docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
+```
+
+## Logs
+
+| Where | How |
+|---|---|
+| Frontend | `frontend/logs/dev-server.log`, or `./scripts/dev.sh logs frontend` |
+| Backend | `./scripts/dev.sh logs backend` |
+| Celery | `./scripts/dev.sh logs worker` / `logs beat` |
+
+Celery is the component that fails quietly. If scheduled billing or reminder emails stop, look
+there before anywhere else.
+
+## Working on the backend without Docker
+
+```bash
+cd backend
+uv sync
+uv run pytest -v
+python start.py                                    # dev server, hot reload
+python -m app.cli.seed                             # setup
+alembic upgrade head                               # migrations
+alembic revision --autogenerate -m "description"   # new migration
+```
+
+## Frontend directly
+
+```bash
+cd frontend
+pnpm install
+./dev.sh start      # background, with logs
+./dev.sh stop
+./dev.sh status
+./dev.sh logs
+pnpm build          # production build
+pnpm lint
+```

--- a/docs/development/local-environment.md
+++ b/docs/development/local-environment.md
@@ -43,7 +43,9 @@ locally with pnpm, so you get Next.js hot reload without a container in the way.
 | `./scripts/dev.sh logs worker` | Celery worker logs |
 | `./scripts/dev.sh logs beat` | Celery beat (scheduler) logs |
 | `./scripts/dev.sh seed` | Interactive setup — the same one every environment uses |
-| `./scripts/dev.sh seed test` | Fixed e2e test accounts and sample data |
+| `./scripts/dev.sh seed demo` | Demo club with **generated** credentials — prefer this |
+| `./scripts/dev.sh seed test` | Fixed e2e test accounts, whose passwords are public |
+| `./scripts/dev.sh passwd [email]` | Replace the super admin password with a generated one |
 | `./scripts/dev.sh test` | Backend test suite |
 | `./scripts/dev.sh e2e` | Cypress, headless |
 | `./scripts/dev.sh e2e:open` | Cypress GUI |
@@ -77,29 +79,63 @@ Adminer sits behind a Compose profile and has no `dev.sh` command:
 docker compose -f backend/docker/docker-compose.yml --profile tools up -d adminer
 ```
 
-## The dev stack is not hardened, and by default it is only on localhost
+## The dev stack is not hardened — everything binds to localhost
 
 The dev stack ships deliberately weak settings: a fixed database password (`memship`), Redis with
 no authentication, and — after `seed test` — **super admin credentials that are published in this
-repository**. That is fine for a laptop and disastrous on a shared network, so the published ports
-bind to `127.0.0.1` only.
+repository**. That is fine on a laptop and disastrous on a shared network, so **nothing is exposed
+beyond loopback by default**: the API, database, Redis and Adminer bind to `127.0.0.1`, and the
+Next.js dev server does too.
 
-If you need to reach the stack from another device — a phone testing the mobile layout, a VM —
-override the bind address for that session:
+Binding the containers is not enough on its own. Next.js binds `0.0.0.0` out of the box, and the
+frontend proxies to the API server-side — so a dev server on every interface is a complete path
+into the app, login included, even when every container is on loopback. Both halves are pinned.
+
+### Working on a public network
+
+Loopback binding is what makes a café or a co-working network safe, and it is the whole defence.
+Layer the rest on top of it:
+
+- **Prefer `./scripts/dev.sh seed demo`** over `seed test` for ordinary work. It seeds the same
+  sample data but generates the super admin password and the demo logins, printing them once.
+  `seed test` exists for the Cypress suite, whose credentials are a contract and therefore public.
+- **If you have already run `seed test`**, `./scripts/dev.sh passwd` replaces the super admin
+  password with a generated one. Re-running `seed test` puts the fixed ones back when you next
+  need the suite.
+- **Never combine `DEV_BIND=0.0.0.0` with `seed test` data.** Anyone on the network can then read
+  the password out of this repository and sign in as super admin. `dev.sh start` checks for those
+  accounts and warns you.
+
+### Reaching the stack from another device
+
+To test on a phone or from a VM, opt in for that session:
 
 ```bash
-DEV_BIND=0.0.0.0 ./scripts/dev.sh start backend
+DEV_BIND=0.0.0.0 ./scripts/dev.sh start all
 ```
 
-Do that only on a network you trust, and never on a stack seeded with `seed test`: those accounts
-are in this repository, so anyone who can reach port 8003 can sign in as a super admin. The
-frontend dev server binds to all interfaces on its own — that is Next.js's default and it serves no
-data without the API.
+That publishes the containers on every interface and starts Next.js with `-H 0.0.0.0`. Do it only
+on a network you control, and reseed with `seed demo` first.
+
+### Platform notes
+
+The `DEV_BIND` mechanism is Docker's own `HOST:PORT:PORT` syntax plus a Next.js flag, so it behaves
+the same on all three platforms. What differs is what surrounds it:
+
+| Platform | What to know |
+|---|---|
+| **Linux (Ubuntu 24.04+)** | Docker inserts its iptables rules **ahead of `ufw`**, so a published port is reachable even while the firewall denies it. `ufw` will not save you from `DEV_BIND=0.0.0.0` — the bind address is the control that works. |
+| **macOS (Docker Desktop)** | Ports are forwarded by the VM to the host and the bind address is honoured, so loopback stays loopback. macOS may prompt for incoming connections the first time you use `dev:lan`. |
+| **Windows (Docker Desktop + WSL2)** | Loopback binding works through WSL2's localhost forwarding. In **mirrored** networking mode (Windows 11, `networkingMode=mirrored` in `.wslconfig`) the WSL instance shares the host's interfaces, so `0.0.0.0` inside WSL is genuinely on the LAN — and Windows Firewall, not `ufw`, is what prompts. Run `dev.sh` from WSL or Git Bash; it is a bash script. |
+
+`0.0.0.0` means *every* interface, which includes VPN and Tailscale adapters — those reach further
+than the café's wifi.
 
 ## First-time setup
 
 ```bash
 ./scripts/dev.sh seed          # interactive, the same setup every environment uses
+./scripts/dev.sh seed demo     # demo club, generated credentials — the everyday choice
 ./scripts/dev.sh seed test     # fixed test accounts + sample data, for the e2e suite
 ```
 

--- a/frontend/dev.sh
+++ b/frontend/dev.sh
@@ -66,7 +66,14 @@ start_server() {
 
     echo -e "${GREEN}+${NC} Starting $SERVER_NAME..."
 
-    pnpm run dev > "$LOG_FILE" 2>&1 &
+    # Next.js binds 0.0.0.0 by default, which put the whole app — login included —
+    # on the local network. `dev` pins it to loopback; `dev:lan` is the opt-in.
+    if [ "${DEV_BIND:-127.0.0.1}" = "127.0.0.1" ]; then
+        pnpm run dev > "$LOG_FILE" 2>&1 &
+    else
+        echo "!! DEV_BIND=${DEV_BIND} — serving the app on every interface."
+        pnpm run dev:lan > "$LOG_FILE" 2>&1 &
+    fi
     local pid=$!
     echo "$pid" > "$PID_FILE"
 
@@ -128,8 +135,16 @@ stop_server() {
 # Function to clean Next.js cache
 clean_cache() {
     echo -e "${BLUE}i${NC} Cleaning Next.js cache..."
-    rm -rf .next
-    echo -e "${GREEN}+${NC} Cache cleaned"
+    # The server we just stopped may still be flushing into .next, and rm then
+    # exits non-zero on a directory that refilled under it. With `set -e` that
+    # aborted the restart before it ever started the server again, leaving
+    # nothing running. A stale cache is not worth failing a restart over.
+    rm -rf .next 2>/dev/null || true
+    if [ -d .next ]; then
+        echo -e "${YELLOW}!${NC} Cache partly in use — continuing with what remains"
+    else
+        echo -e "${GREEN}+${NC} Cache cleaned"
+    fi
 }
 
 # Function to restart server

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     ]
   },
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -H 127.0.0.1",
+    "dev:lan": "next dev --turbopack -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -161,6 +161,37 @@ show_overall_status() {
     echo "  ./scripts/dev.sh logs frontend  - View frontend logs"
 }
 
+
+# --- Credentials & exposure ---
+
+# The dev stack is weak on purpose. That is fine on loopback and dangerous the
+# moment anything is published wider, so say so rather than assume the developer
+# remembers which network they joined.
+warn_if_exposed() {
+    local bind="${DEV_BIND:-127.0.0.1}"
+    [ "$bind" = "127.0.0.1" ] && return 0
+    echo -e "${RED}${BOLD}!! DEV_BIND=$bind — the dev stack is on every interface.${NC}"
+    echo -e "${YELLOW}   Fixed database password, Redis without auth, and any seeded accounts"
+    echo -e "   are reachable by anyone on this network. Do not do this on a network"
+    echo -e "   you do not control.${NC}"
+    if has_test_accounts; then
+        echo -e "${RED}${BOLD}   This database holds the e2e test accounts, whose passwords are"
+        echo -e "   published in this repository. Anyone here can sign in as super admin."
+        echo -e "   Run './scripts/dev.sh passwd' or reseed with 'seed demo'.${NC}"
+    fi
+}
+
+has_test_accounts() {
+    docker compose -f "$BACKEND_COMPOSE" exec -T db \
+        psql -U memship -d memship_db -tAc \
+        "select 1 from users where email = 'super@examplee6e3b1.com' limit 1" 2>/dev/null | grep -q 1
+}
+
+gen_password() {
+    # Avoid characters that need quoting when a developer pastes this around.
+    LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24
+}
+
 # --- Main ---
 
 ACTION="${1:-status}"
@@ -168,6 +199,7 @@ TARGET="${2:-all}"
 
 case "$ACTION" in
     start|stop|restart|logs)
+        [ "$ACTION" = "start" ] && warn_if_exposed
         case "$TARGET" in
             backend)  run_backend "$ACTION" ;;
             frontend) run_frontend "$ACTION" ;;
@@ -198,10 +230,41 @@ case "$ACTION" in
     status)
         show_overall_status
         ;;
+    passwd)
+        # Thin wrapper over the same CLI every environment uses. The password goes
+        # in on the environment, never in argv, so it stays out of `ps` and history.
+        EMAIL="${2:-dev@localhost}"
+        NEWPW="$(gen_password)"
+        echo -e "${BLUE}i${NC} Setting the super admin password for $EMAIL..."
+        if MEMSHIP_ADMIN_PASSWORD="$NEWPW" docker compose -f "$BACKEND_COMPOSE" \
+                exec -T -e MEMSHIP_ADMIN_PASSWORD api \
+                python -m app.cli.seed --admin-email "$EMAIL" >/dev/null; then
+            echo -e "${GREEN}+${NC} Super admin: $EMAIL"
+            echo -e "${GREEN}+${NC} Password:    $NEWPW"
+            echo -e "${YELLOW}i${NC} Shown once — it is stored only as a hash."
+        else
+            echo -e "${RED}x${NC} Could not set the password. Is the API up?"
+            exit 1
+        fi
+        ;;
     seed)
         if [ "$TARGET" = "test" ]; then
             echo -e "${BLUE}i${NC} Running setup with the fixed e2e test accounts..."
+            warn_if_exposed
             docker compose -f "$BACKEND_COMPOSE" exec -it api python -m app.cli.seed --test
+        elif [ "$TARGET" = "demo" ]; then
+            # Same sample data as `seed test`, but nothing a stranger could look up:
+            # the super admin password is generated here and the demo club generates
+            # the rest. Use this unless you are running the Cypress suite.
+            DEMOPW="$(gen_password)"
+            echo -e "${BLUE}i${NC} Seeding a demo club with generated credentials..."
+            MEMSHIP_ADMIN_PASSWORD="$DEMOPW" docker compose -f "$BACKEND_COMPOSE" \
+                exec -T -e MEMSHIP_ADMIN_PASSWORD api \
+                python -m app.cli.seed --admin-email dev@localhost --demo
+            echo ""
+            echo -e "${GREEN}+${NC} Super admin: dev@localhost"
+            echo -e "${GREEN}+${NC} Password:    $DEMOPW"
+            echo -e "${YELLOW}i${NC} Shown once — it is stored only as a hash."
         else
             echo -e "${BLUE}i${NC} Running the interactive setup..."
             docker compose -f "$BACKEND_COMPOSE" exec -it api python -m app.cli.seed
@@ -246,7 +309,7 @@ case "$ACTION" in
     *)
         echo -e "${BOLD}Memship Dev Environment Manager${NC}"
         echo ""
-        echo "Usage: $0 {start|stop|restart|status|logs|seed|test} [backend|frontend|all]"
+        echo "Usage: $0 {start|stop|restart|status|logs|seed|passwd|test|e2e} [backend|frontend|worker|beat|all]"
         echo ""
         echo -e "${BOLD}Commands:${NC}"
         echo "  start [target]    - Start services"
@@ -255,14 +318,18 @@ case "$ACTION" in
         echo "  status            - Show status of all services"
         echo "  logs [target]     - View logs (requires specific target)"
         echo "  seed              - Run the interactive setup (same on every environment)"
-        echo "  seed test         - Seed the fixed e2e test accounts (development only)"
+        echo "  seed demo         - Seed a demo club with generated credentials (prefer this)"
+        echo "  seed test         - Seed the fixed e2e test accounts, published in this repo"
+        echo "  passwd [email]    - Set the super admin password to a fresh generated one"
         echo "  reset             - Wipe DB, restart backend, and re-seed with test data"
         echo "  test              - Run backend tests"
         echo "  e2e               - Run Cypress E2E tests (headless)"
         echo "  e2e:open          - Open Cypress GUI (interactive)"
         echo ""
         echo -e "${BOLD}Targets:${NC}"
-        echo "  backend    - API + DB (Docker, port 8003)"
+        echo "  backend    - API + DB + Redis + worker + beat (Docker, port 8003)"
+        echo "  worker     - Celery worker only"
+        echo "  beat       - Celery beat scheduler only"
         echo "  frontend   - Next.js dev server (local, port 3000)"
         echo "  all        - Both services (default)"
         echo ""
@@ -271,7 +338,9 @@ case "$ACTION" in
         echo "  $0 stop frontend      # Stop only frontend"
         echo "  $0 logs backend       # View API logs"
         echo "  $0 seed               # Run initial setup (interactive)"
-        echo "  $0 seed test          # Seed with test accounts"
+        echo "  $0 seed demo          # Seed with generated credentials"
+        echo "  $0 seed test          # Seed with the fixed e2e accounts"
+        echo "  $0 passwd             # Rotate the super admin password"
         echo "  $0 reset              # Wipe DB and re-seed with test data"
         echo "  $0 test               # Run backend tests"
         echo ""


### PR DESCRIPTION
Reviewed and **ran** the local dev environment end to end, then moved its documentation out of the README. Writing it from a real run rather than from the old text is what produced everything below.

## The dev stack was on the local network

`backend/docker/docker-compose.yml` published `8003`, `6379`, `5433`, `5434` and `8181` on **`0.0.0.0`** — unlike the production compose, which has bound to `127.0.0.1` since v2.0.0.

That stack ships a fixed database password (`memship`), Redis with no authentication, and after `dev.sh seed test` a super admin whose password is published in this repository. The seeder prints *"Never expose an instance seeded this way"* while the compose file did exactly that.

Confirmed from the machine's LAN address, not inferred:

```
POST http://192.168.219.108:8003/api/v1/auth/login   (super@…, published password)  -> 200
5433 OPEN on LAN     6379 OPEN on LAN (redis, no auth)
```

Now `${DEV_BIND:-127.0.0.1}`, with `DEV_BIND=0.0.0.0` as the deliberate opt-out for testing from a phone or a VM. After the change: localhost `200`, LAN refused, `5433`/`6379` closed, and `DEV_BIND=0.0.0.0` restores the old behaviour. **1274 backend tests still pass.**

## Three things the old docs did not mention

- **The first `start all` on a clean machine can fail.** It did here: `failed to mkdir …/docker_memship-storage/_data/registrations: file exists`. The API, worker and beat all mount the same fresh named volume and are created together, so Docker's own volume setup races with itself. Running the command again works. This is the "known fresh-volume race" that did *not* reproduce during the August staging rebuild — it reproduces on a dev machine.
- **`dev.sh reset` runs `docker compose down -v` with no confirmation**, destroying the dev database *and* the storage volume — uploads and `storage/secret.key` with it, so stored payment/SSO credentials become undecryptable.
- **`reset`, `e2e`, `e2e:open` and `e2e:parallel` were undocumented.** The script's own `--help` omits `e2e:parallel` and the `worker`/`beat` targets; the README omitted all four commands. Adminer was documented as a URL with no command that starts it — it needs `--profile tools`, which no `dev.sh` command passes.

## The move

Eighty lines of README became `docs/development/local-environment.md`, with the README keeping three commands and a link. All three locales in parity. `docs/README.md` gains a Development section.

`CLAUDE.md` was a fourth copy of the command list — it now points at the doc, and loses two stale facts: the "167/167 with no retries" claim (which predates the suite growing past 167 tests) and a pointer to the retired `memship-definition` repo.

## Verified working

`start` (on retry), `status`, `seed test`, `logs`, Swagger at `:8003/api/docs`, the frontend at `:3000`, and **1274 backend tests in ~34s**. The suite is healthy; it does emit 1825 warnings, mostly the deprecated `HTTP_422_UNPROCESSABLE_ENTITY`.

## Not fixed here

The volume race and the missing Adminer command are documented, not solved — both are script/compose changes worth doing on their own. The dev `SECRET_KEY` default (`dev-secret-key-change-in-production`) is on the refused-placeholder list as of #56, so it is silently ignored in favour of the persisted session key: harmless, but dead config in three places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D54Bvm9wPe6bfF8Y5b9sti