### PR TITLE
Make a from-scratch dev setup work when followed literally

### DIFF
--- a/docs/development/local-environment.md
+++ b/docs/development/local-environment.md
@@ -16,7 +16,13 @@ locally with pnpm, so you get Next.js hot reload without a container in the way.
 The Node major is pinned in `frontend/.nvmrc` and enforced as a warning by `engines` in
 `frontend/package.json`. **Use 22** — it is what CI runs and what the production image is built on,
 and a different major is the kind of difference that only shows up as a build that works on one
-machine and not another. With `nvm`, `cd frontend && nvm use` picks it up.
+machine and not another. With `nvm`:
+
+```bash
+cd frontend
+nvm install       # reads .nvmrc; `nvm use` on its own only switches to an already-installed major
+corepack enable   # re-run this after every version switch — see below
+```
 
 A mismatch prints `WARN Unsupported engine` and carries on, which is deliberate — it should tell
 you, not stop you mid-session. `pnpm install --engine-strict` turns the same check into a hard
@@ -24,6 +30,11 @@ failure if you ever want it enforced.
 
 pnpm's version is pinned by `packageManager` in the same file, so `corepack enable` gets you the
 right one without installing it yourself.
+
+> **corepack shims live under each Node install**, so switching majors takes pnpm with it. If you
+> arrive on 22 from another version, `./scripts/dev.sh start all` brings the backend up and then
+> fails the frontend with `pnpm: command not found` in `frontend/logs/dev-server.log`. Running
+> `corepack enable` once on the new major fixes it for good.
 
 > **You do not need Node at all just to run memship.** The frontend ships as a container, and the
 > [Quick start](../getting-started/quickstart.md) runs the whole app from published images in one

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -19,6 +19,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BACKEND_COMPOSE="$REPO_ROOT/backend/docker/docker-compose.yml"
 FRONTEND_DIR="$REPO_ROOT/frontend"
 
+# The super admin that `seed demo` and `passwd` act on. It has to satisfy the
+# login schema's email pattern — ^[^@\s]+@[^@\s]+\.[^@\s]+$ in
+# backend/app/domains/auth/schemas.py — which needs a dot in the domain.
+# `dev@localhost` has none, so the account seeded fine and then rejected every
+# login with a 422 before the password was even checked (#77). Override it if
+# you want a different address.
+DEV_ADMIN_EMAIL="${DEV_ADMIN_EMAIL:-dev@memship.local}"
+
 # --- Backend (Docker) ---
 
 backend_start() {
@@ -32,7 +40,10 @@ backend_start() {
 
 backend_stop() {
     echo -e "${YELLOW}x${NC} Stopping backend services..."
-    docker compose -f "$BACKEND_COMPOSE" down
+    # The profiles matter: `dev.sh test` starts db-test under `test` and adminer
+    # runs under `tools`. Without them "stop all" leaves those containers up and
+    # the network attached, which surfaces as "Resource is still in use".
+    docker compose -f "$BACKEND_COMPOSE" --profile test --profile tools down
     echo -e "${GREEN}+${NC} Backend services stopped"
 }
 
@@ -233,7 +244,9 @@ case "$ACTION" in
     passwd)
         # Thin wrapper over the same CLI every environment uses. The password goes
         # in on the environment, never in argv, so it stays out of `ps` and history.
-        EMAIL="${2:-dev@localhost}"
+        # Must satisfy the login schema's pattern (a dot in the domain), or the
+        # account is created and can never sign in — see the note in `seed demo`.
+        EMAIL="${2:-$DEV_ADMIN_EMAIL}"
         NEWPW="$(gen_password)"
         echo -e "${BLUE}i${NC} Setting the super admin password for $EMAIL..."
         if MEMSHIP_ADMIN_PASSWORD="$NEWPW" docker compose -f "$BACKEND_COMPOSE" \
@@ -260,9 +273,9 @@ case "$ACTION" in
             echo -e "${BLUE}i${NC} Seeding a demo club with generated credentials..."
             MEMSHIP_ADMIN_PASSWORD="$DEMOPW" docker compose -f "$BACKEND_COMPOSE" \
                 exec -T -e MEMSHIP_ADMIN_PASSWORD api \
-                python -m app.cli.seed --admin-email dev@localhost --demo
+                python -m app.cli.seed --admin-email "$DEV_ADMIN_EMAIL" --demo
             echo ""
-            echo -e "${GREEN}+${NC} Super admin: dev@localhost"
+            echo -e "${GREEN}+${NC} Super admin: $DEV_ADMIN_EMAIL"
             echo -e "${GREEN}+${NC} Password:    $DEMOPW"
             echo -e "${YELLOW}i${NC} Shown once — it is stored only as a hash."
         else


### PR DESCRIPTION
Closes #77, #78, #79.

Set the dev environment up from nothing on this machine against `docs/development/local-environment.md`, the same way the install guide and the quickstart were walked. The backend came up fine. Everything after it needed a workaround the docs do not mention.

## `dev.sh seed demo` seeded a super admin nobody could log in as (#77)

It used `dev@localhost`, and the login schema requires a dot in the domain:

```python
# backend/app/domains/auth/schemas.py:9
Email = Annotated[str, StringConstraints(pattern=r"^[^@\s]+@[^@\s]+\.[^@\s]+$", max_length=255)]
```

so every attempt was rejected as `string_pattern_mismatch` — a **422 before the password was ever read**. The account existed and the printed credentials were correct; the address was simply unusable. `passwd` defaulted to the same one, so it cheerfully generated new passwords for an account that still could not sign in.

Both now share `DEV_ADMIN_EMAIL`, defaulting to `dev@memship.local` and overridable from the environment. This is the seed the docs call **"the everyday choice"**, so it was the first thing a new developer hit.

## The Node instructions did not survive being followed (#78)

`nvm use` does not install. On a machine without 22 it prints `N/A: version "v22" is not yet installed.` and leaves the wrong major in place. Switching majors then takes pnpm with it — corepack shims live under each Node install — so `start all` brought the backend up and failed the frontend with `pnpm: command not found`:

```
node v24.11.1 -> pnpm: /home/dev2/.nvm/versions/node/v24.11.1/bin/pnpm
node v22.23.2 -> pnpm: NOT FOUND
```

The prerequisites now spell out `nvm install` plus `corepack enable`, with a note on why the second is needed again after every switch.

## `stop all` left the test database running (#79)

`backend_stop` ran a plain `down` with no profiles, so `db-test` — and `adminer`, when started — stayed up. That is also what produced `Network docker_default Resource is still in use`: the network could not be removed while a container still held it, so the warning was a symptom, not noise. It now passes the same profile flags `reset` already used, minus the `-v`.

## Verification

Reran the whole documented path on a clean machine — `nvm install`, `corepack enable`, `start all`, `seed demo`, login **through the frontend proxy at 200**, 62 members, then `stop all` leaving nothing behind and no warning. Ports 3000 and 8003 stay closed on the LAN address, so #70's loopback guarantee is unchanged.

## Also checked, and correct — no change needed

- **The `engines` guard** behaves as documented: on Node 24 it warned `wanted: {"node":">=22.0.0 <23.0.0"}` and carried on rather than blocking (#71).
- **The `packageManager` pin** resolves pnpm 10.29.3 under both majors when run from `frontend/`.
- **`dev.sh start all` propagates a frontend failure** — it exits 1, not 0. I briefly had this recorded as a defect; the 0 came from reading `$?` through a pipe, so the value measured was `tail`'s. Forcing the failure without a pipe returns 1 from both `start frontend` and `start all`.
- **The backend suite** is 1274 tests in 34.7s, matching the doc's "roughly 1,270 … well under a minute".
- **The quickstart needs nothing.** Walked from an empty directory against merged `main`: first-try `up` with no race (#76), all five security headers and no `Server` (#75), `/health` reporting `sha-f4403a7f38df` (#74), the unattended seed commands working verbatim, and data surviving a `down`/`up`.

Scripts and docs only, no product code, so no release is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6