### PR TITLE
Run the dev backend only in containers, and drop AI commit trailers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,11 @@ SECRETS_KEY_FILE=
 # Application
 APP_ENV=production
 DEFAULT_LOCALE=es
+# Mail domain for the members `seed --demo` creates. The default cannot receive
+# mail at all (.example is reserved), which is deliberate: a demo install must
+# not send to addresses someone else owns. Set it to a domain you control with
+# catch-all receiving if this environment sends real mail and you want to read it.
+SEED_EMAIL_DOMAIN=mediterrani.example
 CORS_ORIGINS=http://localhost
 FRONTEND_URL=http://localhost
 # Public origin the browser reaches the API on. Caddy serves the API under

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Keeps AI-assistant attribution out of the commit trailers.
+#
+# GitHub parses `Co-authored-by:` as a real contributor: the co-author gets an
+# avatar on the commit and its own row in the repository's Insights contributors
+# graph, next to the people who actually maintain memship. An assistant listed
+# there reads as a maintainer, which is not what it is. This hook removes that
+# line before the commit is written.
+#
+# It also drops `Claude-Session:`, which publishes a session URL in a public
+# repository and tells a reader nothing useful.
+#
+# Transparency about the tooling is deliberate and stays. Rather than deleting
+# the attribution outright, a stripped commit gets `Assisted-by: Claude Code`,
+# which records that an assistant was involved without claiming authorship. An
+# `Assisted-by:` line that is already there is left exactly as written, model
+# name and all.
+#
+# Enable once per clone — git does not distribute hooks:
+#
+#     git config core.hooksPath .githooks
+#
+set -euo pipefail
+
+MSG_FILE="$1"
+
+# Case-insensitive on purpose: tools emit both `Co-Authored-By:` and
+# `Co-authored-by:`, and the trailer name varies with the model.
+STRIP='^[[:space:]]*(co-authored-by:.*claude|claude-session:)'
+
+grep -qiE "$STRIP" "$MSG_FILE" || exit 0
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+grep -viE "$STRIP" "$MSG_FILE" > "$TMP" || true
+
+# Leave one trailing newline rather than the blank block the removed trailers
+# leave behind.
+printf '%s\n' "$(cat "$TMP")" > "$TMP"
+
+if ! grep -qiE '^[[:space:]]*assisted-by:' "$TMP"; then
+    printf '\nAssisted-by: Claude Code\n' >> "$TMP"
+fi
+
+cat "$TMP" > "$MSG_FILE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,17 +49,22 @@ Full reference: [docs/development/local-environment.md](docs/development/local-e
 ./scripts/dev.sh start frontend  # Start only frontend (local)
 ```
 
-### Backend (manual)
+### Backend (containers only)
+
+The backend never runs on the host — no `uv sync`, no virtualenv, no host Python. `backend/app`,
+`backend/tests` and `backend/alembic` are bind-mounted into the containers, so edit locally and the
+running code changes.
+
 ```bash
-cd backend
-uv sync                          # Install dependencies
-uv run pytest -v                 # Run tests
-uv run pytest -v --tb=short      # Run tests (short traceback)
-python start.py                  # Start dev server (hot reload)
-python -m app.cli.seed           # Run seed command (initial setup)
-alembic upgrade head             # Run migrations
-alembic revision --autogenerate -m "description"  # Create migration
+./scripts/dev.sh test                     # Full backend suite (throwaway container, tmpfs db)
+./scripts/dev.sh test tests/unit -x       # Everything after `test` is passed to pytest
+./scripts/dev.sh shell                    # Shell in the API container
+./scripts/dev.sh migration "description"  # Autogenerate an Alembic revision
 ```
+
+The API container runs `alembic upgrade head` on start, so pulled migrations apply themselves.
+Inside a container use `python` / `pytest` / `alembic` directly — **never `uv run`**, which needs
+write access to `/app/.venv` and fails as the non-root runtime user.
 
 ### Frontend (manual)
 ```bash
@@ -182,6 +187,13 @@ memship/
 - No Makefiles — use scripts in `scripts/`
 - Version: git tags are the single source of truth (no VERSION file). Images bake the tag in as the `APP_VERSION` build-arg/env; running from source falls back to `git describe`. Release by tagging a validated commit with `scripts/release.sh`
 - Container naming: `memship-` prefix
+- **Commits are authored by a human maintainer, always.** AI-assisted work ends with a plain
+  `Assisted-by: Claude Code (claude-opus-5)` line — **never** `Co-Authored-By:`, which GitHub
+  parses as a real contributor and lists in the repository's Insights next to the maintainers, and
+  no `Claude-Session:` URL, which publishes a session link in a public repo. Transparency about the
+  tooling is wanted; attribution that reads as authorship is not. The `commit-msg` hook in
+  `.githooks/` enforces it (`git config core.hooksPath .githooks`, once per clone) — a human
+  co-author is never stripped.
 
 ### Backend
 - Database naming: `snake_case`, plural tables (e.g., `members`, `activities`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ So there is nothing to "prepare" as a `preproduction` branch — a pre-productio
 
 ### Development Setup
 
-**Prerequisites:** Docker + Docker Compose, Node.js 22+ with [pnpm](https://pnpm.io), and [uv](https://github.com/astral-sh/uv) for Python.
+**Prerequisites:** Docker + Docker Compose, and Node.js 22+ with [pnpm](https://pnpm.io) for the frontend. The backend — including its test suite — runs entirely in containers, so there is no host Python to install.
 
 The backend (API, PostgreSQL, Redis, Celery worker and beat) runs in Docker; the frontend runs locally with pnpm. One script manages all of it:
 
@@ -65,6 +65,12 @@ The backend (API, PostgreSQL, Redis, Celery worker and beat) runs in Docker; the
 ./scripts/dev.sh start all     # Start backend (Docker) + frontend (local)
 ./scripts/dev.sh status        # Show what is running
 ./scripts/dev.sh stop all      # Stop everything
+```
+
+Enable the repository's hooks once per clone (git does not distribute them):
+
+```bash
+git config core.hooksPath .githooks
 ```
 
 Then seed the database with test accounts:
@@ -75,15 +81,16 @@ Then seed the database with test accounts:
 
 The app is at http://localhost:3000 and the API docs at http://localhost:8003/api/docs. Log in with `admin@examplee6e3b1.com` / `TestAdmin1!`.
 
-Run the backend tests with `./scripts/dev.sh test`.
+Run the backend tests with `./scripts/dev.sh test` — they run in a throwaway container against a tmpfs database, and anything after `test` is passed straight to pytest (`./scripts/dev.sh test tests/unit -x`).
 
 See the [Development section of the README](README.md#development) for the full command reference, service URLs, and the rest of the seeded test accounts.
 
-> **Note:** Python dependencies are baked into the backend Docker image — `pyproject.toml` is not bind-mounted. After adding or upgrading a backend dependency, rebuild the image or the running container will not have it:
+> **Note:** Python dependencies are installed into the image's virtualenv at build time. After adding or upgrading a backend dependency, rebuild or the running containers will not have it — the test container builds a different stage, so it needs its own:
 >
 > ```bash
 > docker compose -f backend/docker/docker-compose.yml build --no-cache api
-> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
+> docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api celery-worker celery-beat
+> docker compose -f backend/docker/docker-compose.yml --profile test build tests
 > ```
 
 ### Commit Messages
@@ -91,6 +98,17 @@ See the [Development section of the README](README.md#development) for the full 
 - Use clear, descriptive commit messages
 - Start with a verb in imperative mood (e.g., "Add member search endpoint")
 - Keep the first line under 72 characters
+- **Every commit is authored by a human maintainer.** If an AI assistant helped, record it with a
+  plain `Assisted-by:` line — never `Co-Authored-By:`, which GitHub reads as a real contributor and
+  lists in the repository's Insights graph beside the maintainers:
+
+  ```
+  Assisted-by: Claude Code (claude-opus-5)
+  ```
+
+  The `commit-msg` hook in `.githooks/` enforces this: it strips an assistant `Co-Authored-By:` (and
+  the `Claude-Session:` URL some tools add) and substitutes the `Assisted-by:` line. A human
+  co-author is never touched — keep crediting people that way.
 
 ### Pull Requests
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,12 @@
 # Memship Backend — Local Development
-# Copy this file to .env for running outside Docker
+#
+# Optional. Copy to backend/.env to hand credentials to the dev stack — in
+# practice the email ones, since nothing else needs preseeding. The Celery
+# worker reads it if it exists; see docs/development/local-environment.md.
+#
+# DATABASE_URL and CELERY_BROKER_URL below are ignored inside the containers:
+# the Compose `environment:` keys win, and name the Docker network rather than
+# localhost. They are kept as a reference for what the app reads.
 
 # Database
 DATABASE_URL=postgresql://memship:memship@localhost:5433/memship_db

--- a/backend/app/cli/demo_data.py
+++ b/backend/app/cli/demo_data.py
@@ -8,9 +8,16 @@ summary have real monthly revenue, outstanding, and membership-growth curves.
 Everything is idempotent: each generator early-returns if its data is already
 present, so re-running ``--demo`` adds nothing.
 
-Demo records are namespaced (member emails ``demo{n}@mediterrani.example``,
+Demo records are namespaced (member emails ``demo{n}@<SEED_EMAIL_DOMAIN>``,
 receipt numbers ``DEMO-{year}-{seq}``) so they never collide with ``--test``
 fixtures. Randomness is seeded for reproducible screenshots.
+
+The mail domain defaults to ``mediterrani.example`` — a reserved TLD, so nothing
+seeded here can receive mail. An environment that deliberately sends real mail
+sets ``SEED_EMAIL_DOMAIN`` to a domain it owns, so the demo club's members are
+reachable and the messages can be read. Every lookup below matches on the same
+setting, so changing it seeds a fresh demo set rather than colliding with one
+already there.
 """
 
 from __future__ import annotations
@@ -19,6 +26,7 @@ import random
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 
+from app.core.config import settings
 from app.domains.billing.models import Concept, PaymentProvider, Receipt, SepaMandate
 from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
@@ -77,7 +85,7 @@ def generate_members(
     carry their own ``D-`` member-number namespace so they never collide with
     base-install / ``--test`` numbering.
     """
-    if db.query(Person).filter(Person.email.like("demo%@mediterrani.example")).first():
+    if db.query(Person).filter(Person.email.like(f"demo%@{settings.SEED_EMAIL_DOMAIN}")).first():
         print("  Demo members: already seeded")
         return demo_members(db)
 
@@ -110,7 +118,7 @@ def generate_members(
         person = Person(
             first_name=first,
             last_name=last,
-            email=f"demo{i}@mediterrani.example",
+            email=f"demo{i}@{settings.SEED_EMAIL_DOMAIN}",
             gender=_rng.choice(GENDERS),
             date_of_birth=date(_rng.randint(1965, 2010), _rng.randint(1, 12), _rng.randint(1, 28)),
         )
@@ -150,7 +158,7 @@ def demo_members(db) -> list[Member]:
     return (
         db.query(Member)
         .join(Person, Member.person_id == Person.id)
-        .filter(Person.email.like("demo%@mediterrani.example"))
+        .filter(Person.email.like(f"demo%@{settings.SEED_EMAIL_DOMAIN}"))
         .all()
     )
 
@@ -290,7 +298,7 @@ def generate_sepa(db) -> None:
         db.query(Member, Person)
         .join(Person, Member.person_id == Person.id)
         .filter(
-            Person.email.like("demo%@mediterrani.example"),
+            Person.email.like(f"demo%@{settings.SEED_EMAIL_DOMAIN}"),
             Person.bank_iban.isnot(None),
         )
         .all()

--- a/backend/app/cli/seed.py
+++ b/backend/app/cli/seed.py
@@ -36,6 +36,7 @@ from argon2 import PasswordHasher
 from sqlalchemy import text
 
 from app.cli.reset import preview_club_data, reset_club_data
+from app.core.config import settings as app_settings
 from app.core.permissions import ADMIN_SLUG, SUPER_ADMIN_SLUG
 from app.db.session import SessionLocal
 from app.domains.audit.models import AuditLog
@@ -1565,7 +1566,10 @@ def seed_sepa_data(db) -> None:
     print("  SEPA seed: complete — ready for manual SEPA workflow testing")
 
 
-DEMO_CLUB_ADMIN_EMAIL = "admin@mediterrani.example"
+# Follows SEED_EMAIL_DOMAIN like the demo members do — an environment that
+# points the members at a domain it owns needs the admin reachable too, or the
+# one account that receives password resets is the one that cannot.
+DEMO_CLUB_ADMIN_EMAIL = f"admin@{app_settings.SEED_EMAIL_DOMAIN}"
 
 
 def any_admin_user_id(db) -> int | None:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -75,6 +75,12 @@ class Settings(BaseSettings):
     APP_ENV: str = "development"
     APP_VERSION: str = _read_version()
     DEFAULT_LOCALE: str = "es"
+    # Mail domain for the members `seed --demo` creates. The default is an
+    # RFC 2606 reserved TLD, so nothing it generates can ever be delivered —
+    # which is what you want everywhere except an environment that deliberately
+    # sends real mail. Point it at a domain you own with catch-all receiving to
+    # make the demo club's members reachable.
+    SEED_EMAIL_DOMAIN: str = "mediterrani.example"
     CORS_ORIGINS: str = "http://localhost:3000"
     LOG_LEVEL: str = "info"
 

--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS base
 
 WORKDIR /app
 
@@ -12,6 +12,46 @@ RUN apt-get update && \
 
 # Install uv for fast dependency management
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+
+# --- Development image -------------------------------------------------------
+#
+# The production dependency set plus the `dev` extra (pytest and friends), and
+# nothing else. Only the `tests` service in docker/docker-compose.yml builds
+# this: api, worker and beat deliberately build the production stage below, so
+# the dev stack keeps exercising the image that actually ships.
+#
+# No application code is copied in. The compose service bind-mounts app/ and
+# tests/ from the checkout, which is the point — edit on the host, run in here.
+# That also means tests/ can stay in .dockerignore, out of the shipped image.
+#
+# Defined before the production stage so it is not the default build target: a
+# plain `docker build` still produces the runtime image, and CI stays unchanged.
+FROM base AS dev
+
+COPY pyproject.toml ./
+RUN uv sync --extra dev --no-install-project
+
+# Same reasoning as the production stage below: venv on PATH rather than
+# `uv run`, and PYTHONPATH because dependencies are installed with
+# --no-install-project, so the `app` package is not in the venv.
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH=/app \
+    PYTHONDONTWRITEBYTECODE=1
+
+# The compose service runs as the host user's uid so that anything written to a
+# bind mount belongs to the operator. That uid owns nothing in the image, so
+# /app is opened up here — otherwise pytest cannot even read the venv it runs
+# from. Safe: this stage never reaches a registry.
+RUN chmod -R a+rX /app
+
+# No ENTRYPOINT and no CMD: compose supplies the command, and `docker compose
+# run --rm tests pytest ...` should reach pytest directly rather than the
+# production entrypoint, which waits for the app database and runs migrations.
+
+
+# --- Production image (default build target) ----------------------------------
+FROM base AS runtime
 
 # Version comes from the git tag at build time (there is no VERSION file). CI passes
 # --build-arg APP_VERSION=<tag>; the app reads it from the environment at runtime.

--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -61,8 +61,14 @@ services:
     # never reached the worker and every queued email hit the log-and-skip path.
     # The `environment:` keys below still win over the file, so the localhost
     # DATABASE_URL / CELERY_BROKER_URL in .env cannot leak into the container.
+    #
+    # `required: false` is not optional here: backend/.env is optional and no
+    # setup step creates it, while a missing env_file is a hard Compose error —
+    # so without the flag every `dev.sh start backend` on a fresh checkout died
+    # before a container was created.
     env_file:
-      - ../.env
+      - path: ../.env
+        required: false
     environment:
       - DATABASE_URL=postgresql://memship:memship@db:5432/memship_db
       - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-in-production}
@@ -147,6 +153,65 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
+  # The backend test suite, in a container. It is the only service that builds
+  # the Dockerfile's `dev` stage, so api/worker/beat keep running the production
+  # image and the dev stack still validates what ships.
+  #
+  # Nothing is baked in: the suite runs out of the bind-mounted checkout, so a
+  # test edited on the host is the test that runs, with no rebuild. (tests/ is
+  # in .dockerignore and reaches no image at all.)
+  tests:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: dev
+    container_name: memship-tests
+    # The WHOLE repository, not just backend/. Two unit suites deliberately read
+    # across the repo — test_permission_i18n.py compares the permission registry
+    # against frontend/locales, and test_deployment_env.py parses the root
+    # docker-compose.yml, .env.example and scripts/install.sh. Both resolve those
+    # paths as `Path(__file__).parents[3]`, so backend/ has to sit one level
+    # under the mount or they cannot see the files they exist to check.
+    working_dir: /workspace/backend
+    volumes:
+      - ../..:/workspace
+    # Run as the host operator so anything written into the mounted checkout
+    # belongs to you rather than to the image's uid 1001. Only this service can:
+    # api/worker/beat mount the memship-storage named volume, which Docker
+    # initialises from the image, owned by 1001.
+    user: "${HOST_UID:-1001}:${HOST_GID:-1001}"
+    environment:
+      # The venv on PATH stays at /app; only the code moves. Dependencies are
+      # installed with --no-install-project, so the `app` package is found here
+      # and nowhere else.
+      - PYTHONPATH=/workspace/backend
+      # tests/integration/conftest.py reads this before falling back to the
+      # settings default, which names localhost:5434 — the host's view of
+      # db-test, and unreachable from inside a container.
+      - DATABASE_TEST_URL=postgresql://memship:memship@db-test:5432/memship_test_db
+      # A reachable broker, on a Redis database the dev worker never consumes.
+      # The suite enqueues Celery tasks (registration triggers verification and
+      # confirmation email tasks), and the default broker URL is localhost:6379
+      # — which on the host happens to be the dev Redis, but inside a container
+      # is nothing. Kombu then retries the publish for ~19s before giving up, on
+      # every enqueue: one integration file went from 3s to 9m53s, with the
+      # slowest tests landing on exact multiples of that stall.
+      #
+      # Database 15 rather than the worker's 0 so a task enqueued by a test is
+      # never picked up and run against the dev database.
+      - CELERY_BROKER_URL=redis://redis:6379/15
+      - APP_ENV=development
+      # A cache directory in a container that is removed after every run buys
+      # nothing, and the host user may not be able to create one.
+      - PYTEST_ADDOPTS=-p no:cacheprovider
+    depends_on:
+      db-test:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    profiles:
+      - test
 
   adminer:
     image: adminer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ x-backend-env: &backend-env
   SECRETS_KEY_FILE: ${SECRETS_KEY_FILE:-}
   APP_ENV: ${APP_ENV:-production}
   DEFAULT_LOCALE: ${DEFAULT_LOCALE:-es}
+  SEED_EMAIL_DOMAIN: ${SEED_EMAIL_DOMAIN:-mediterrani.example}
   CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost}
   # Report the deployed image tag as the app version (no VERSION file; images
   # are promoted, not rebuilt, so the version is supplied at deploy time).

--- a/docs/development/local-environment.md
+++ b/docs/development/local-environment.md
@@ -9,9 +9,18 @@ locally with pnpm, so you get Next.js hot reload without a container in the way.
 
 | Tool | Why |
 |---|---|
-| Docker Engine + Compose plugin | The backend stack |
+| Docker Engine + Compose plugin | The whole backend — API, database, Redis, worker, beat, migrations and the test suite |
 | **Node 22** and **pnpm** | The frontend dev server |
-| **uv** | Backend dependencies and the test run, which happen on the host rather than in a container |
+
+That is the complete list. **The backend never runs on the host**: no `uv sync`, no virtualenv, no
+Python version to match, so the same checkout behaves the same on any machine with Docker.
+`backend/app`, `backend/tests` and `backend/alembic` are bind-mounted into the containers — you
+edit them in your editor and the running code changes. The container is where the code executes,
+not where it lives.
+
+Only the frontend stays on the host, and deliberately: the Next.js dev server is there for hot
+reload, which is the one thing a container does not do as well. Cypress needs a real browser, so
+the e2e suite is on the host too.
 
 The Node major is pinned in `frontend/.nvmrc` and enforced as a warning by `engines` in
 `frontend/package.json`. **Use 22** — it is what CI runs and what the production image is built on,
@@ -67,7 +76,9 @@ right one without installing it yourself.
 | `./scripts/dev.sh seed demo` | Demo club with **generated** credentials — prefer this |
 | `./scripts/dev.sh seed test` | Fixed e2e test accounts, whose passwords are public |
 | `./scripts/dev.sh passwd [email]` | Replace the super admin password with a generated one |
-| `./scripts/dev.sh test` | Backend test suite |
+| `./scripts/dev.sh test [args]` | Backend test suite, in a container — extra arguments go to pytest |
+| `./scripts/dev.sh shell` | A shell inside the API container |
+| `./scripts/dev.sh migration "msg"` | Autogenerate an Alembic revision from your model changes |
 | `./scripts/dev.sh e2e` | Cypress, headless |
 | `./scripts/dev.sh e2e:open` | Cypress GUI |
 | `./scripts/dev.sh e2e:parallel` | Cypress, 4 workers |
@@ -169,15 +180,49 @@ are a contract with the test suite rather than a seeding choice, so they live wi
 > passwords, so it requires `APP_ENV=development` or `CI`. For anything real, use the interactive
 > setup — see [First-time setup](../getting-started/first-setup.md).
 
+## Email in dev
+
+The dev stack dispatches nothing until a provider is configured — every send is logged and
+skipped. Two ways in, and the first wins:
+
+1. **Settings > Mailing** in the running app. It is stored in the database, so the API and the
+   Celery worker both pick it up without a restart. Prefer it: it is the same path a self-hosting
+   operator uses, and it is the only one the API container reads.
+2. **`backend/.env`** — copy `backend/.env.example` and fill in `RESEND_API_KEY` or the `SMTP_*`
+   block. The file is optional, no setup step creates it, and the worker reads it only if it is
+   there. Its `DATABASE_URL` and `CELERY_BROKER_URL` are ignored inside the containers — the
+   Compose `environment:` keys win — so the localhost values it ships with cannot break the stack.
+
+Mind the asymmetry: mail sent straight from a request — password reset, email verification, the
+Mailing screen's own test send — leaves the `api` container, which does not read `backend/.env`.
+Only queued mail goes through the worker. Configure through the Mailing screen to exercise both.
+
 ## Tests
 
 ```bash
-./scripts/dev.sh test     # backend suite: starts the test database, then pytest on the host
+./scripts/dev.sh test                                # the whole backend suite
+./scripts/dev.sh test tests/unit                     # one directory
+./scripts/dev.sh test tests/unit/test_email.py -k layout   # anything else is passed to pytest
 ```
 
-Roughly 1,270 tests, well under a minute. It runs `uv run pytest` from `backend/` against the
-test database on port 5434, so backend dependencies must be installed on the host — `uv sync` in
-`backend/` if it is a fresh checkout.
+1,368 tests in about 40 seconds. They run in a throwaway `tests` container against `db-test`,
+whose data directory is a tmpfs, so a run leaves nothing behind. Everything after `test` goes
+straight to pytest.
+
+The container points Celery at `redis://redis:6379/15` rather than the default. The suite enqueues
+tasks — registering a member fires verification and confirmation emails — and the default broker
+URL is `localhost:6379`, which on a host machine happens to be the dev Redis. So a host run was
+publishing test-triggered tasks into the *dev* broker on database 0, where the dev worker picked
+them up and ran them against the dev database. Database 15 has no consumer, so a task an assertion
+provokes goes nowhere. (It is also what keeps the suite fast: with no listener at all, kombu retries
+each publish for ~19 seconds — that alone took one file from 3s to 9m53s.)
+
+That container is the only place the `dev` stage of `backend/docker/Dockerfile` is built. It
+carries the `dev` extra — pytest, xdist, factory-boy — that the shipped image deliberately leaves
+out, while the API, worker and beat containers keep building the production stage. So the stack
+you develop against stays the one that ships, and the test dependencies never reach a registry.
+`backend/tests` is bind-mounted, so an edited test runs immediately; only a dependency change
+needs a rebuild.
 
 For end-to-end tests, **run the full suite against a production build**:
 
@@ -196,13 +241,18 @@ open problem — see [issue #58](https://github.com/marcandreuf/memship/issues/5
 
 ## Adding a backend dependency
 
-Python dependencies are baked into the image — `pyproject.toml` is **not** bind-mounted — so a new
-dependency is missing from the running container until you rebuild:
+Dependencies are installed into the image's virtualenv at build time, so a new one is missing from
+the running containers until you rebuild. The test container is a separate build of a separate
+stage, so it needs its own:
 
 ```bash
 docker compose -f backend/docker/docker-compose.yml build --no-cache api
-docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
+docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api celery-worker celery-beat
+docker compose -f backend/docker/docker-compose.yml --profile test build tests
 ```
+
+`backend/pyproject.toml` *is* mounted into the test container, but only so pytest's own settings
+follow the checkout. A mounted manifest installs nothing.
 
 ## Logs
 
@@ -215,17 +265,32 @@ docker compose -f backend/docker/docker-compose.yml up -d --force-recreate api
 Celery is the component that fails quietly. If scheduled billing or reminder emails stop, look
 there before anywhere else.
 
-## Working on the backend without Docker
+## Migrations
+
+The API container applies `alembic upgrade head` on every start, so a pulled migration is already
+in your database by the time the container is up. Creating one:
 
 ```bash
-cd backend
-uv sync
-uv run pytest -v
-python start.py                                    # dev server, hot reload
-python -m app.cli.seed                             # setup
-alembic upgrade head                               # migrations
-alembic revision --autogenerate -m "description"   # new migration
+./scripts/dev.sh migration "add attachment type allowlist"
 ```
+
+It autogenerates against the running dev database and writes the revision into
+`backend/alembic/versions` on the host. The command runs as **your** uid rather than the image's,
+which is what makes the new file yours to edit — the container's built-in user is uid 1001, and
+that is not the operator on every machine.
+
+## Editor tooling
+
+The backend runs in a container; your editor does not. Autocomplete, go-to-definition and inline
+type checking need an interpreter that can resolve `fastapi`, `sqlalchemy` and the rest, and this
+is the one reason a Python toolchain might still touch your machine:
+
+- **Point the editor at the container** — VS Code Dev Containers or a JetBrains remote interpreter,
+  against the `api` service. Nothing is installed on the host.
+- **Keep a host virtualenv purely as a language-server target** — `cd backend && uv sync --extra dev`.
+  Nothing ever runs from it: `dev.sh` does not read it, and neither do the tests.
+
+Both are optional. The stack, the suite and the migrations all work with neither installed.
 
 ## Frontend directly
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -27,6 +27,11 @@ FRONTEND_DIR="$REPO_ROOT/frontend"
 # you want a different address.
 DEV_ADMIN_EMAIL="${DEV_ADMIN_EMAIL:-dev@memship.local}"
 
+# Passed to the `tests` service so anything it writes into the bind-mounted
+# checkout belongs to you rather than to the image's built-in uid 1001.
+export HOST_UID="${HOST_UID:-$(id -u)}"
+export HOST_GID="${HOST_GID:-$(id -g)}"
+
 # --- Backend (Docker) ---
 
 backend_start() {
@@ -302,10 +307,29 @@ case "$ACTION" in
         echo -e "${GREEN}+${NC} Reset complete"
         ;;
     test)
-        echo -e "${BLUE}i${NC} Running backend tests..."
-        docker compose -f "$BACKEND_COMPOSE" --profile test up -d db-test
-        sleep 2
-        (cd "$REPO_ROOT/backend" && uv run pytest tests/ -v)
+        # In the container, not on the host: the backend has no host-side
+        # install step any more. `run --rm` starts db-test through depends_on
+        # and builds the dev image on first use.
+        echo -e "${BLUE}i${NC} Running backend tests (container)..."
+        shift
+        docker compose -f "$BACKEND_COMPOSE" --profile test run --rm tests \
+            pytest "${@:-tests/}"
+        ;;
+    shell)
+        docker compose -f "$BACKEND_COMPOSE" exec api bash
+        ;;
+    migration)
+        # Autogenerate against the running dev database. --user is the point:
+        # the file lands in the bind-mounted backend/alembic/versions, and the
+        # container's own uid is the image's 1001, which is not the operator on
+        # every machine.
+        shift
+        if [ -z "$*" ]; then
+            echo -e "${RED}x${NC} A message is required: $0 migration \"add foo table\""
+            exit 1
+        fi
+        docker compose -f "$BACKEND_COMPOSE" exec --user "$(id -u):$(id -g)" api \
+            alembic revision --autogenerate -m "$*"
         ;;
     e2e)
         echo -e "${BLUE}i${NC} Running Cypress E2E tests..."
@@ -322,7 +346,7 @@ case "$ACTION" in
     *)
         echo -e "${BOLD}Memship Dev Environment Manager${NC}"
         echo ""
-        echo "Usage: $0 {start|stop|restart|status|logs|seed|passwd|test|e2e} [backend|frontend|worker|beat|all]"
+        echo "Usage: $0 {start|stop|restart|status|logs|seed|passwd|test|shell|migration|e2e} [backend|frontend|worker|beat|all]"
         echo ""
         echo -e "${BOLD}Commands:${NC}"
         echo "  start [target]    - Start services"
@@ -335,7 +359,9 @@ case "$ACTION" in
         echo "  seed test         - Seed the fixed e2e test accounts, published in this repo"
         echo "  passwd [email]    - Set the super admin password to a fresh generated one"
         echo "  reset             - Wipe DB, restart backend, and re-seed with test data"
-        echo "  test              - Run backend tests"
+        echo "  test [args]       - Run backend tests in the container (args go to pytest)"
+        echo "  shell             - Open a shell in the API container"
+        echo "  migration \"msg\"   - Autogenerate an Alembic revision from the model changes"
         echo "  e2e               - Run Cypress E2E tests (headless)"
         echo "  e2e:open          - Open Cypress GUI (interactive)"
         echo ""
@@ -356,6 +382,8 @@ case "$ACTION" in
         echo "  $0 passwd             # Rotate the super admin password"
         echo "  $0 reset              # Wipe DB and re-seed with test data"
         echo "  $0 test               # Run backend tests"
+        echo "  $0 test tests/unit    # Run one directory"
+        echo "  $0 shell              # Shell into the API container"
         echo ""
         exit 1
         ;;


### PR DESCRIPTION
Two changes that both rewrite `CLAUDE.md` and `CONTRIBUTING.md`, so they land together.

## The dev backend runs only in containers

`uv` leaves the prerequisites and **"Working on the backend without Docker" is gone**. `dev.sh test` runs the suite in a container and forwards everything after it to pytest; `dev.sh shell` and `dev.sh migration "msg"` join it. `migration` execs as the caller's uid so a generated revision in the bind-mounted `alembic/versions` belongs to the operator, not to the image's uid 1001.

The Dockerfile grows a `dev` stage carrying the `dev` extra the shipped image leaves out. **It sits before the production stage on purpose** — a plain `docker build` still produces the runtime image, so CI and `release.yml` are untouched — and only the new `tests` service builds it. api, worker and beat keep building the production stage, so the stack we develop against stays the one that ships.

The `tests` service mounts the **whole repository**, not just `backend/`: `test_permission_i18n` compares the permission registry against `frontend/locales` and `test_deployment_env` parses the root compose file, and both resolve those as `parents[3]`. Mounting only `backend/` gave 5 failures and 11 errors, all `FileNotFoundError`.

### A latent bug this surfaced

The service also points Celery at `redis://redis:6379/15`. The suite enqueues tasks, and the default broker URL is `localhost:6379` — which **on a host machine is the dev Redis**. Host runs were publishing test-triggered tasks into the dev broker on database 0, where the dev worker consumed them and executed them against the dev database. Database 15 has no consumer.

It is also what makes the suite usable in a container. With nothing listening, kombu retries each publish for ~19s:

| | before | after |
|---|---|---|
| `test_registrations.py` (46 tests) | 9m53s | 3.42s |
| full suite (1368 tests) | 27m39s | 40.68s |

Host parity: the same file takes 3.13s outside a container.

### Also

`backend/.env` is marked `required: false`. It is optional and no setup step creates it, while a missing `env_file` is a hard Compose error — so every `dev.sh start backend` on a fresh checkout died before a container was created.

## Commit attribution

`.githooks/commit-msg` strips `Co-Authored-By:` lines naming an assistant, and the `Claude-Session:` URL, substituting `Assisted-by:`. GitHub reads `Co-authored-by:` as a real contributor and lists it in the repository's Insights graph beside the maintainers; an assistant does not belong there, while a record that one was used does. **A human co-author is never touched.**

Enable once per clone — git does not distribute hooks:

```bash
git config core.hooksPath .githooks
```

## Verification

- Full suite in the container: **1368 passed in 40.68s**
- Compose config resolves with and without `backend/.env`; with one present, `SMTP_*`/`RESEND_*` reach the worker while `DATABASE_URL`/`CELERY_BROKER_URL` stay on the Docker network
- Hook tested through a real `git commit`, including the human-co-author case

## Follow-ups, not in this PR

- CI's integration job has no Redis service, so those tasks are silently dropped rather than exercised — no CI test verifies a task actually runs.
- The real fix belongs in the suite: integration tests should not depend on a broker being present at all. A conftest fixture stubbing `.delay()` would make it explicit everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)