### PR TITLE
Refuse to write a wrong SEPA file, and decide activity capacity under a lock

### DIFF
--- a/backend/app/domains/activities/registration_service.py
+++ b/backend/app/domains/activities/registration_service.py
@@ -130,7 +130,9 @@ def register_member(
     # 5. Validate consents
     _validate_consents(db, activity.id, consents or [])
 
-    # 6. Check capacity
+    # 6. Check capacity, under a row lock so the decision and the increment in
+    #    step 10 cannot interleave with another registration.
+    _lock_capacity_rows(db, activity, modality)
     waiting_list_enabled = activity.features.get("waiting_list", False) if activity.features else False
     status = _determine_registration_status(activity, modality, waiting_list_enabled)
 
@@ -397,45 +399,114 @@ def _validate_consents(db: Session, activity_id: int, consents: list) -> None:
         raise RegistrationError(f"Mandatory consents not accepted: {names}")
 
 
+def _lock_capacity_rows(
+    db: Session, activity: Activity, modality: "ActivityModality | None"
+) -> None:
+    """Serialize the read-modify-write on the capacity counters.
+
+    ``current_participants`` is a cached column incremented in Python, so two
+    registrations arriving together both read ``max - 1``, both take the
+    confirmed branch and both increment: the activity ends up over capacity and
+    the counter drifts from the ``registrations`` rows. Locking the row the
+    decision reads makes the second caller wait for the first to commit.
+
+    ``populate_existing()`` is not optional. The activity is already in the
+    session — the endpoint loaded it to return a 404 — and without it SQLAlchemy
+    hands back the identity-mapped instance with the *stale* counter still
+    attached, so the lock would be taken and then the old value read straight
+    through it.
+
+    Rows are always locked activity-then-modality so two callers cannot take
+    them in opposite orders and deadlock.
+
+    This is the pattern ``domains/bookings/service.py`` already uses on
+    ``space_slots``.
+    """
+    db.query(Activity).filter(Activity.id == activity.id).populate_existing().with_for_update().first()
+    if modality is not None:
+        (
+            db.query(ActivityModality)
+            .filter(ActivityModality.id == modality.id)
+            .populate_existing()
+            .with_for_update()
+            .first()
+        )
+
+
+def _full_level(activity: Activity, modality: "ActivityModality | None") -> str | None:
+    """Which capacity level is full, or None if a confirmed seat fits.
+
+    The single place the capacity rule lives. Both the new-registration path and
+    waitlist promotion ask this, so the two cannot drift apart — promotion used
+    to skip the check entirely. Modality is tested first because it is the
+    narrower cap. ``Activity.max_participants`` is NOT NULL; a modality's is
+    optional and means "no cap of its own".
+    """
+    if modality is not None and modality.max_participants is not None:
+        if (modality.current_participants or 0) >= modality.max_participants:
+            return "modality"
+    if (activity.current_participants or 0) >= activity.max_participants:
+        return "activity"
+    return None
+
+
+def _has_capacity(activity: Activity, modality: "ActivityModality | None") -> bool:
+    """Whether one more confirmed seat fits, at both levels."""
+    return _full_level(activity, modality) is None
+
+
 def _determine_registration_status(
     activity: Activity,
     modality: ActivityModality | None,
     waiting_list_enabled: bool,
 ) -> str:
     """Determine whether a new registration should be confirmed or waitlisted."""
-    # Check modality-level capacity first
-    if modality and modality.max_participants is not None:
-        if (modality.current_participants or 0) >= modality.max_participants:
-            if waiting_list_enabled:
-                return "waitlist"
-            raise RegistrationError("This modality is full")
-
-    # Check activity-level capacity
-    if (activity.current_participants or 0) >= activity.max_participants:
-        if waiting_list_enabled:
-            return "waitlist"
-        raise RegistrationError("Activity is full")
-
-    return "confirmed"
+    full = _full_level(activity, modality)
+    if full is None:
+        return "confirmed"
+    if waiting_list_enabled:
+        return "waitlist"
+    raise RegistrationError(
+        "This modality is full" if full == "modality" else "Activity is full"
+    )
 
 
 def _promote_from_waitlist(
     db: Session, activity: Activity, modality_id: int | None = None
 ) -> Registration | None:
-    """Promote the oldest waitlisted registration to confirmed."""
+    """Promote the oldest waitlisted registration to confirmed.
+
+    Only ever fills the seat that was actually freed. ``modality_id`` is the
+    modality of the cancelled registration, and a promotion must match it: with
+    an unfiltered query, cancelling a registration that had no modality promoted
+    the oldest waitlister in the whole activity — possibly one waiting on a
+    different modality that is still full — and then incremented that modality
+    past its own cap. ``None`` means the freed seat had no modality, so the
+    candidates are the waitlisters that also have none.
+
+    Capacity is re-checked rather than assumed. A freed seat is not proof there
+    is room: an admin may have lowered the cap while people were waiting.
+    """
+    modality_filter = (
+        Registration.modality_id == modality_id
+        if modality_id is not None
+        else Registration.modality_id.is_(None)
+    )
     query = (
         db.query(Registration)
         .filter(
             Registration.activity_id == activity.id,
             Registration.status == "waitlist",
+            modality_filter,
         )
         .order_by(Registration.created_at.asc())
     )
-    if modality_id:
-        query = query.filter(Registration.modality_id == modality_id)
 
     next_in_line = query.first()
     if not next_in_line:
+        return None
+
+    if not _has_capacity(activity, next_in_line.modality):
         return None
 
     next_in_line.status = "confirmed"

--- a/backend/app/domains/billing/remittance_service.py
+++ b/backend/app/domains/billing/remittance_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.domains.billing.models import Receipt, Remittance, SepaMandate
 from app.domains.billing.schemas import RemittanceCreate
-from app.domains.billing.sepa_xml import generate_sepa_xml
+from app.domains.billing.sepa_xml import SepaExportError, generate_sepa_xml
 from app.domains.organizations.models import OrganizationSettings
 
 
@@ -215,8 +215,17 @@ def generate_remittance_xml(db: Session, remittance: Remittance) -> bytes:
         if m.member_id not in mandate_map or m.created_at > mandate_map[m.member_id].created_at:
             mandate_map[m.member_id] = m
 
-    # Generate XML
-    xml_bytes = generate_sepa_xml(remittance, receipts, mandate_map)
+    # Generate XML. Mandates are re-read above, so one cancelled between
+    # create_remittance and now is missing here even though creation checked for
+    # it. Refuse rather than write a file that collects less than the remittance
+    # says it does — see SepaExportError.
+    try:
+        xml_bytes = generate_sepa_xml(remittance, receipts, mandate_map)
+    except SepaExportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
     # Save to storage
     year = remittance.emission_date.year

--- a/backend/app/domains/billing/sepa_xml.py
+++ b/backend/app/domains/billing/sepa_xml.py
@@ -1,11 +1,34 @@
 """SEPA XML generation using the sepaxml library (pain.008.001.02)."""
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
 from sepaxml import SepaDD
 
 from app.domains.billing.models import Receipt, Remittance, SepaMandate
+
+
+class SepaExportError(Exception):
+    """The batch cannot be turned into a valid pain.008 file.
+
+    Raised instead of writing a file that does not match the remittance it came
+    from. A remittance carries the ``total_amount`` and ``receipt_count`` agreed
+    when it was created, and its receipts stay linked by ``remittance_id``, so a
+    file quietly built from a subset means the bank collects less than the batch
+    says while those receipts are excluded from future batches. Nothing
+    reconciles the two afterwards.
+    """
+
+
+def _as_date(value: date | datetime) -> date:
+    """Narrow a datetime to a date.
+
+    sepaxml's schema validation rejects a ``datetime`` where pain.008 wants a
+    date, and the failure message names neither the field nor the payment. Both
+    columns feeding this module are ``Date`` today, so this is a guard against a
+    model change reintroducing an error that is hard to read.
+    """
+    return value.date() if isinstance(value, datetime) else value
 
 
 def generate_sepa_xml(
@@ -22,6 +45,9 @@ def generate_sepa_xml(
 
     Returns:
         XML content as bytes.
+
+    Raises:
+        SepaExportError: a receipt has no mandate in ``mandates``.
     """
     config = {
         "name": remittance.creditor_name,
@@ -35,10 +61,19 @@ def generate_sepa_xml(
 
     dd = SepaDD(config, schema="pain.008.001.02", clean=True)
 
+    # Checked up front so the message names every affected member, rather than
+    # failing on the first one and hiding the rest behind a second run.
+    missing = sorted({r.member_id for r in receipts if r.member_id not in mandates})
+    if missing:
+        raise SepaExportError(
+            "Cannot generate the SEPA file: no active mandate for member(s) "
+            f"{missing}. The mandate was most likely cancelled after this "
+            "remittance was created. Reinstate the mandate, or remove those "
+            "receipts and create the remittance again."
+        )
+
     for receipt in receipts:
-        mandate = mandates.get(receipt.member_id)
-        if not mandate:
-            continue
+        mandate = mandates[receipt.member_id]
 
         # sepaxml expects amount in cents (integer)
         amount_cents = int(Decimal(str(receipt.total_amount)) * 100)
@@ -48,9 +83,9 @@ def generate_sepa_xml(
             "IBAN": mandate.debtor_iban,
             "amount": amount_cents,
             "type": "RCUR" if mandate.mandate_type == "recurrent" else "OOFF",
-            "collection_date": remittance.due_date,
+            "collection_date": _as_date(remittance.due_date),
             "mandate_id": mandate.mandate_reference,
-            "mandate_date": mandate.signed_at if isinstance(mandate.signed_at, date) else mandate.signed_at,
+            "mandate_date": _as_date(mandate.signed_at),
             "description": f"{receipt.receipt_number} - {receipt.description}"[:140],
         }
         if mandate.debtor_bic:
@@ -58,6 +93,8 @@ def generate_sepa_xml(
 
         dd.add_payment(payment)
 
-    # validate=False because sepaxml's xmlschema validator is strict about
-    # date formatting (datetime vs date). The XML structure is correct.
-    return dd.export(validate=False)
+    # Validated on the way out. The file goes to a bank, which is the only other
+    # thing that checks it and the slowest place to find out. Validation used to
+    # be off because sepaxml rejects a datetime where the schema wants a date;
+    # `_as_date` removes that cause, so the check can stay on.
+    return dd.export(validate=True)

--- a/backend/tests/integration/test_registration_capacity.py
+++ b/backend/tests/integration/test_registration_capacity.py
@@ -1,0 +1,228 @@
+"""Capacity must be decided under a lock, and only for the seat that was freed.
+
+``current_participants`` is a cached column incremented in Python. Without a row
+lock two registrations arriving together both read ``max - 1``, both confirm and
+both increment, so the activity goes over capacity and the counter drifts from
+the ``registrations`` rows. Waitlist promotion had the mirror problem: it filled
+a seat without checking there was one, and could fill it from another modality.
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from itertools import count
+
+import pytest
+from sqlalchemy import event
+
+from app.domains.activities.models import Activity, ActivityModality, ActivityPrice
+from app.domains.activities.registration_service import (
+    cancel_registration,
+    register_member,
+)
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+PRICE = Decimal("10.00")
+_slugs = count(1)
+
+
+@pytest.fixture
+def org(db):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if not org:
+        org = OrganizationSettings(id=1, name="Capacity Club", default_vat_rate=21)
+        db.add(org)
+        db.flush()
+    return org
+
+
+@pytest.fixture
+def membership_type(db):
+    mt = MembershipType(name="Capacity", slug="capacity", is_active=True)
+    db.add(mt)
+    db.flush()
+    return mt
+
+
+def _member(db, membership_type, suffix):
+    person = Person(
+        first_name="Cap", last_name=suffix, email=f"cap-{suffix}@examplee6e3b1.com"
+    )
+    db.add(person)
+    db.flush()
+    member = Member(
+        person_id=person.id,
+        membership_type_id=membership_type.id,
+        member_number=f"CAP-{suffix}",
+        status="active",
+    )
+    db.add(member)
+    db.flush()
+    return member
+
+
+def _activity(db, *, max_participants=1, waiting_list=True):
+    now = datetime.now(timezone.utc)
+    activity = Activity(
+        name="Capacity Activity",
+        slug=f"capacity-activity-{next(_slugs)}",
+        starts_at=now + timedelta(days=10),
+        ends_at=now + timedelta(days=11),
+        registration_starts_at=now - timedelta(days=1),
+        registration_ends_at=now + timedelta(days=9),
+        max_participants=max_participants,
+        status="published",
+        is_active=True,
+        features={"waiting_list": waiting_list},
+    )
+    db.add(activity)
+    db.flush()
+    price = ActivityPrice(
+        activity_id=activity.id,
+        name="Standard",
+        amount=PRICE,
+        is_default=True,
+        is_active=True,
+    )
+    db.add(price)
+    db.flush()
+    return activity, price
+
+
+def _modality(db, activity, name, max_participants):
+    m = ActivityModality(
+        activity_id=activity.id,
+        name=name,
+        max_participants=max_participants,
+        current_participants=0,
+        is_active=True,
+    )
+    db.add(m)
+    db.flush()
+    return m
+
+
+class TestCapacityIsLocked:
+    """The capacity read must take a row lock before deciding.
+
+    This asserts the statement is emitted, not that two connections actually
+    contend. The `db` fixture is one connection inside a transaction that is
+    rolled back, so a real race would need committed setup on a second
+    connection, and a test that deliberately blocks on a lock is exactly the
+    kind that turns flaky under parallel load (see issue #58). What can go wrong
+    silently is the lock not being requested at all, which is what this catches.
+    """
+
+    def _statements(self, db, fn):
+        seen = []
+
+        def record(conn, cursor, statement, params, context, executemany):
+            seen.append(" ".join(statement.split()))
+
+        event.listen(db.get_bind(), "before_cursor_execute", record)
+        try:
+            fn()
+        finally:
+            event.remove(db.get_bind(), "before_cursor_execute", record)
+        return seen
+
+    def test_activity_row_is_locked(self, db, org, membership_type):
+        activity, price = _activity(db, max_participants=2)
+        member = _member(db, membership_type, "locked")
+
+        sql = self._statements(
+            db, lambda: register_member(db, activity, member, price.id)
+        )
+        locks = [s for s in sql if "FOR UPDATE" in s.upper() and "activities" in s]
+        assert locks, "register_member must SELECT ... FOR UPDATE the activity row"
+
+    def test_modality_row_is_locked_too(self, db, org, membership_type):
+        activity, price = _activity(db, max_participants=5)
+        modality = _modality(db, activity, "Morning", max_participants=2)
+        member = _member(db, membership_type, "lockedmod")
+
+        sql = self._statements(
+            db,
+            lambda: register_member(
+                db, activity, member, price.id, modality_id=modality.id
+            ),
+        )
+        locks = [
+            s for s in sql if "FOR UPDATE" in s.upper() and "activity_modalities" in s
+        ]
+        assert locks, "the modality row must be locked when one is supplied"
+
+    def test_the_lock_refreshes_the_counter(self, db, org, membership_type):
+        """populate_existing() is what makes the lock worth taking.
+
+        Without it SQLAlchemy returns the identity-mapped instance and the stale
+        counter is read straight through the lock.
+        """
+        activity, price = _activity(db, max_participants=1)
+        first = _member(db, membership_type, "stale1")
+        second = _member(db, membership_type, "stale2")
+
+        register_member(db, activity, first, price.id)
+        # Simulate another transaction having taken the seat.
+        db.execute(
+            Activity.__table__.update()
+            .where(Activity.id == activity.id)
+            .values(current_participants=1)
+        )
+        activity.current_participants = 0  # stale in-session value
+
+        second_reg = register_member(db, activity, second, price.id)
+        assert second_reg.status == "waitlist"
+
+
+class TestPromotionRespectsCapacity:
+    def test_no_promotion_when_the_cap_was_lowered(self, db, org, membership_type):
+        """A freed seat is not proof there is room."""
+        activity, price = _activity(db, max_participants=2)
+        first = _member(db, membership_type, "cap1")
+        second = _member(db, membership_type, "cap2")
+        third = _member(db, membership_type, "cap3")
+
+        a = register_member(db, activity, first, price.id)
+        register_member(db, activity, second, price.id)
+        waiting = register_member(db, activity, third, price.id)
+        assert waiting.status == "waitlist"
+
+        # An admin shrinks the activity while someone is waiting.
+        activity.max_participants = 1
+        db.flush()
+
+        cancel_registration(db, a)
+
+        assert waiting.status == "waitlist", "promoted past the lowered cap"
+
+
+class TestPromotionStaysInItsModality:
+    def test_a_freed_unmodalitied_seat_does_not_promote_across(
+        self, db, org, membership_type
+    ):
+        """The bug: modality_id None meant an unfiltered query.
+
+        Cancelling a registration that had no modality promoted the oldest
+        waitlister in the whole activity — possibly one waiting on a different
+        modality that is still full — and incremented that modality past its cap.
+        """
+        activity, price = _activity(db, max_participants=2)
+        morning = _modality(db, activity, "Morning", max_participants=1)
+
+        plain = _member(db, membership_type, "plain")
+        morning_taken = _member(db, membership_type, "mtaken")
+        morning_waiting = _member(db, membership_type, "mwait")
+
+        plain_reg = register_member(db, activity, plain, price.id)
+        register_member(db, activity, morning_taken, price.id, modality_id=morning.id)
+        waiting = register_member(
+            db, activity, morning_waiting, price.id, modality_id=morning.id
+        )
+        assert waiting.status == "waitlist"
+
+        cancel_registration(db, plain_reg)
+
+        assert waiting.status == "waitlist", "promoted into a full modality"
+        assert morning.current_participants == 1

--- a/backend/tests/unit/test_sepa_xml.py
+++ b/backend/tests/unit/test_sepa_xml.py
@@ -4,7 +4,9 @@ from datetime import date
 from decimal import Decimal
 from unittest.mock import MagicMock
 
-from app.domains.billing.sepa_xml import generate_sepa_xml
+import pytest
+
+from app.domains.billing.sepa_xml import SepaExportError, generate_sepa_xml
 
 
 def _mock_remittance(**overrides):
@@ -95,7 +97,14 @@ class TestSepaXmlGeneration:
         assert "NbOfTxs>2<" in xml
         assert "125.00" in xml  # CtrlSum
 
-    def test_skips_receipts_without_mandate(self):
+    def test_refuses_receipts_without_mandate(self):
+        """Was `test_skips_receipts_without_mandate`, asserting NbOfTxs>1<.
+
+        That pinned the defect in place: the second receipt was dropped and the
+        file happily declared one transaction, while the remittance still said
+        two. See TestMissingMandate for why silently shrinking the batch is the
+        wrong answer.
+        """
         remittance = _mock_remittance()
         receipts = [
             _mock_receipt(member_id=1),
@@ -103,8 +112,8 @@ class TestSepaXmlGeneration:
         ]
         mandates = {1: _mock_mandate(member_id=1)}
 
-        xml = generate_sepa_xml(remittance, receipts, mandates).decode()
-        assert "NbOfTxs>1<" in xml
+        with pytest.raises(SepaExportError):
+            generate_sepa_xml(remittance, receipts, mandates)
 
     def test_one_off_mandate_type(self):
         remittance = _mock_remittance()
@@ -132,3 +141,75 @@ class TestSepaXmlGeneration:
         xml = generate_sepa_xml(remittance, receipts, mandates).decode()
         # Description should be truncated to 140 chars
         assert "A" * 140 not in xml or len(xml) > 0  # Just ensure no error
+
+
+class TestMissingMandate:
+    """A receipt whose mandate is gone must stop the export, not be dropped.
+
+    The remittance keeps the total_amount and receipt_count agreed at creation
+    and the receipts stay linked by remittance_id, so a file built from a subset
+    means the bank collects less than the batch says while those receipts are
+    excluded from future batches, with nothing reconciling the two.
+    """
+
+    def test_raises_instead_of_skipping(self):
+        remittance = _mock_remittance()
+        receipts = [_mock_receipt(member_id=1), _mock_receipt(member_id=2)]
+        mandates = {1: _mock_mandate(member_id=1)}  # member 2's mandate is gone
+
+        with pytest.raises(SepaExportError) as exc:
+            generate_sepa_xml(remittance, receipts, mandates)
+        assert "[2]" in str(exc.value)
+
+    def test_names_every_missing_member(self):
+        remittance = _mock_remittance()
+        receipts = [_mock_receipt(member_id=n) for n in (1, 2, 3)]
+        mandates = {2: _mock_mandate(member_id=2)}
+
+        with pytest.raises(SepaExportError) as exc:
+            generate_sepa_xml(remittance, receipts, mandates)
+        # Both, so one run tells the operator everything to fix.
+        assert "[1, 3]" in str(exc.value)
+
+    def test_no_partial_file_is_returned(self):
+        """The failure must not come back as a shorter file."""
+        remittance = _mock_remittance()
+        receipts = [_mock_receipt(member_id=1), _mock_receipt(member_id=2)]
+        mandates = {1: _mock_mandate(member_id=1)}
+
+        with pytest.raises(SepaExportError):
+            generate_sepa_xml(remittance, receipts, mandates)
+
+
+class TestSchemaValidation:
+    """The export is validated on the way out.
+
+    The bank is otherwise the only thing that checks the file, and the slowest
+    place to find out.
+    """
+
+    def test_export_is_schema_valid(self):
+        remittance = _mock_remittance()
+        receipts = [_mock_receipt()]
+        mandates = {1: _mock_mandate()}
+
+        # Would raise sepaxml's ValidationError if the document were malformed.
+        xml = generate_sepa_xml(remittance, receipts, mandates)
+        assert b"pain.008.001.02" in xml
+
+    def test_datetime_dates_are_narrowed(self):
+        """A datetime where the schema wants a date used to fail validation.
+
+        Both columns are Date today, so this guards the model changing under us
+        rather than a live path — the failure it prevents names neither the
+        field nor the payment.
+        """
+        from datetime import datetime
+
+        remittance = _mock_remittance(due_date=datetime(2026, 5, 1, 9, 30))
+        receipts = [_mock_receipt()]
+        mandates = {1: _mock_mandate(signed_at=datetime(2026, 4, 1, 8, 15))}
+
+        xml = generate_sepa_xml(remittance, receipts, mandates)
+        assert b"2026-05-01" in xml
+        assert b"2026-04-01" in xml


### PR DESCRIPTION
Closes #81, #82, #83. Each finding was re-verified against `main` before anything was changed.

## #81 — the SEPA export dropped receipts silently

A mandate cancelled between `create_remittance` and `generate_remittance_xml` is missing from the second read, and the builder skipped it with a bare `continue`. The remittance keeps the `total_amount` and `receipt_count` agreed at creation and the receipts stay linked by `remittance_id`, so **the bank collected less than the batch said** while those receipts were excluded from future batches — with nothing reconciling the two.

It now raises `SepaExportError` naming every affected member in one message, surfaced as a 400. Failing is the right answer here: a remittance that no longer matches what was approved should not be quietly rewritten into a smaller one.

> **A test asserted the old behaviour.** `test_skips_receipts_without_mandate` checked `NbOfTxs>1<` for a two-receipt batch — it pinned the defect in place. Rewritten rather than deleted, with a note recording what it used to claim.

## #82 — the file was written unvalidated, and half the finding was wrong

`export(validate=False)` meant **neither we nor sepaxml checked the file**, and the bank was the only thing that did, days later.

The comment blamed strict date handling, and it was right — verified directly:

```
date + date                -> PASSES
datetime mandate_date      -> FAILS: ValidationError
datetime collection_date   -> FAILS: ValidationError
```

Both columns feeding this are `Date` today, so the workaround has outlived its reason. `_as_date` narrows defensively and validation goes back on.

**The other half of that finding does not exist on `main`.** The audit says `signed_at` may be `None`; it is `signed_at: date` (required) on `MandateCreate` and `nullable=False` in migration `be824d96ca35`. The ternary that "checked" it was dead code, not a live defect. [Reported on the issue](https://github.com/marcandreuf/memship/issues/82#issuecomment-5368553990) rather than fixed silently.

## #83 — activity capacity had no concurrency control

`current_participants` is a cached column incremented in Python, so two registrations arriving together both read `max - 1`, both confirm, both increment.

`register_member` now locks the activity row — and the modality when one is supplied, always in that order so two callers cannot deadlock — before deciding.

**`populate_existing()` is the part that matters.** The endpoint has already loaded the activity to return its 404, and without it SQLAlchemy hands back the identity-mapped instance with the *stale* counter still attached: the lock would be taken and the old value read straight through it. There is a test for exactly that, because it is the failure mode that would look fixed.

This follows the pattern `domains/bookings/service.py:585,661` already uses on `space_slots` — applying an in-house pattern, not inventing one.

### Two Medium findings in the same function

Cheap to do while it was open, and both were listed in #83:

- **M3** — promotion never re-checked capacity, so a cap an admin lowered while people were waiting was ignored.
- **M4** — a freed seat with no modality ran an *unfiltered* query, promoting someone waiting on a different, still-full modality and pushing it past its own cap.

The capacity rule now lives in one place, `_full_level`, since the new-registration path and promotion had already drifted apart once.

## Verification

**1284 passed** (1274 before, plus 10 new), zero failures.

One honest limitation: **the lock is covered by asserting the statement is emitted, not by racing two connections.** The `db` fixture is a single connection inside a rolled-back transaction, so a real race needs committed setup on a second connection — and a test that deliberately blocks on a lock is exactly the kind that turns flaky under parallel load (#58). What can go wrong silently is the lock not being requested at all, and that is what the test catches. A true contention test would be better evidence; it is not better than the flakiness it would add here.

Product code, unlike everything else merged today — so this one does earn a release when you next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6
