### PR TITLE
Add the v2.3.1 release row in all three locales

### DIFF
--- a/README.ca.md
+++ b/README.ca.md
@@ -109,6 +109,7 @@ Memship segueix el [versionat semàntic](https://semver.org/) i **els números d
 | v2.1.0 | Configuració inicial sense credencials publicades — el mateix procés interactiu a tots els entorns, sense comptes amb contrasenyes publicades en aquest repositori, més opcions desateses per a instal·lacions automatitzades | Fet |
 | v2.2.0 | Recuperació del superadministrador des del servidor — la seva contrasenya es restableix amb `python -m app.cli.seed` a la màquina, no per correu. **Seguretat:** l'accés a la bústia equivalia a controlar tota la instància | Fet |
 | v2.3.0 | Fitxers pujats darrere d'autenticació, i un inici de sessió que no es pot endevinar indefinidament — **Seguretat:** el directori d'emmagatzematge es servia com a fitxers estàtics, els tokens de restabliment tornaven en la resposta de l'API i la clau de signatura d'exemple publicada era el valor per defecte de compose. **Canvi incompatible:** les instal·lacions que feien servir aquesta clau en reben una de nova i tanquen totes les sessions | Fet |
+| v2.3.1 | Camins de diners que fallaven en silenci — un fitxer SEPA ja no descarta rebuts amb el mandat cancel·lat, un webhook de pagament ja no registra un import diferent com a pagament complet, i una activitat ja no pot superar l'aforament si dues persones s'hi inscriuen alhora. **Comportament:** una remesa amb el mandat desaparegut ara falla amb un error en lloc de generar un fitxer incomplet, i un pagament per un import diferent deixa el rebut pendent de revisió | Fet |
 
 ## Full de ruta
 

--- a/README.es.md
+++ b/README.es.md
@@ -109,6 +109,7 @@ Memship sigue el [versionado semántico](https://semver.org/) y **los números d
 | v2.1.0 | Configuración inicial sin credenciales publicadas — el mismo proceso interactivo en todos los entornos, sin cuentas cuyas contraseñas se publiquen en este repositorio, más opciones desatendidas para instalaciones automatizadas | Hecho |
 | v2.2.0 | Recuperación del superadministrador desde el servidor — su contraseña se restablece con `python -m app.cli.seed` en la máquina, no por correo. **Seguridad:** el acceso al buzón equivalía a controlar toda la instancia | Hecho |
 | v2.3.0 | Archivos subidos tras autenticación, y un inicio de sesión que no se puede adivinar indefinidamente — **Seguridad:** el directorio de almacenamiento se servía como archivos estáticos, los tokens de restablecimiento volvían en la respuesta de la API y la clave de firma de ejemplo publicada era el valor por defecto de compose. **Cambio incompatible:** las instalaciones que usaban esa clave reciben una nueva y cierran todas las sesiones | Hecho |
+| v2.3.1 | Rutas de dinero que fallaban en silencio — un fichero SEPA ya no descarta recibos cuyo mandato se canceló, un webhook de pago ya no registra un importe distinto como pago completo, y una actividad ya no puede sobrepasar su aforo si dos personas se inscriben a la vez. **Comportamiento:** una remesa cuyo mandato ha desaparecido ahora falla con un error en lugar de generar un fichero incompleto, y un pago por un importe distinto deja el recibo pendiente de revisión | Hecho |
 
 ## Hoja de ruta
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Memship follows [semantic versioning](https://semver.org/), and **version number
 | v2.1.0 | Setup without published credentials — the same interactive setup on every environment, with no accounts whose passwords ship in this repository, plus unattended flags for scripted installs | Done |
 | v2.2.0 | Super admin recovery from the host — a super admin's password is reset with `python -m app.cli.seed` on the server rather than by email. **Security:** mailbox access was equivalent to owning the instance | Done |
 | v2.3.0 | Uploaded files behind authentication, and sign-in that cannot be guessed at forever — **Security:** the storage directory was served by a static-file mount, reset tokens came back in API responses, and the published placeholder signing key was the Compose default. **Breaking:** installs on that placeholder key get a fresh one, signing everyone out | Done |
+| v2.3.1 | Money paths that were wrong quietly — a SEPA file no longer drops receipts whose mandate was cancelled, a payment webhook no longer records a mismatched amount as paid in full, and an activity can no longer be over-booked by two people registering at once. **Behaviour:** a remittance whose mandate vanished now fails with an error instead of producing a short file, and a payment for the wrong amount leaves the receipt unpaid for review | Done |
 
 ## Roadmap
 


### PR DESCRIPTION
Prepares the release. The tagged commit must carry its own README row or the Release workflow fails, so this is the commit staging will validate and the one that gets tagged.

**v2.3.1, a patch** — by the rule in `CONTRIBUTING.md` ("Patch — bug fixes and small polish, no new feature"), everything since v2.3.0 is a fix, with no new feature or roadmap item.

The row leads with what an operator would notice rather than audit finding numbers:

- a SEPA file no longer drops receipts whose mandate was cancelled (#81)
- a payment webhook no longer records a mismatched amount as paid in full (M15)
- an activity can no longer be over-booked by two people registering at once (#83)

Both **deliberate behaviour changes** are called out, since each turns a call that used to succeed into one that does not — a remittance whose mandate vanished now errors instead of writing a short file, and a mismatched payment leaves the receipt unpaid for review. An operator seeing either for the first time should be able to find out why from the release row.

Three locales in parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6