### PR TITLE
Say where meeting notes and ideas belong, and stop tracking agent config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ e2e/runner-results/
 
 # Claude Code session journals (local, never committed)
 .claude/journals/
+
+# Per-repo config for personal agent skills (local, never committed)
+# The skills read these from the working tree; contributors do not need them.
+docs/agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ When scoping any feature before v1.0.0:
 
 Full strategic context lives in the private `memship-context` repo (`docs/`, `STATUS.md`).
 
+Meeting notes, idea and proposal documents, and strategy material belong there too — never in this repo. `docs/` here is **functional and setup documentation only**: how memship works and how to run it. This repo is public; that one is not.
+
 **Tech stack:**
 - Backend: Python 3.12+ / FastAPI / SQLAlchemy 2.0 / Alembic
 - Frontend: Next.js 16 / React 19 / Tailwind 4 / Shadcn/ui / next-intl / next-themes


### PR DESCRIPTION
Two small changes to what this repo documents about itself.

## Where project-running documents live

`CLAUDE.md` already pointed at the private `memship-context` repo for strategic context, but never said that meeting records, undecided proposals and strategy material are **excluded** from this repo. `docs/` here is functional and setup documentation only — how memship works and how to run it.

## `docs/agents/` is no longer tracked

Those three files were per-repo configuration for one maintainer's personal agent skills, generated by a setup skill from a third-party collection. They should not ship in a public repo:

- They read as project policy when they are not. `triage-labels.md` presents a triage vocabulary in which, by its own admission, **four of the five labels do not exist**.
- One column is headed "Label in `mattpocock/skills`" — a collection unrelated to memship, in a repo where contributors use other tools.
- They sat in `docs/`, the tree contributors browse for product documentation.

Nothing is lost by ignoring them: the skills read those files from the **working tree** at a hardcoded path, not from git history, so they keep working locally for whoever has them. This is the arrangement `.claude/journals/` already uses, and the new entry sits directly beneath it.

The `## Agent skills` section is removed from `CLAUDE.md` in the same commit, since it pointed at files a fresh clone will not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)