### PR TITLE
Fix what walking the quickstart found, from stale warnings to the reported version

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -22,8 +22,8 @@ La majoria d'eines de gestió de socis són plataformes SaaS cares o programari 
 ## Inici ràpid (Docker)
 
 > **Per provar Memship, no per fer-lo servir.** És la via més ràpida a una instància
-> funcionant a la vostra màquina: imatges publicades, volums llencívols i una clau
-> secreta que és en aquest repositori. Per gestionar una organització real, seguiu la
+> funcionant a la vostra màquina: imatges publicades, volums llencívols i una
+> contrasenya de base de dades fixa. Per gestionar una organització real, seguiu la
 > [Instal·lació](docs/getting-started/installation.md) — el mateix producte, configurat
 > per poder-lo copiar, actualitzar i conservar.
 

--- a/README.es.md
+++ b/README.es.md
@@ -23,8 +23,8 @@ La mayoría de herramientas de gestión de socios son plataformas SaaS caras o s
 
 > **Para probar Memship, no para usarlo.** Es la vía más rápida a una instancia
 > funcionando en tu propia máquina: imágenes publicadas, volúmenes desechables y una
-> clave secreta que está en este repositorio. Para gestionar una organización real,
-> sigue la [Instalación](docs/getting-started/installation.md) — el mismo producto,
+> contraseña de base de datos fija. Para gestionar una organización real, sigue
+> la [Instalación](docs/getting-started/installation.md) — el mismo producto,
 > configurado para poder respaldarlo, actualizarlo y conservarlo.
 
 Prueba Memship con un solo comando, sin necesidad de clonar el repositorio:

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Most membership tools are either expensive SaaS platforms or outdated legacy sof
 
 > **For trying memship out, not for running it.** This is the fastest path to a
 > working instance on your own machine: published images, throwaway volumes, and
-> a secret key that is committed to this repository. To run memship for a real
-> organization, follow [Installation](docs/getting-started/installation.md)
-> instead — same product, set up so it can be backed up, upgraded and kept.
+> a fixed database password. To run memship for a real organization, follow
+> [Installation](docs/getting-started/installation.md) instead — same product,
+> set up so it can be backed up, upgraded and kept.
 
 Try memship with a single command — no cloning required:
 

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -6,8 +6,8 @@
 #   docker compose exec -it demo-memship-api python -m app.cli.seed
 #   Open http://localhost:8081
 #
-# EVALUATION ONLY. SECRET_KEY below is committed to the repository and the data
-# lives in throwaway Docker volumes. To run memship for a real organization use
+# EVALUATION ONLY. The database password below is fixed and the data lives in
+# throwaway Docker volumes. To run memship for a real organization use
 # scripts/install.sh and the root docker-compose.yml — see
 # docs/getting-started/installation.md.
 #
@@ -24,10 +24,12 @@ x-backend-env: &backend-env
   # on the shared volume. Set SECRET_KEY in the environment to supply your own.
   SECRET_KEY: ${SECRET_KEY:-}
   APP_ENV: production
-  APP_VERSION: ${IMAGE_TAG:-latest}
   DEFAULT_LOCALE: es
-  CORS_ORIGINS: http://localhost
-  FRONTEND_URL: http://localhost
+  # Both must follow PORT, or every link the backend builds (password reset,
+  # email verification, receipt payment) points at port 80 and 404s. A browser
+  # omits the port from Origin when it is 80, so the bare form is listed too.
+  CORS_ORIGINS: http://localhost:${PORT:-80},http://localhost
+  FRONTEND_URL: http://localhost:${PORT:-80}
   CELERY_BROKER_URL: redis://demo-memship-redis:6379/0
 
 services:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -32,6 +32,21 @@ docker compose exec -it demo-memship-api python -m app.cli.seed
 2. **Club data** — offered only when there is some, so on a fresh install it is a no-op.
 3. **Club setup** — enter your organization's real details, or generate a demo club.
 
+The three questions also have flags, for scripting an evaluation or running it where
+there is no terminal to answer prompts:
+
+```bash
+# same three steps, unattended
+docker compose exec -T -e MEMSHIP_ADMIN_PASSWORD='...' demo-memship-api \
+  python -m app.cli.seed --admin-email you@example.org
+docker compose exec -T demo-memship-api python -m app.cli.seed --demo
+```
+
+Note `-T` instead of `-it`, and that the password goes through `docker compose exec -e`:
+the container does not inherit your shell's environment, and passing it as an argument
+would leave it in your shell history and in `ps`. `--reset-club-data` drives the third
+question. See `python -m app.cli.seed --help`.
+
 Answer **2) demo club** to look around with realistic data: ~60 members across all
 statuses, activities, receipts in every state, SEPA mandates and dashboard reminders.
 Ideal for evaluating the finance dashboard and annual summary. Safe to re-run
@@ -56,8 +71,8 @@ Keep that output — the passwords are stored only as hashes and cannot be shown
 Go to **http://localhost:8081** and log in as the super admin you created.
 
 > **The quick-start stack is for evaluation, not for running a club.** Its compose file
-> ships insecure defaults — a `SECRET_KEY` committed to this repository and a fixed database
-> password — and keeps data in throwaway Docker volumes. Follow
+> ships a fixed database password, serves the API without the security headers a real
+> install gets, and keeps data in throwaway Docker volumes. Follow
 > [Installation](installation.md) and the
 > [Configuration reference](../self-hosting/configuration.md) before putting Memship on a
 > network or entering real member data.


### PR DESCRIPTION
The quickstart was the only one of the three deployment paths with no walkthrough behind it, and it is the first thing an evaluator runs. Walked it literally from an empty directory on 2026-08-21, the same way the install guide was walked in #62.

**The happy path works.** Install, both seed paths, login, the demo club, and teardown all behave as documented. Six defects came out of it; the four doc/config ones are fixed here, and the two that need code are filed as issues.

## Fixed here

**The `SECRET_KEY` warning has been false since #56.** That PR changed the quickstart to `SECRET_KEY: ${SECRET_KEY:-}`, so each install generates and persists its own key to `/app/storage/session.key`. The old warning survived in **five** places — including `docker-compose.quickstart.yml:9`, twelve lines above the comment that correctly explains the opposite. Corrected in all three locales. The fixed database password is real, so that half of every warning stays.

**`CORS_ORIGINS` and `FRONTEND_URL` ignored `PORT`.** Both were pinned to `http://localhost` while the documented command is `PORT=8081 docker compose up -d`. `FRONTEND_URL` builds the password-reset (`auth.py:288`), email-verification (`auth.py:141`), new-member login (`members.py:330`) and receipt-payment (`receipts.py:589,672`) links, so every one of them pointed at port 80. Latent today only because the quickstart configures no email transport. Both entries now follow `${PORT:-80}`; the bare `http://localhost` stays in the CORS list because a browser omits the port from `Origin` when it is 80.

**`/health` reported the literal string `latest`.** `APP_VERSION: ${IMAGE_TAG:-latest}` was overriding the value the Dockerfile already bakes in, so an evaluator filing a bug could not say which build they ran. Dropped the override. Health now reports `sha-f4403a7f38df` — a commit rather than a version, because `release.yml` retags the RC with `imagetools create` instead of rebuilding it, which is more precise for a bug report anyway. `IMAGE_TAG` was vestigial here regardless: the quickstart pins `:latest` directly, it does not interpolate the variable.

**The unattended seed flags were undocumented.** The doc gave only the interactive `exec -it` form, which a non-TTY caller cannot answer. `--admin-email`, `--demo` and `--reset-club-data` all exist and work — this walkthrough used them throughout. Documented, including that the password must go through `docker compose exec -e`, the same trap #62 fixed in `first-setup.md`.

## Filed, not fixed

- **#72** — `api`, `celery-worker` and `celery-beat` race to initialise the shared `demo-memship-storage` volume, failing the first `up` in ~10% of clean starts (3 in ~31 measured). Exits 1, so not silent, but leaves the stack half-built. Second instance of a race already logged against the dev stack, so a fix should cover both compose files.
- **#73** — the API path is served with no security headers at all, while the frontend serves its own on `/`, so a homepage spot-check hides it. Same failure mode #62 fixed for the installed path.

The doc warning in this PR now says the API is served without the security headers a real install gets, so the docs are honest until #73 lands.

## Verification

Re-ran the whole path against the corrected compose file: `up`, super admin seed, demo seed, login, 62 members, and confirmed `FRONTEND_URL`/`CORS_ORIGINS` interpolate correctly at both `PORT=8081` and the default.

Also confirmed correct and unchanged, so they need no retest:

- `--reset-club-data` does exactly what the doc promises — 62 members / 68 receipts / 28 activities down to 1 / 0 / 0, roles intact, super admin still logs in, club admin correctly gone (401).
- Data and `session.key` survive a `down` + `up` cycle; the per-install key from #56 works.
- Auth is enforced — `/api/v1/members/` is 401 without a cookie, 200 with one.
- OpenAPI is not exposed under `APP_ENV=production`.
- The compose comment naming `session.key` is accurate; `secret.key` is a different key (`secrets_crypto.py:45`) for encrypted stored secrets.
- `demo-memship-*` container names do not collide with the dev stack.

Docs only — no product code, so no release is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6