### PR TITLE
Let the API populate the storage volume before the celery services mount it

### DIFF
--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -25,6 +25,12 @@ services:
       - ../alembic:/app/alembic
       - ../start.py:/app/start.py
       - ../alembic.ini:/app/alembic.ini
+      # Three services mount this volume. Docker copies the image's
+      # /app/storage into a named volume the first time one is mounted empty,
+      # and concurrent copies collide — "failed to mkdir .../registrations:
+      # file exists" — failing the first `dev.sh start all` on a clean machine
+      # (#72). The API goes first and the celery services wait on it, so only
+      # one container ever populates the volume.
       - memship-storage:/app/storage
     depends_on:
       db:
@@ -60,6 +66,9 @@ services:
       - ../app:/app/app
       - memship-storage:/app/storage
     depends_on:
+      # The API populates memship-storage — see the note in the api service.
+      api:
+        condition: service_started
       redis:
         condition: service_healthy
       db:
@@ -87,6 +96,9 @@ services:
       # Survives a restart, so beat does not re-fire a job it already ran.
       - memship-celerybeat:/var/lib/celery
     depends_on:
+      # The API populates memship-storage — see the note in the api service.
+      api:
+        condition: service_started
       redis:
         condition: service_healthy
       db:

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -109,6 +109,14 @@ services:
     volumes:
       - demo-memship-storage:/app/storage
     depends_on:
+      # The API populates demo-memship-storage. Docker copies the image's
+      # /app/storage into a named volume the first time one is mounted empty,
+      # and two containers doing that concurrently collide — "failed to mkdir
+      # .../registrations: file exists" — failing `up` on roughly one clean
+      # start in ten (#72). Waiting for the API means the volume is already
+      # populated, so this container's mount is a no-op.
+      demo-memship-api:
+        condition: service_started
       demo-memship-db:
         condition: service_healthy
       demo-memship-redis:

--- a/docs/development/local-environment.md
+++ b/docs/development/local-environment.md
@@ -38,13 +38,6 @@ right one without installing it yourself.
 ./scripts/dev.sh stop all       # stop everything
 ```
 
-> **The first `start all` on a clean machine can fail** with
-> `failed to mkdir /var/lib/docker/volumes/docker_memship-storage/_data/<dir>: file exists`.
-> The API, the Celery worker and beat all mount the same `memship-storage` volume and are created
-> at the same time, so Docker's own volume setup races with itself. It is not a memship error and
-> nothing is broken — **run the command again** and it starts cleanly. Only the first start on a
-> given volume is affected.
-
 ## Commands
 
 | Command | Description |


### PR DESCRIPTION
Closes #72.

## The bug

The first `docker compose up -d` on a clean machine fails roughly one time in ten:

```
failed to mkdir .../demo-memship-storage/_data/registrations: file exists
```

Docker copies the image's `/app/storage` into a named volume the first time one is mounted empty. Two containers doing that concurrently walk the same tree and one loses.

`up` exits **1** and leaves the stack half-built (seen as both 0/7 and 4/7 containers stuck in `Created`), so it is not a silent failure — but a retry always works, which is why it survived this long. It only ever hits someone running the quickstart for the first time, which is exactly the worst audience for it.

## The fix

`depends_on` is enough. Docker finishes populating the volume before the container reaches `running`, so once the API is up every later mount is a no-op and there is no second copy to race.

Verified on a live cycle rather than assumed — the API started 669 ms ahead of the worker, and the worker found `/app/storage` already populated.

Both stacks that share a **named** storage volume are fixed:

| Stack | Services sharing the volume | Change |
|---|---|---|
| `docker-compose.quickstart.yml` | `api`, `celery-worker` | worker waits on api |
| `backend/docker/docker-compose.yml` | `api`, `celery-worker`, `celery-beat` | both wait on api |

**Production needed no change and was never affected.** `docker-compose.yml` bind-mounts storage, and Docker only populates *named* volumes from an image, never bind mounts. That is why the self-hosting walkthrough never hit this, and it means no real install could.

This also corrects the issue description, which said three services race in the quickstart — there it is two, since `celery-beat` mounts only `demo-memship-celerybeat`. The dev stack is the three-way one.

## Verification

**60 clean start cycles, zero failures** — 40 on the quickstart, 20 on the dev stack, each cycle a full `down -v` followed by `up -d`, checking both the exit code and that all containers came up.

The measured baseline was 3 failures in ~31 quickstart starts (~10%). At that rate, 40 consecutive clean runs would happen by chance about 1.5% of the time, so the run is meaningful rather than lucky. Combined with the ordering invariant above — which is deterministic, not probabilistic — I am confident this is closed.

One honest gap: I did not measure a *baseline* failure rate for the dev stack, since that would mean reverting the fix for another 20 cycles. Its 20 clean runs are consistent with the fix but weaker evidence on their own; the mechanism is identical and proven on the quickstart.

## Docs

Drops the "**The first `start all` on a clean machine can fail** … run the command again" note from `docs/development/local-environment.md`, which documented the workaround this removes.

Config and docs only, no product code, so no release is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6