### PR TITLE
Serve the quickstart API with the same headers a real install gets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      caddy: ${{ steps.filter.outputs.caddy }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -45,6 +46,22 @@ jobs:
               - 'backend/**'
             frontend:
               - 'frontend/**'
+            caddy:
+              - 'Caddyfile'
+              - 'docker-compose.quickstart.yml'
+              - 'scripts/check-caddy-headers.sh'
+
+  caddy-headers:
+    name: Caddy Header Parity
+    needs: changes
+    if: ${{ needs.changes.outputs.caddy == 'true' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Compare the two Caddy header blocks
+        run: ./scripts/check-caddy-headers.sh
 
   unit:
     name: Unit Tests

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -44,6 +44,24 @@ services:
       - |
         cat > /etc/caddy/Caddyfile <<'CADDYEOF'
         :80 {
+          # Kept identical to the header block in ./Caddyfile, which is what a
+          # real install serves. Without it the frontend still sets four of
+          # these itself, so a spot-check of the homepage passes while every
+          # /api/v1/* response goes out bare — that is exactly how this was
+          # missed until a walkthrough curled the API directly.
+          # scripts/check-caddy-headers.sh fails CI if the two lists drift.
+          header {
+            X-Content-Type-Options nosniff
+            Content-Security-Policy "frame-ancestors 'none'"
+            X-Frame-Options DENY
+            Referrer-Policy strict-origin-when-cross-origin
+            # Inert over plain HTTP, which is all this stack ever serves. Kept
+            # so the two files can be compared directive for directive.
+            Strict-Transport-Security "max-age=31536000"
+            # Caddy advertises itself, and the API answers with Server: uvicorn.
+            -Server
+          }
+
           handle /api/v1/* {
             reverse_proxy demo-memship-api:8000
           }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -71,8 +71,7 @@ Keep that output — the passwords are stored only as hashes and cannot be shown
 Go to **http://localhost:8081** and log in as the super admin you created.
 
 > **The quick-start stack is for evaluation, not for running a club.** Its compose file
-> ships a fixed database password, serves the API without the security headers a real
-> install gets, and keeps data in throwaway Docker volumes. Follow
+> ships a fixed database password and keeps data in throwaway Docker volumes. Follow
 > [Installation](installation.md) and the
 > [Configuration reference](../self-hosting/configuration.md) before putting Memship on a
 > network or entering real member data.

--- a/scripts/check-caddy-headers.sh
+++ b/scripts/check-caddy-headers.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# The quickstart cannot include ./Caddyfile — it is a single file you curl with
+# no clone behind it — so its proxy config is duplicated inside
+# docker-compose.quickstart.yml. Duplication drifts: #56 added the header block
+# to ./Caddyfile, the quickstart never got it, and the gap survived because the
+# frontend sets four of the same headers itself, so only a direct curl of
+# /api/v1/* shows it (#73).
+#
+# This compares the two header lists by directive name and fails if they differ.
+# Add a header to one file, add it to the other.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Directive names inside the first `header { ... }` block of a file, sorted.
+# Strips comments and blank lines, keeps the leading '-' of removals.
+directives() {
+  awk '
+    /header[[:space:]]*\{/ { inblock = 1; next }
+    inblock && /^[[:space:]]*\}/ { exit }
+    inblock {
+      sub(/#.*/, "")
+      if ($1 != "") print $1
+    }
+  ' "$1" | sort
+}
+
+canonical=$(directives Caddyfile)
+quickstart=$(directives docker-compose.quickstart.yml)
+
+if [ -z "$canonical" ]; then
+  echo "check-caddy-headers: no header block found in ./Caddyfile" >&2
+  exit 1
+fi
+
+if [ "$canonical" != "$quickstart" ]; then
+  echo "check-caddy-headers: the two Caddy header blocks have drifted." >&2
+  echo >&2
+  diff <(echo "$canonical") <(echo "$quickstart") \
+    --label "Caddyfile" --label "docker-compose.quickstart.yml" -u >&2 || true
+  echo >&2
+  echo "Add the missing directive to both, or update this check if the" >&2
+  echo "difference is deliberate." >&2
+  exit 1
+fi
+
+echo "check-caddy-headers: both header blocks list $(echo "$canonical" | wc -l | tr -d ' ') directives, matching."


### PR DESCRIPTION
Closes #73.

## The gap

On the quickstart stack, `/api/v1/*` came back completely bare:

```
$ curl -sI http://localhost:8081/api/v1/health
HTTP/1.1 405 Method Not Allowed
Server: uvicorn
Via: 1.1 Caddy
```

#56 added the `header` block to `./Caddyfile`. The quickstart's inline Caddyfile never got it, so an evaluation instance served the API with no CSP, no `X-Frame-Options`, no `X-Content-Type-Options` and no `Referrer-Policy`, and advertised both Caddy and uvicorn.

It stayed invisible because **Next.js sets four of the same headers itself**, so `GET /` looks correct and only a direct curl of the API shows the gap — the same masking that hid the missing Caddy recreate in #62.

## The fix

The header block copied verbatim, `-Server` included. `Strict-Transport-Security` is inert over plain HTTP, which is all this stack ever serves, but it is kept so the two lists can be compared directive for directive.

After:

```
$ curl -sI http://localhost:8081/api/v1/health
HTTP/1.1 405 Method Not Allowed
Content-Security-Policy: frame-ancestors 'none'
Referrer-Policy: strict-origin-when-cross-origin
Strict-Transport-Security: max-age=31536000
Via: 1.1 Caddy
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
```

No `Server` header at all.

## Stopping the third occurrence

The quickstart **cannot** `import ./Caddyfile` — it is a single file you `curl` with nothing cloned behind it — so the duplication is forced. Since this is now the second Caddy config missed after #56, `scripts/check-caddy-headers.sh` compares the two header blocks by directive name, and a CI job runs it whenever `Caddyfile`, `docker-compose.quickstart.yml` or the script itself changes.

Verified in both directions — it passes as committed, and dropping one header from the quickstart side fails with:

```
check-caddy-headers: the two Caddy header blocks have drifted.
--- Caddyfile
+++ docker-compose.quickstart.yml
 Content-Security-Policy
-Referrer-Policy
 -Server
```

If you would rather not carry the extra CI job, the check is one script and one job block and can come out on its own — the header fix does not depend on it.

## Verification

Ran the stack from the corrected file: all five headers on `/api/v1/health`, no `Server` header, homepage unchanged, Caddy config valid with no errors once the API was up, login 200 and the demo club's 62 members intact.

Also updated the warning in `quickstart.md` that #74 added — it said the API is served without the security headers a real install gets, which this PR makes false.

Docs and config only, no product code, so no release is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6