### PR TITLE
Stop a webhook paying the wrong amount, and three quieter audit fixes

### DIFF
--- a/backend/app/core/security/dependencies.py
+++ b/backend/app/core/security/dependencies.py
@@ -8,6 +8,24 @@ from app.db.session import get_db
 from app.domains.auth.models import User
 
 
+def _subject_id(payload: dict) -> int | None:
+    """The user id in a token's ``sub``, or None if it is not usable.
+
+    A token can carry a valid signature and still be unusable: no ``sub`` at
+    all, or one that is not numeric. Reading it as ``int(payload["sub"])`` turned
+    those into a KeyError or ValueError escaping the dependency, so the caller
+    got a 500 where the honest answer is 401 — an authentication failure
+    reported as a server fault, and noise in any error budget watching 5xx.
+    """
+    sub = payload.get("sub")
+    if sub is None:
+        return None
+    try:
+        return int(sub)
+    except (TypeError, ValueError):
+        return None
+
+
 def get_current_user(
     access_token: str | None = Cookie(default=None),
     db: Session = Depends(get_db),
@@ -25,7 +43,12 @@ def get_current_user(
             detail="Invalid or expired token",
         )
 
-    user_id = int(payload["sub"])
+    user_id = _subject_id(payload)
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )
     user = db.query(User).filter(User.id == user_id, User.is_active == True).first()
 
     if not user:
@@ -85,5 +108,7 @@ def get_optional_user(
     if payload is None:
         return None
 
-    user_id = int(payload["sub"])
+    user_id = _subject_id(payload)
+    if user_id is None:
+        return None
     return db.query(User).filter(User.id == user_id, User.is_active == True).first()

--- a/backend/app/domains/activities/registration_service.py
+++ b/backend/app/domains/activities/registration_service.py
@@ -295,7 +295,17 @@ def cancel_registration(
         for receipt in unpaid_receipts:
             receipt.status = "cancelled"
     except Exception:
-        pass  # Don't fail cancellation if receipt update fails
+        # The seat is already released, so failing the cancellation here would be
+        # worse than an invoice left open — but it must not be invisible. A
+        # receipt still standing against a cancelled registration is money the
+        # member is asked for and does not owe, and nothing else reconciles the
+        # two. Same reasoning as ensure_registration_receipt, which logs for the
+        # mirror case.
+        logger.exception(
+            "Failed to cancel receipts for registration %s; a receipt may still "
+            "stand against a cancelled registration",
+            registration.id,
+        )
 
     # Dispatch cancellation email (async via Celery)
     _dispatch_cancellation_email(registration, activity)

--- a/backend/app/domains/billing/providers/redsys_provider.py
+++ b/backend/app/domains/billing/providers/redsys_provider.py
@@ -18,7 +18,7 @@ import logging
 import re
 import secrets
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from urllib.parse import parse_qs
 
 from redsys.client import RedirectClient
@@ -96,6 +96,29 @@ def map_response_to_outcome(ds_response: str) -> str:
     if 0 <= code <= 99:
         return "paid"
     return "denied"
+
+
+def _amount_mismatch(notified: str | None, expected) -> Decimal | None:
+    """The notified amount when it differs from the receipt total, else None.
+
+    python-redsys hands back a Decimal in euros — the same unit ``create_payment``
+    passes in — so the two compare directly.
+
+    Returns None when there is nothing to check: no amount on the notification,
+    or one that will not parse. A real payment must not be held up by a field we
+    failed to read; this check exists to catch a wrong number, not to add a new
+    way for a correct payment to be rejected.
+    """
+    if notified is None:
+        return None
+    try:
+        got = Decimal(str(notified))
+    except (InvalidOperation, TypeError, ValueError):
+        logger.warning(
+            "Could not parse Redsys Ds_Amount %r; amount not checked", notified
+        )
+        return None
+    return got if got != Decimal(str(expected)) else None
 
 
 class RedsysAdapter(PaymentProviderAdapter):
@@ -251,6 +274,29 @@ class RedsysAdapter(PaymentProviderAdapter):
                 receipt = db.query(Receipt).filter(Receipt.id == fallback_id).first()
         if not receipt:
             return {"ignored": True, "reason": f"No receipt for order {ds_order}"}
+
+        mismatch = _amount_mismatch(event_data.get("ds_amount"), receipt.total_amount)
+        if mismatch is not None:
+            # Authorised, but not for what we asked. Marking it paid in full
+            # would write off the difference silently; the signature proves the
+            # message is genuine, not that the sum is right. Left unpaid and
+            # logged so a person decides — a retry cannot change the amount, so
+            # this is reported as handled rather than failed.
+            logger.error(
+                "Redsys notified %s for receipt %s, which totals %s. Receipt "
+                "left unpaid for manual review.",
+                mismatch,
+                receipt.id,
+                receipt.total_amount,
+            )
+            return {
+                "ignored": True,
+                "reason": (
+                    f"Amount mismatch: notified {mismatch}, "
+                    f"expected {receipt.total_amount}"
+                ),
+                "receipt_id": receipt.id,
+            }
 
         outcome = map_response_to_outcome(ds_response)
         if outcome != "paid":

--- a/backend/app/domains/billing/providers/stripe_provider.py
+++ b/backend/app/domains/billing/providers/stripe_provider.py
@@ -177,6 +177,37 @@ class StripeAdapter(PaymentProviderAdapter):
                 "receipt_id": receipt.id,
             }
 
+        # Paid, but for how much? A partial capture or an amount that does not
+        # match is otherwise recorded as payment in full. The webhook signature
+        # proves Stripe sent this, not that the sum is the one we asked for.
+        # Left unpaid and logged so a person decides; a retry cannot change the
+        # amount, so this is reported as handled rather than failed.
+        notified_minor = session_obj.get("amount_total")
+        currency = (session_obj.get("currency") or "eur").lower()
+        expected_minor = (
+            to_minor_units(Decimal(str(receipt.total_amount)), currency)
+            if notified_minor is not None
+            else None
+        )
+        if notified_minor is not None and int(notified_minor) != expected_minor:
+            logger.error(
+                "Stripe notified %s %s minor units for receipt %s, which totals "
+                "%s (%s minor units). Receipt left unpaid for manual review.",
+                notified_minor,
+                currency,
+                receipt.id,
+                receipt.total_amount,
+                expected_minor,
+            )
+            return {
+                "ignored": True,
+                "reason": (
+                    f"Amount mismatch: notified {notified_minor}, "
+                    f"expected {expected_minor} ({currency} minor units)"
+                ),
+                "receipt_id": receipt.id,
+            }
+
         try:
             validate_status_transition(receipt.status, "paid")
         except Exception:

--- a/backend/app/domains/billing/reminder_service.py
+++ b/backend/app/domains/billing/reminder_service.py
@@ -152,7 +152,12 @@ def send_reminder(
     pay_now_url = None
     bank_details = None
     if _has_active_online_provider(db):
-        pay_now_url = f"{settings.FRONTEND_URL}/{locale}/receipts"
+        # The member's own page, not /receipts — that one is the admin list,
+        # gated on `billing.read`, so the portal layout bounced the recipient of
+        # every reminder we sent straight to /dashboard. See
+        # frontend/lib/route-permissions.ts: /my-receipts wants
+        # `self.billing.read`, which is what a member actually holds.
+        pay_now_url = f"{settings.FRONTEND_URL}/{locale}/my-receipts"
     elif org and org.bank_iban:
         bank_details = " — ".join(filter(None, [org.bank_name, org.bank_iban]))
 

--- a/backend/app/domains/billing/service.py
+++ b/backend/app/domains/billing/service.py
@@ -315,6 +315,16 @@ def generate_membership_fees(
     edit an amount before issuing them.
     """
     org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if not org:
+        # Stated rather than dereferenced. Without this the run died on an
+        # AttributeError halfway through — a 500 from the endpoint, and a task
+        # traceback from the scheduled run, neither of which names the actual
+        # problem. Matches generate_receipt_number, which is called from this
+        # same path and already guards this way.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Organization settings not found",
+        )
     default_vat = Decimal(str(org.default_vat_rate or 21))
 
     # Get all active members with their membership type

--- a/backend/tests/integration/api/v1/test_payment_reminders.py
+++ b/backend/tests/integration/api/v1/test_payment_reminders.py
@@ -305,6 +305,32 @@ class TestPayNowLink:
         assert captured["pay_now_url"] is not None
         assert captured["bank_details"] is None
 
+    def test_pay_now_points_at_the_member_page(self, db, monkeypatch):
+        """It used to link /receipts — the admin list, gated on `billing.read`.
+
+        The portal layout bounced the recipient of every reminder we sent to
+        /dashboard, so the only call to action in a dunning email went nowhere
+        for the person it was addressed to. /my-receipts wants
+        `self.billing.read`, which is what a member holds.
+        """
+        captured = _capture_reminder_email(monkeypatch)
+        _ensure_org_settings(db)
+        db.add(
+            PaymentProvider(
+                provider_type="stripe", display_name="Stripe", status="active"
+            )
+        )
+        db.flush()
+        member = _create_member(db, "pn3")
+        r = _create_receipt(
+            db, member, "pn3", "overdue", due_date=TODAY - timedelta(days=5)
+        )
+        send_reminder(db, r, "manual", today=TODAY)
+
+        url = captured["pay_now_url"]
+        assert url.endswith("/my-receipts"), url
+        assert not url.endswith("/receipts") or "/my-receipts" in url
+
     def test_bank_fallback_when_no_provider(self, db, monkeypatch):
         captured = _capture_reminder_email(monkeypatch)
         org = _ensure_org_settings(db)

--- a/backend/tests/unit/test_redsys_provider.py
+++ b/backend/tests/unit/test_redsys_provider.py
@@ -7,6 +7,7 @@ wiring so an accidental library swap won't break silently in production.
 import re
 from decimal import ROUND_HALF_UP, Decimal
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 from urllib.parse import urlencode
 
 import pytest
@@ -326,3 +327,69 @@ class TestEventExtraction:
     def test_event_type_denied(self):
         adapter = RedsysAdapter(VALID_CONFIG)
         assert adapter.extract_event_type({"ds_response": "0180"}) == "payment.denied"
+
+
+class TestAmountVerification:
+    """A valid signature proves the message is genuine, not that the sum is right.
+
+    Redsys returns the amount in euros — the same unit `create_payment` sends —
+    so the two compare directly.
+    """
+
+    def _adapter(self):
+        return RedsysAdapter(VALID_CONFIG)
+
+    def _db_returning(self, receipt):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = receipt
+        return db
+
+    def _notify(self, adapter, db, amount, order="000000000042"):
+        return adapter.handle_webhook(
+            db,
+            {
+                "ds_order": order,
+                "ds_response": "0000",
+                "ds_auth_code": "123456",
+                "ds_amount": amount,
+            },
+        )
+
+    def test_short_payment_does_not_mark_paid(self):
+        receipt = fake_receipt(amount="50.00")
+        result = self._notify(self._adapter(), self._db_returning(receipt), "10.00")
+
+        assert result["ignored"] is True
+        assert "mismatch" in result["reason"].lower()
+        assert receipt.status == "emitted", "a short payment was recorded as paid"
+
+    def test_matching_amount_still_pays(self):
+        receipt = fake_receipt(amount="50.00")
+        result = self._notify(self._adapter(), self._db_returning(receipt), "50.00")
+
+        assert result.get("ignored") is not True
+        assert receipt.status == "paid"
+
+    def test_absent_amount_is_not_a_mismatch(self):
+        """Nothing to compare must not become a new way to reject a payment."""
+        receipt = fake_receipt(amount="50.00")
+        result = self._notify(self._adapter(), self._db_returning(receipt), None)
+
+        assert result.get("ignored") is not True
+        assert receipt.status == "paid"
+
+    def test_unparseable_amount_is_not_a_mismatch(self):
+        """A field we could not read must not hold up a real payment."""
+        receipt = fake_receipt(amount="50.00")
+        result = self._notify(self._adapter(), self._db_returning(receipt), "not-a-number")
+
+        assert result.get("ignored") is not True
+        assert receipt.status == "paid"
+
+    def test_trailing_zeros_are_not_a_mismatch(self):
+        """Decimal("50.0") == Decimal("50.00") — compare values, not strings."""
+        receipt = fake_receipt(amount="50.00")
+        result = self._notify(self._adapter(), self._db_returning(receipt), "50.0")
+
+        assert result.get("ignored") is not True
+        assert receipt.status == "paid"

--- a/backend/tests/unit/test_stripe_provider.py
+++ b/backend/tests/unit/test_stripe_provider.py
@@ -168,3 +168,91 @@ class TestHandleWebhook:
         })
 
         assert result["ignored"] is True
+
+
+class TestAmountVerification:
+    """An authorised session is not proof it paid what we asked.
+
+    The signature proves Stripe sent the message, not that the sum is right, so
+    a partial capture or a mismatched amount used to be recorded as payment in
+    full.
+    """
+
+    def _adapter(self):
+        return StripeAdapter({"secret_key": "sk_test", "webhook_secret": "whsec_test"})
+
+    def _receipt(self, total="50.00", status="emitted"):
+        receipt = MagicMock()
+        receipt.id = 42
+        receipt.status = status
+        receipt.total_amount = Decimal(total)
+        return receipt
+
+    def _completed(self, adapter, db, **obj):
+        return adapter.handle_webhook(
+            db,
+            {
+                "type": "checkout.session.completed",
+                "data": {"object": {"metadata": {"receipt_id": "42"}, **obj}},
+            },
+        )
+
+    def test_short_payment_does_not_mark_paid(self):
+        adapter, db = self._adapter(), MagicMock()
+        receipt = self._receipt(total="50.00")
+        db.query.return_value.filter.return_value.first.return_value = receipt
+
+        result = self._completed(
+            adapter, db, amount_total=1000, currency="eur"  # 10.00, not 50.00
+        )
+
+        assert result["ignored"] is True
+        assert "mismatch" in result["reason"].lower()
+        assert receipt.status == "emitted", "a short payment was recorded as paid"
+
+    def test_matching_amount_still_pays(self):
+        adapter, db = self._adapter(), MagicMock()
+        receipt = self._receipt(total="50.00")
+        db.query.return_value.filter.return_value.first.return_value = receipt
+
+        result = self._completed(
+            adapter, db, amount_total=5000, currency="eur", payment_intent="pi_ok"
+        )
+
+        assert result.get("ignored") is not True
+        assert receipt.status == "paid"
+
+    def test_overpayment_is_also_a_mismatch(self):
+        """Not just a shortfall — any disagreement needs a person."""
+        adapter, db = self._adapter(), MagicMock()
+        receipt = self._receipt(total="50.00")
+        db.query.return_value.filter.return_value.first.return_value = receipt
+
+        result = self._completed(adapter, db, amount_total=9900, currency="eur")
+
+        assert result["ignored"] is True
+        assert receipt.status == "emitted"
+
+    def test_absent_amount_is_not_a_mismatch(self):
+        """Nothing to compare must not become a new way to reject a payment."""
+        adapter, db = self._adapter(), MagicMock()
+        receipt = self._receipt(total="50.00")
+        db.query.return_value.filter.return_value.first.return_value = receipt
+
+        result = self._completed(adapter, db, payment_intent="pi_ok")
+
+        assert result.get("ignored") is not True
+        assert receipt.status == "paid"
+
+    def test_zero_decimal_currency_is_not_scaled(self):
+        """JPY has no minor unit, so 5000 yen is amount_total 5000."""
+        adapter, db = self._adapter(), MagicMock()
+        receipt = self._receipt(total="5000")
+        db.query.return_value.filter.return_value.first.return_value = receipt
+
+        result = self._completed(
+            adapter, db, amount_total=5000, currency="jpy", payment_intent="pi_ok"
+        )
+
+        assert result.get("ignored") is not True
+        assert receipt.status == "paid"

--- a/backend/tests/unit/test_token_subject.py
+++ b/backend/tests/unit/test_token_subject.py
@@ -1,0 +1,36 @@
+"""A token that is signed but unusable is a 401, not a 500.
+
+`int(payload["sub"])` turned a missing or non-numeric subject into a KeyError or
+ValueError escaping the dependency, so the caller saw a server fault where the
+honest answer is an authentication failure — and 5xx noise in anything watching
+error rates.
+"""
+
+import pytest
+
+from app.core.security.dependencies import _subject_id
+
+
+class TestSubjectId:
+    def test_reads_a_numeric_subject(self):
+        assert _subject_id({"sub": "42"}) == 42
+
+    def test_accepts_an_integer_subject(self):
+        assert _subject_id({"sub": 42}) == 42
+
+    def test_missing_subject_is_none(self):
+        assert _subject_id({}) is None
+
+    def test_null_subject_is_none(self):
+        assert _subject_id({"sub": None}) is None
+
+    def test_non_numeric_subject_is_none(self):
+        assert _subject_id({"sub": "not-a-user-id"}) is None
+
+    def test_structured_subject_is_none(self):
+        """A well-formed JWT can still carry the wrong shape here."""
+        assert _subject_id({"sub": {"id": 42}}) is None
+
+    @pytest.mark.parametrize("value", ["", " ", "4 2", "42.5", "0x2a"])
+    def test_other_unusable_subjects(self, value):
+        assert _subject_id({"sub": value}) is None


### PR DESCRIPTION
Four Medium findings from the 2026-08-09 audit, picked for harm-to-effort rather than working the list in order. The other 22 open Medium/Low findings are genuinely "as convenient" and are left alone.

## M15 — webhooks never checked the amount

Both handlers marked a receipt **paid in full on any authorised response**. The signature proves the provider sent the message, not that the sum is the one we asked for — so a partial capture or a mismatched amount was recorded as full payment and the difference written off silently.

The two providers speak different units, which is most of the work:

| | Unit returned | Compared against |
|---|---|---|
| Redsys | euros — same unit `create_payment` sends | `receipt.total_amount` directly |
| Stripe | minor units | `to_minor_units(receipt.total_amount, currency)` |

On a mismatch the receipt is **left unpaid** and logged at error level for a person to decide, and reported as handled rather than failed — a retry cannot change the amount, so making the provider redeliver forever helps nobody.

**Deliberately not a new way to reject a good payment.** An absent amount, or one that will not parse, skips the check rather than blocking; a field we failed to read must not hold up a real payment. Tested along with overpayment (not just shortfalls), trailing zeros (`50.0` vs `50.00` — values compared, not strings) and a zero-decimal currency (JPY, where 5000 yen really is `amount_total: 5000`).

## M10 — every payment reminder linked somewhere the member cannot open

The pay-now URL pointed at `/receipts`, which `frontend/lib/route-permissions.ts:24` gates on `billing.read` — an admin permission. The portal layout bounced the recipient of every dunning email we sent to `/dashboard`. The member route is `/my-receipts` (`self.billing.read`).

One path change, but it was the **only call to action in the email**.

## M16 — a signed token with no usable `sub` returned 500

`int(payload["sub"])` let a `KeyError`/`ValueError` escape the dependency, so an authentication failure surfaced as a server fault — and as 5xx noise in anything watching error rates. `_subject_id` returns `None` instead, and the two call sites do what each already does for an invalid token: 401 on the required path, `None` on the optional one.

## M21 — the billing run dereferenced org settings unguarded

Missing settings died on an `AttributeError` mid-run rather than saying what was wrong — a 500 from the endpoint, a bare traceback from the scheduled task. Guarded the way `generate_receipt_number` already does, which is called from this same path, so the exception type is one that already flows through it.

## M2 — the half that was left

The audit found two bare `except: pass` sites. The receipt-generation one had already gained logging via `ensure_registration_receipt`. The **cancellation** path had not, so a receipt left standing against a cancelled registration — money the member is asked for and does not owe — was invisible. It logs now.

## Verification

**1306 passed**, zero failures (1284 before, plus 22 new).

One thing caught while writing the Stripe test rather than after: computing the expected minor units *before* checking whether an amount was even notified would have broken the existing `MagicMock`-based tests, and done needless work on every webhook. Reordered so the receipt total is only read when there is something to compare it to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6