### PR TITLE
Add a way back in when a confirmation email never arrived

### DIFF
--- a/backend/app/cli/verify_email.py
+++ b/backend/app/cli/verify_email.py
@@ -1,0 +1,130 @@
+"""Mark a user's email address as confirmed, from the host.
+
+Sign-in requires a confirmed address. That closes a real hole — otherwise anyone
+could register with a mailbox they do not own and hold a session on it — but it
+also means an account that never confirmed cannot get in, and the only
+self-service way back, ``/resend-verification``, needs a working mail transport.
+
+Email is the component that fails quietly here: sends are dispatched through
+Celery and the dispatch sites swallow failures, so an instance can accumulate
+unconfirmed accounts without anyone noticing until they try to sign in. Without
+this command the remedy is raw SQL against the production database, which is a
+worse thing to put in a support answer than one documented command.
+
+Deliberately does not send anything. It is for the case where sending is what is
+broken; the operator has confirmed who the person is by some other means.
+
+Usage:
+    python -m app.cli.verify_email --email someone@example.org
+    python -m app.cli.verify_email --all-unverified --yes
+    python -m app.cli.verify_email --list
+"""
+
+import argparse
+import sys
+from datetime import datetime, timezone
+
+# Importing User alone is not enough: its relationships name classes defined in
+# other modules, and SQLAlchemy cannot configure the mapper until all of them are
+# registered. Standalone, that surfaces as "expression 'Person' failed to locate
+# a name" the first time a query runs — which the test suite never sees, because
+# its conftest has already imported everything.
+import app.db.models_registry  # noqa: F401
+from app.db.session import SessionLocal
+from app.domains.auth.models import User
+
+
+def _unverified(db):
+    return (
+        db.query(User)
+        .filter(User.email_verified.is_(False) | User.email_verified.is_(None))
+        .order_by(User.email)
+        .all()
+    )
+
+
+def _confirm(user: User) -> None:
+    user.email_verified = True
+    user.email_verified_at = datetime.now(timezone.utc)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m app.cli.verify_email",
+        description=(
+            "Mark an email address as confirmed so its owner can sign in. For "
+            "when the mail transport is what is broken."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--email", help="The address to confirm.")
+    group.add_argument(
+        "--list",
+        action="store_true",
+        help="Show every account with an unconfirmed address and exit.",
+    )
+    group.add_argument(
+        "--all-unverified",
+        action="store_true",
+        help=(
+            "Confirm every unconfirmed address. Needs --yes. Use after fixing a "
+            "mail transport that had been failing silently."
+        ),
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt. Required with --all-unverified.",
+    )
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        if args.list:
+            pending = _unverified(db)
+            if not pending:
+                print("Every account has a confirmed address.")
+                return
+            print(f"{len(pending)} account(s) with an unconfirmed address:\n")
+            for u in pending:
+                print(f"  {u.email}")
+            print("\nConfirm one with --email, or all of them with "
+                  "--all-unverified --yes.")
+            return
+
+        if args.all_unverified:
+            pending = _unverified(db)
+            if not pending:
+                print("Every account has a confirmed address. Nothing to do.")
+                return
+            if not args.yes:
+                print(
+                    f"This would confirm {len(pending)} address(es) without any of "
+                    "them proving they own the mailbox.\n"
+                    "Re-run with --yes if that is what you mean.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            for u in pending:
+                _confirm(u)
+            db.commit()
+            print(f"Confirmed {len(pending)} address(es).")
+            return
+
+        user = db.query(User).filter(User.email == args.email).first()
+        if not user:
+            print(f"No account with the address {args.email}.", file=sys.stderr)
+            sys.exit(1)
+        if user.email_verified:
+            print(f"{args.email} is already confirmed. Nothing to do.")
+            return
+
+        _confirm(user)
+        db.commit()
+        print(f"Confirmed {args.email}. They can sign in now.")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/integration/test_verify_email_cli.py
+++ b/backend/tests/integration/test_verify_email_cli.py
@@ -1,0 +1,92 @@
+"""The way back when sign-in requires a confirmed address.
+
+Requiring confirmation closes a real hole, but it also means an account that
+never confirmed cannot get in — and the self-service route needs a working mail
+transport, which is exactly what tends to be broken when this comes up. Without
+this command the remedy is raw SQL against production.
+"""
+
+import pytest
+
+from app.cli import verify_email as cli
+from app.domains.auth.models import User
+from app.domains.persons.models import Person
+
+
+def _user(db, email, verified=False):
+    person = Person(first_name="V", last_name="E", email=email)
+    db.add(person)
+    db.flush()
+    user = User(
+        person_id=person.id,
+        email=email,
+        password_hash="x",
+        role="member",
+        is_active=True,
+        email_verified=verified,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+class TestListing:
+    def test_lists_only_the_unconfirmed(self, db):
+        _user(db, "yes@examplee6e3b1.com", verified=True)
+        _user(db, "no@examplee6e3b1.com", verified=False)
+
+        pending = [u.email for u in cli._unverified(db)]
+
+        assert "no@examplee6e3b1.com" in pending
+        assert "yes@examplee6e3b1.com" not in pending
+
+    def test_a_null_counts_as_unconfirmed(self, db):
+        """The column is nullable and predates the flag being used."""
+        user = _user(db, "null@examplee6e3b1.com", verified=False)
+        user.email_verified = None
+        db.flush()
+
+        assert "null@examplee6e3b1.com" in [u.email for u in cli._unverified(db)]
+
+
+class TestConfirming:
+    def test_confirming_sets_the_flag_and_the_timestamp(self, db):
+        user = _user(db, "one@examplee6e3b1.com")
+        assert user.email_verified_at is None
+
+        cli._confirm(user)
+        db.flush()
+
+        assert user.email_verified is True
+        assert user.email_verified_at is not None
+
+    def test_a_confirmed_user_can_sign_in(self, client, db):
+        """The whole point — end to end through the login endpoint."""
+        from app.core.security.password import hash_password
+
+        email = "signin@examplee6e3b1.com"
+        user = _user(db, email)
+        user.password_hash = hash_password("Sup3rSecret!")
+        db.flush()
+
+        before = client.post(
+            "/api/v1/auth/login", json={"email": email, "password": "Sup3rSecret!"}
+        )
+        assert before.status_code == 403, "unconfirmed should not get in"
+
+        cli._confirm(user)
+        db.flush()
+
+        after = client.post(
+            "/api/v1/auth/login", json={"email": email, "password": "Sup3rSecret!"}
+        )
+        assert after.status_code == 200, after.text
+
+    def test_confirming_does_not_touch_anyone_else(self, db):
+        target = _user(db, "target@examplee6e3b1.com")
+        bystander = _user(db, "bystander@examplee6e3b1.com")
+
+        cli._confirm(target)
+        db.flush()
+
+        assert bystander.email_verified is False

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -126,6 +126,34 @@ Reset it from the host with the same command. It is deliberately the only way in
 recovery through the web interface for a super admin, and every reset is written to the audit log
 with no acting user, since whoever ran it had shell access.
 
+### A member cannot sign in: "Confirm your email address before signing in"
+
+Signing in requires a confirmed address, so an account that never followed its confirmation link
+is locked out. Normally they request a new link from the sign-in page — but that needs a working
+mail transport, and a mail transport that had been failing silently is the usual reason the
+address was never confirmed in the first place.
+
+Confirm it from the host instead, once you know who the person is:
+
+```bash
+docker compose exec -T api python -m app.cli.verify_email --list
+docker compose exec -T api python -m app.cli.verify_email --email member@example.org
+```
+
+`--list` shows every account in this state, which is also the quickest way to tell whether your
+email delivery has been broken for a while. After fixing delivery you can clear the backlog in one
+go:
+
+```bash
+docker compose exec -T api python -m app.cli.verify_email --all-unverified --yes
+```
+
+That confirms addresses **without anyone proving they own them**, which is why it insists on
+`--yes`. Use it when you know the accounts are genuine and the mail was the problem; use `--email`
+one at a time when you are not sure.
+
+The command never sends anything — it is for the case where sending is what is broken.
+
 ### The API refuses to start, complaining about `SECRET_KEY`
 
 The placeholder key shipped in `.env.example` and the Compose default are published in this


### PR DESCRIPTION
Sign-in now requires a confirmed address (#90). That closes a real hole — otherwise anyone can register with a mailbox they do not own and hold a session on it — but it leaves an account that never confirmed unable to get in, **with no operator remedy**.

I checked before writing this: there is no admin endpoint and no CLI command to confirm an address. The only self-service route is `/resend-verification`, which needs a working mail transport — and a transport failing silently is the usual reason the address was never confirmed in the first place. So the remedy today is raw SQL against a production database, which is a worse thing to put in a support answer than one documented command.

```bash
docker compose exec -T api python -m app.cli.verify_email --list
docker compose exec -T api python -m app.cli.verify_email --email member@example.org
docker compose exec -T api python -m app.cli.verify_email --all-unverified --yes
```

`--list` doubles as the diagnostic: a pile of unconfirmed addresses is what broken delivery looks like from the database side.

`--all-unverified` confirms addresses **without anyone proving they own them**, so it refuses without `--yes` and says why. Nothing is ever sent — this is for when sending is what is broken.

## The bug only running it revealed

Importing `User` alone is not enough. Its relationships name classes from other modules and the mapper cannot configure until they are registered, so standalone the command died with:

```
InvalidRequestError: When initializing mapper Mapper[User(users)],
expression 'Person' failed to locate a name
```

**The tests never saw it** — conftest has already imported every model. Fixed by importing `app.db.models_registry`, which exists for exactly this case and documents it. Found by running the command as an operator would, not by running its tests.

## Verification

Every path exercised against real rows, not just asserted: the listing, the refusal without `--yes` **and its exit code**, a single confirmation, the same one again as a no-op, an address that does not exist (exit 1), and the bulk path.

Plus 5 tests — one goes through the login endpoint to assert **403 before and 200 after**, which is the behaviour that actually matters.

**1322 passed.**

> While testing by hand I committed two rows into the test database and five unrelated OAuth tests started failing on a user count. That was my pollution, not a regression; the rows are gone and the suite is clean.

Documented under "Setup and login" in the troubleshooting guide, beside the super admin recovery it sits next to in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGooU9dsLBkoNCP999b3m6