### PR TITLE
Require a confirmed email to sign in, and make invoice numbers gapless

### DIFF
--- a/backend/alembic/versions/f4c0f3226f34_add_invoice_sequences.py
+++ b/backend/alembic/versions/f4c0f3226f34_add_invoice_sequences.py
@@ -1,0 +1,72 @@
+"""Add invoice_sequences — a gapless receipt number per year
+
+Revision ID: f4c0f3226f34
+Revises: d1a2b3c4e5f6
+Create Date: 2026-08-21
+
+The receipt number used to be COUNT(receipts in that year, is_active) + 1.
+Deactivating a receipt therefore shifted the number of every receipt issued
+after it, and the collision loop guarding the result skipped numbers — so an
+invoice series that Spanish practice expects to be sequential and unbroken was
+neither.
+
+This replaces it with a counter per year. The backfill matters as much as the
+table: without it, an existing install would restart its series at 1 and collide
+with every number it has already issued. Each year starts from the highest
+number actually present in that year's receipts, so numbering continues where it
+left off.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f4c0f3226f34"
+down_revision = "d1a2b3c4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invoice_sequences",
+        # autoincrement=False: the year is the calendar year, not a surrogate
+        # key. Without it an integer primary key gets a sequence default, so a
+        # row inserted without a year would be filed under year 1.
+        sa.Column("year", sa.Integer(), nullable=False, autoincrement=False),
+        sa.Column("next_number", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("year"),
+    )
+
+    # Seed each year from the highest number already issued in it.
+    #
+    # Read from the receipt_number rather than counting rows: the count is the
+    # very thing that was wrong, and it excludes deactivated receipts whose
+    # numbers are still spent. Numbers are `{prefix}-{year}-{NNNN}`, so the last
+    # dash-separated field is the sequence; the regex filter keeps any
+    # hand-edited number that does not end in digits out of the MAX.
+    #
+    # Grouped by the year in the number, not by emission_date, because that is
+    # the year the number was drawn against — a receipt backdated across a year
+    # boundary must not raise the wrong year's counter.
+    op.execute(
+        """
+        INSERT INTO invoice_sequences (year, next_number)
+        SELECT
+            CAST(split_part(receipt_number, '-', 2) AS INTEGER) AS series_year,
+            MAX(CAST(split_part(receipt_number, '-', -1) AS INTEGER)) + 1
+        FROM receipts
+        WHERE receipt_number ~ '^.*-[0-9]{4}-[0-9]+$'
+        GROUP BY 1
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("invoice_sequences")

--- a/backend/alembic/versions/f4c0f3226f34_add_invoice_sequences.py
+++ b/backend/alembic/versions/f4c0f3226f34_add_invoice_sequences.py
@@ -48,9 +48,14 @@ def upgrade() -> None:
     #
     # Read from the receipt_number rather than counting rows: the count is the
     # very thing that was wrong, and it excludes deactivated receipts whose
-    # numbers are still spent. Numbers are `{prefix}-{year}-{NNNN}`, so the last
-    # dash-separated field is the sequence; the regex filter keeps any
-    # hand-edited number that does not end in digits out of the MAX.
+    # numbers are still spent. Numbers are `{prefix}-{year}-{NNNN}`, and both
+    # fields are read from the END of the string rather than by dash position:
+    # the prefix is free text with no pattern on it, so it can contain dashes
+    # itself. `FAC-A-2026-0007` put "A" where the year was expected and the cast
+    # aborted the migration, which would have blocked the upgrade outright for
+    # that install. Anchoring on the end is indifferent to how many dashes come
+    # before. The filter keeps a hand-edited number that does not end in
+    # `<year>-<digits>` out of the MAX.
     #
     # Grouped by the year in the number, not by emission_date, because that is
     # the year the number was drawn against — a receipt backdated across a year
@@ -59,10 +64,11 @@ def upgrade() -> None:
         """
         INSERT INTO invoice_sequences (year, next_number)
         SELECT
-            CAST(split_part(receipt_number, '-', 2) AS INTEGER) AS series_year,
-            MAX(CAST(split_part(receipt_number, '-', -1) AS INTEGER)) + 1
+            CAST(substring(receipt_number from '([0-9]{4})-[0-9]+$') AS INTEGER)
+                AS series_year,
+            MAX(CAST(substring(receipt_number from '([0-9]+)$') AS INTEGER)) + 1
         FROM receipts
-        WHERE receipt_number ~ '^.*-[0-9]{4}-[0-9]+$'
+        WHERE receipt_number ~ '[0-9]{4}-[0-9]+$'
         GROUP BY 1
         """
     )

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -127,6 +127,27 @@ def login(
             detail="Account is locked",
         )
 
+    # Proving the password is not proving the address. Without this, anyone could
+    # register with a mailbox they do not own and hold a working session on it —
+    # which is what /register already refuses to do by not issuing a cookie of its
+    # own ("the account is not usable until the email is confirmed"). Login was
+    # handing out the session that endpoint declined to.
+    #
+    # 403 rather than 401: the credentials were right. The message has to say what
+    # to do, because the login form shows it verbatim.
+    #
+    # Awaiting *approval* is deliberately not checked here. That address is
+    # verified, the session is what lets the portal explain the wait, and
+    # require_approved_member already closes every feature router behind it.
+    if not user.email_verified:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Confirm your email address before signing in. Check your inbox "
+                "for the confirmation link, or request a new one."
+            ),
+        )
+
     # The address is proven, so forget its failures. The source address keeps
     # its count — holding one valid account must not reset a spray from there.
     LOGIN_BY_EMAIL.clear(email)

--- a/backend/app/cli/reset.py
+++ b/backend/app/cli/reset.py
@@ -34,13 +34,20 @@ KNOWN_TABLES = frozenset({
     "announcement_recipients", "announcements", "audit_logs", "billing_runs",
     "bookings", "concepts", "contacts", "contact_types",
     "custom_field_definitions", "custom_field_values", "discount_codes",
-    "groups", "members", "membership_types", "notifications",
-    "organization_settings", "payment_providers", "persons",
+    "groups", "invoice_sequences", "members", "membership_types",
+    "notifications", "organization_settings", "payment_providers", "persons",
     "receipt_reminders", "receipts", "registration_attachments",
     "registration_consents", "registrations", "reminders", "remittances",
     "role_permissions", "roles", "sepa_mandates", "spaces", "space_slots",
     "user_identities", "user_roles", "users", "webhook_events",
 })
+
+# `invoice_sequences` is club data and goes with the receipts. Preserving it
+# would leave a counter with nothing behind it, so the first invoice of the new
+# club would be numbered as though dozens had already been issued. Nothing is
+# reused either, because the receipts those numbers belonged to are gone in the
+# same operation — the series restarts because the series it continued no longer
+# exists.
 
 # Instance-level configuration and lookups. A club reset never touches these.
 PRESERVED_TABLES = frozenset({

--- a/backend/app/domains/billing/models.py
+++ b/backend/app/domains/billing/models.py
@@ -386,3 +386,33 @@ class ReceiptReminder(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     receipt = relationship("Receipt", backref="reminders")
+
+class InvoiceSequence(Base):
+    """The next receipt number for one year, held as a counter.
+
+    Spanish invoicing practice expects a document series to be sequential and
+    unbroken. The number used to be derived from ``COUNT(receipts in year) + 1``
+    filtered on ``is_active``, which breaks that three ways: deactivating a
+    receipt shifted the number for every one issued afterwards, the sequence was
+    not monotonic, and the collision loop that guarded it skipped numbers —
+    manufacturing the gaps it was meant to prevent.
+
+    A counter only ever moves forward. One row per year, so a receipt backdated
+    into a closed year draws from that year's series instead of clobbering the
+    current one, and the row is locked FOR UPDATE while it is read and bumped.
+
+    Allocated numbers are not returned to the pool. A cancelled receipt keeps
+    its number and stays in the series, which is what makes the series auditable
+    — a missing number is a question, not a tidy-up.
+    """
+
+    __tablename__ = "invoice_sequences"
+
+    # autoincrement=False: this is a calendar year, not a surrogate key. An
+    # integer primary key is autoincrementing by default, which would hand a
+    # row inserted without one the year 1.
+    year = Column(Integer, primary_key=True, autoincrement=False)
+    next_number = Column(Integer, nullable=False, default=1)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/domains/billing/service.py
+++ b/backend/app/domains/billing/service.py
@@ -7,7 +7,9 @@ from fastapi import HTTPException, status
 from sqlalchemy import extract, func, or_
 from sqlalchemy.orm import Query, Session, joinedload
 
-from app.domains.billing.models import Concept, Receipt
+from sqlalchemy.exc import IntegrityError
+
+from app.domains.billing.models import Concept, InvoiceSequence, Receipt
 from app.domains.billing.schemas import (
     GenerateMembershipFeesRequest,
     ReceiptCreate,
@@ -113,16 +115,36 @@ def generate_receipt_number(db: Session, emission_date: date) -> str:
     annual_reset = org.invoice_annual_reset if org.invoice_annual_reset is not None else True
 
     if annual_reset:
-        # Count existing receipts for this year to determine next number
-        count = (
-            db.query(func.count(Receipt.id))
-            .filter(
-                extract("year", Receipt.emission_date) == year,
-                Receipt.is_active.is_(True),
-            )
-            .scalar()
+        # A counter per year, not COUNT(receipts). The count was filtered on
+        # is_active, so deactivating one receipt shifted the number of every
+        # receipt issued after it — an invoice series has to be sequential and
+        # unbroken, and that made it neither. See InvoiceSequence.
+        #
+        # Its own row lock, taken after the org lock and always in that order.
+        seq_row = (
+            db.query(InvoiceSequence)
+            .filter(InvoiceSequence.year == year)
+            .with_for_update()
+            .first()
         )
-        sequence = count + 1
+        if seq_row is None:
+            # First receipt of this year. Two callers can reach this at once, so
+            # the loser of the insert re-reads the winner's row under the lock
+            # rather than both starting at 1.
+            try:
+                with db.begin_nested():
+                    seq_row = InvoiceSequence(year=year, next_number=1)
+                    db.add(seq_row)
+                    db.flush()
+            except IntegrityError:
+                seq_row = (
+                    db.query(InvoiceSequence)
+                    .filter(InvoiceSequence.year == year)
+                    .with_for_update()
+                    .one()
+                )
+        sequence = seq_row.next_number or 1
+        seq_row.next_number = sequence + 1
     else:
         # Global sequential — use org counter
         sequence = org.invoice_next_number or 1
@@ -130,10 +152,19 @@ def generate_receipt_number(db: Session, emission_date: date) -> str:
 
     receipt_number = f"{prefix}-{year}-{sequence:04d}"
 
-    # Ensure uniqueness (safety net)
-    while db.query(Receipt).filter(Receipt.receipt_number == receipt_number).first():
-        sequence += 1
-        receipt_number = f"{prefix}-{year}-{sequence:04d}"
+    # This used to increment past a collision, which quietly produced the gap it
+    # was guarding against. Under the locks above a collision means the counter
+    # disagrees with the receipts — usually a number issued outside this function
+    # — and that is a question for a person, not something to paper over.
+    if db.query(Receipt).filter(Receipt.receipt_number == receipt_number).first():
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                f"Receipt number {receipt_number} already exists. The invoice "
+                f"sequence for {year} is behind the receipts already issued and "
+                "must be corrected before more are created."
+            ),
+        )
 
     return receipt_number
 

--- a/backend/tests/integration/api/v1/test_auth.py
+++ b/backend/tests/integration/api/v1/test_auth.py
@@ -325,3 +325,73 @@ class TestLogout:
         response = client.post("/api/v1/auth/logout")
         assert response.status_code == 200
         assert response.json()["message"] == "Logged out"
+
+
+class TestUnverifiedEmailCannotSignIn:
+    """Proving the password is not proving the address.
+
+    /register deliberately issues no session — "the account is not usable until
+    the email is confirmed" — but login handed out the session that endpoint had
+    declined to, so anyone could register with a mailbox they do not own and hold
+    a working session on it.
+    """
+
+    def _unverified(self, db, email="unverified@examplee6e3b1.com", password="Sup3rSecret!"):
+        person = Person(first_name="Un", last_name="Verified", email=email)
+        db.add(person)
+        db.flush()
+        user = User(
+            person_id=person.id,
+            email=email,
+            password_hash=hash_password(password),
+            role="member",
+            is_active=True,
+            email_verified=False,
+        )
+        db.add(user)
+        db.flush()
+        return user, password
+
+    def test_correct_password_is_still_refused(self, client, db):
+        user, password = self._unverified(db)
+
+        r = client.post(
+            "/api/v1/auth/login", json={"email": user.email, "password": password}
+        )
+
+        assert r.status_code == 403, r.text
+        assert "auth" not in r.cookies, "a session was issued to an unverified address"
+
+    def test_the_message_says_what_to_do(self, client, db):
+        """The login form renders this string verbatim."""
+        user, password = self._unverified(db)
+
+        r = client.post(
+            "/api/v1/auth/login", json={"email": user.email, "password": password}
+        )
+
+        detail = r.json()["detail"].lower()
+        assert "confirm your email" in detail
+        assert "link" in detail
+
+    def test_a_wrong_password_still_reads_as_wrong_credentials(self, client, db):
+        """403 must not become a way to enumerate which addresses exist."""
+        user, _ = self._unverified(db)
+
+        r = client.post(
+            "/api/v1/auth/login",
+            json={"email": user.email, "password": "not-the-password"},
+        )
+
+        assert r.status_code == 401, r.text
+
+    def test_verifying_lets_them_in(self, client, db):
+        user, password = self._unverified(db)
+        user.email_verified = True
+        db.flush()
+
+        r = client.post(
+            "/api/v1/auth/login", json={"email": user.email, "password": password}
+        )
+
+        assert r.status_code == 200, r.text

--- a/backend/tests/integration/test_invoice_numbering.py
+++ b/backend/tests/integration/test_invoice_numbering.py
@@ -1,0 +1,153 @@
+"""Receipt numbers must be sequential and unbroken.
+
+The number used to be COUNT(receipts in that year, is_active) + 1, so
+deactivating one receipt shifted the number of every receipt issued after it,
+and the loop that guarded against the resulting collision skipped numbers —
+manufacturing the gaps it was there to prevent. Spanish invoicing practice
+expects the series to be sequential and unbroken; a counter is the only shape
+that gives that.
+"""
+
+from datetime import date
+
+import pytest
+
+from app.domains.billing.models import InvoiceSequence, Receipt
+from app.domains.billing.service import generate_receipt_number
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+
+@pytest.fixture
+def org(db):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if not org:
+        org = OrganizationSettings(id=1, name="Numbering Club", default_vat_rate=21)
+        db.add(org)
+    org.invoice_prefix = "FAC"
+    org.invoice_annual_reset = True
+    db.flush()
+    return org
+
+
+@pytest.fixture
+def member(db):
+    mt = db.query(MembershipType).first()
+    if not mt:
+        mt = MembershipType(name="Numbering", slug="numbering", is_active=True)
+        db.add(mt)
+        db.flush()
+    person = Person(
+        first_name="Num", last_name="Bering", email="num@examplee6e3b1.com"
+    )
+    db.add(person)
+    db.flush()
+    m = Member(
+        person_id=person.id,
+        membership_type_id=mt.id,
+        member_number="NUM-0001",
+        status="active",
+    )
+    db.add(m)
+    db.flush()
+    return m
+
+
+def _issue(db, member, year=2026, day=15):
+    """Allocate a number and persist a receipt holding it, as callers do."""
+    number = generate_receipt_number(db, date(year, 6, day))
+    db.add(
+        Receipt(
+            receipt_number=number,
+            member_id=member.id,
+            emission_date=date(year, 6, day),
+            due_date=date(year, 7, day),
+            base_amount=10,
+            vat_rate=0,
+            vat_amount=0,
+            total_amount=10,
+            origin="manual",
+            description="Numbering probe",
+            status="pending",
+            is_active=True,
+        )
+    )
+    db.flush()
+    return number
+
+
+class TestSequential:
+    def test_numbers_run_consecutively(self, db, org, member):
+        got = [_issue(db, member) for _ in range(5)]
+        assert got == [
+            "FAC-2026-0001",
+            "FAC-2026-0002",
+            "FAC-2026-0003",
+            "FAC-2026-0004",
+            "FAC-2026-0005",
+        ]
+
+    def test_a_deactivated_receipt_does_not_shift_later_numbers(self, db, org, member):
+        """The defect, directly.
+
+        With COUNT-based numbering, deactivating FAC-2026-0002 made the next
+        receipt FAC-2026-0003 a second time — a duplicate the collision loop then
+        "fixed" by skipping to 0004, leaving a gap and a reused number.
+        """
+        first, second, third = _issue(db, member), _issue(db, member), _issue(db, member)
+        assert (first, second, third) == (
+            "FAC-2026-0001",
+            "FAC-2026-0002",
+            "FAC-2026-0003",
+        )
+
+        db.query(Receipt).filter(Receipt.receipt_number == second).update(
+            {"is_active": False}
+        )
+        db.flush()
+
+        assert _issue(db, member) == "FAC-2026-0004"
+
+    def test_a_cancelled_number_is_not_reissued(self, db, org, member):
+        """A spent number stays spent — that is what makes the series auditable."""
+        first = _issue(db, member)
+        db.query(Receipt).filter(Receipt.receipt_number == first).update(
+            {"status": "cancelled"}
+        )
+        db.flush()
+
+        assert _issue(db, member) == "FAC-2026-0002"
+
+
+class TestPerYear:
+    def test_each_year_keeps_its_own_counter(self, db, org, member):
+        assert _issue(db, member, year=2026) == "FAC-2026-0001"
+        assert _issue(db, member, year=2026) == "FAC-2026-0002"
+        assert _issue(db, member, year=2027) == "FAC-2027-0001"
+        assert _issue(db, member, year=2026) == "FAC-2026-0003"
+
+    def test_backdating_does_not_disturb_the_current_year(self, db, org, member):
+        """A receipt dated into a closed year draws from that year's series."""
+        _issue(db, member, year=2026)
+        _issue(db, member, year=2026)
+        assert _issue(db, member, year=2025) == "FAC-2025-0001"
+        assert _issue(db, member, year=2026) == "FAC-2026-0003"
+
+    def test_the_counter_row_tracks_the_next_number(self, db, org, member):
+        _issue(db, member, year=2026)
+        _issue(db, member, year=2026)
+        row = (
+            db.query(InvoiceSequence).filter(InvoiceSequence.year == 2026).one()
+        )
+        assert row.next_number == 3
+
+
+class TestGlobalMode:
+    def test_annual_reset_off_uses_the_org_counter(self, db, org, member):
+        org.invoice_annual_reset = False
+        org.invoice_next_number = 41
+        db.flush()
+
+        assert _issue(db, member, year=2026) == "FAC-2026-0041"
+        assert _issue(db, member, year=2027) == "FAC-2027-0042"


### PR DESCRIPTION
Two decisions taken today, both from the 2026-08-09 audit.

## H3 — login did not require a confirmed email

`/register` deliberately issues no session, on the grounds that *"the account is not usable until the email is confirmed"*. Login handed out the session that endpoint had declined to — so anyone could register with a mailbox they did not own and hold a working session on it.

Login now refuses with a **403** and a message saying what to do, because the login form renders that string verbatim.

**Awaiting approval is deliberately still allowed to hold a session.** That address is verified, the session is what lets the portal explain the wait, and `require_approved_member` already closes every feature router behind it. Blocking login there too would replace a specific explanation with a dead end. This PR changes the *verification* gate only.

Two things checked before shipping it, because both would have been quiet disasters:

- **Seeded accounts set `email_verified=True`** (`seed.py:410,717,1655`), so no existing super admin is locked out. Confirmed against staging: its admin is verified.
- **The column has existed since the initial migration**, so the population holding `False` is exactly the self-registered-and-never-confirmed — who are the point of the fix.

**Known limitation:** only sessions issued from here on are affected. One already held by an unverified account stays valid until it expires.

## M6 — invoice numbers could not be sequential

The number came from `COUNT(receipts in that year, is_active) + 1`. Three ways that breaks a series Spanish practice expects to be unbroken:

- deactivating one receipt shifted the number of **every receipt issued after it**
- the sequence was not monotonic
- the loop guarding the resulting collision **skipped numbers**, manufacturing the gaps it existed to prevent

Replaced with a counter per year in a new `invoice_sequences` table, locked `FOR UPDATE` while it is read and bumped. A year of its own rather than one global counter means a receipt backdated into a closed year draws from **that year's** series instead of clobbering the current one. The collision check now fails loudly — under the lock it means the counter disagrees with the receipts, which is a question for a person, not something to skip past.

### The migration matters as much as the table

It backfills each year from the highest number **actually present** in it, read out of `receipt_number` rather than counted — the count is the thing that was wrong, and it ignores deactivated receipts whose numbers are still spent. Without the backfill an existing install would restart at 1 and collide with everything it had already issued.

Verified against a mixed dataset before shipping:

```
FAC-2025-0001, FAC-2025-0002, FAC-2025-0007  ->  year 2025 next_number 8
FAC-2026-0001..0003                          ->  year 2026 next_number 4
LEGACY-MANUAL                                ->  excluded, no crash
```

The 2025 gap at 0003–0006 is preserved: numbers already spent stay spent.

### Two things only running it revealed

- **`autoincrement=False` on the year.** An integer primary key otherwise gets a sequence default, so a row inserted without a year would land in **year 1**. Found by applying the migration and reading the resulting column, not by reading the code.
- **A club reset has to classify the new table.** A guard in `reset.py` refuses to run until someone decides — the sequences are cleared with the receipts, because keeping a counter with nothing behind it would number the new club's first invoice as though dozens had been issued.

## Verification

**1317 passed** (1306 before, plus 11 new). The migration applies to head and reverses cleanly.

**This is the first release-bound change since v2.3.1 that carries a schema migration** — so it is also the first chance to exercise the upgrade path recorded as untested in `memship-context/docs/cloud/TESTING-upgrade-path.md`. Worth deploying to staging over the existing 2.3.1 database rather than a fresh one, since migrating from a populated previous release is precisely what has never been tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6