### PR TITLE
Bind the drafted release to its tag, and seed notes worth publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,10 @@ jobs:
           # Re-promotion via workflow_dispatch must never touch notes that already
           # exist — overwriting a published release with a seeded draft would lose
           # the prose this whole step exists to protect.
+          #
+          # This lookup is by tag, so it also depended on the binding below being
+          # right: a release carrying the `untagged-<sha>` placeholder is invisible
+          # here, and a re-run would have drafted a second one alongside it (#88).
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "::notice::$TAG already has a release. Left untouched."
             echo "created=false" >> "$GITHUB_OUTPUT"
@@ -218,30 +222,48 @@ jobs:
           # Newest line, or a patch to an older one? Only the former claims Latest.
           HIGHEST="$(git tag -l 'v*.*.*' --sort=v:refname | tail -1)"
 
+          # Everything here has to read sensibly if it is published untouched.
+          # The seed used to carry "delete this before publishing" instructions
+          # and every commit subject in the range, which is fine as raw material
+          # and wrong as a release note — and one keystroke away from being the
+          # published one. A summary and a compare link are useful either way.
           {
-            echo "<!-- Draft seeded from the README release table row. Replace this summary with the"
-            echo "     real notes before publishing: lead on why the change matters, not what"
-            echo "     changed. Body starts at ##, no H1. Delete the commit list below. -->"
+            echo "<!-- Seeded from the README release table row. Replace this with real notes:"
+            echo "     lead on why the change matters, not what changed. Body starts at ##, no H1."
+            echo "     Publishing it unedited is not a disaster, but it is not the story either. -->"
             echo ""
             echo "## Summary"
             echo ""
             echo "$SUMMARY"
             echo ""
-            echo "---"
-            echo ""
-            echo "### Commits in $RANGE — raw material, delete before publishing"
-            echo ""
-            git log --no-merges --format='- %s' "$RANGE"
+            if [[ "$RANGE" == *".."* ]]; then
+              echo "**What changed:** [\`$RANGE\`](https://github.com/${{ github.repository }}/compare/${RANGE/../...})"
+            fi
           } > release-notes.md
 
-          LATEST_FLAG="--latest=false"
-          if [[ "$HIGHEST" == "$TAG" ]]; then LATEST_FLAG="--latest"; fi
+          if [[ "$HIGHEST" == "$TAG" ]]; then MAKE_LATEST=true; else MAKE_LATEST=false; fi
 
-          gh release create "$TAG" \
-            --draft \
-            $LATEST_FLAG \
-            --title "$TAG — $HEADLINE" \
-            --notes-file release-notes.md
+          # Created through the REST API rather than `gh release create` because
+          # that produced a release carrying the `untagged-<sha>` placeholder
+          # instead of the tag (#88): a published release bound to no tag, and a
+          # tag with no release, discovered only when someone opened it. tag_name
+          # is explicit here, and checked below — the tag already exists, since
+          # pushing it is what triggered this workflow.
+          RELEASE_ID="$(gh api --method POST "repos/${{ github.repository }}/releases" \
+            -f tag_name="$TAG" \
+            -f name="$TAG — $HEADLINE" \
+            -f body="$(cat release-notes.md)" \
+            -F draft=true \
+            -f make_latest="$MAKE_LATEST" \
+            --jq .id)"
+
+          # A mis-bound release must fail here, not be found by whoever publishes it.
+          BOUND="$(gh api "repos/${{ github.repository }}/releases/$RELEASE_ID" --jq .tag_name)"
+          if [[ "$BOUND" != "$TAG" ]]; then
+            echo "::error::Drafted release $RELEASE_ID is bound to '$BOUND', not '$TAG'. Fix it with: gh api --method PATCH repos/${{ github.repository }}/releases/$RELEASE_ID -f tag_name=$TAG"
+            exit 1
+          fi
+          echo "Draft $RELEASE_ID bound to $BOUND."
 
           echo "created=true" >> "$GITHUB_OUTPUT"
           echo "::notice::Drafted $TAG — $HEADLINE. Finish the notes and publish it."


### PR DESCRIPTION
Closes #88. Cutting v2.3.1 was the first tag since #52 taught this workflow to draft notes, and it surfaced two problems.

## The release was not attached to its tag

`gh release create "$TAG" --draft` produced a release carrying the placeholder:

```
$ gh api repos/marcandreuf/memship/releases/374353839 --jq .tag_name
untagged-fa9dec29bf88bbd19549
```

That survived publishing. For a few minutes there was a **published release attached to no tag** and a `v2.3.1` tag with no release — `gh release view v2.3.1` reported `release not found` while the release sat plainly in `gh release list`.

It is created through the REST API now, with `tag_name` explicit and **asserted after creation**. A mis-bound release fails the step with the exact `gh api --method PATCH` command to repair it, rather than being discovered by whoever opens it later.

### The knock-on nobody would have looked for

The idempotency guard at the top of that step — the one protecting published prose from being overwritten by a re-promotion — looks the release up **by tag**:

```bash
if gh release view "$TAG" >/dev/null 2>&1; then ... fi
```

A placeholder-bound release is invisible to it. A `workflow_dispatch` re-promotion would have drafted a *second* release alongside the first rather than leaving it alone, which is the opposite of what that guard exists to do.

## The seeded notes were not safe to publish

The body carried an HTML comment reading *"Replace this summary… Delete the commit list below"* followed by every commit subject in the range. Fine as raw material, wrong as a release note, and one keystroke from being the published one — which nearly happened here, caught only by reading the draft before publishing rather than trusting it.

Now it is a summary plus a link to the compare view: still useful when writing the real notes, and coherent if it goes out untouched. The reminder stays as a comment. What changed is the cost of ignoring it.

## Two smaller corrections

- `make_latest` is sent as a **string**, which is what the API enum (`"true"`/`"false"`/`"legacy"`) expects, not the boolean `-F` was sending.
- `target_commitish` is gone. It is redundant when `tag_name` names a tag that already exists — and passing it is exactly what made the manual repair PATCH fail with a 422.

## Verification

Simulated the step against the real v2.3.1 README row:

```
TITLE: v2.3.1 — Money paths that were wrong quietly

## Summary

Money paths that were wrong quietly — a SEPA file no longer drops receipts whose mandate …

**What changed:** [`v2.3.0..v2.3.1`](https://github.com/marcandreuf/memship/compare/v2.3.0...v2.3.1)
```

The compare URL resolves (200). The YAML parses.

**What this cannot verify** is the API call itself — that needs a real tag push, so the next release is the true test. The assertion is there precisely so that test fails loudly rather than quietly, and v2.3.1 itself has already been repaired by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6