### PR TITLE
Move Spaces and the billing lists onto the canonical entity UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,36 @@ memship/
 - Dark mode: next-themes (ThemeProvider, attribute="class", system default)
 - Styling: Tailwind CSS 4 with OKLCH CSS variables (teal brand palette)
 - Tables: use `table-compact` CSS class for tab/supporting data tables
+- Navigation: `Link` and `useRouter` always come from `@/lib/i18n/routing`, never from
+  `next/navigation` — the plain ones drop the locale prefix and bounce through middleware
+
+### Entity views
+
+Every entity in the app — members, activities, groups, spaces — is rendered by the same
+two shells, assembled from `components/entity/`. A new list or detail page reuses them
+rather than inventing chrome; Activities is the reference implementation.
+
+**List** (`activities/page.tsx`):
+- `h1.text-2xl.font-bold` + `<PageInfo>` + the primary action, on one row
+- `<SearchInput>`, plus a status `<Select>` when the entity has states
+- `<TableSkeleton>` while loading; an empty state as `div.py-8.text-center.text-muted-foreground`
+- desktop `<div className="hidden md:block rounded-md border">` around the `<Table>`,
+  rows `cursor-pointer` with `onClick={() => router.push(detail)}` — never an action column
+  whose only job is to open the row
+- mobile `<div className="space-y-3 md:hidden">` of `<Link>` cards
+- `<Pagination>` when the endpoint paginates, `<ExportButton>` when an export exists
+
+**Detail** (`activities/[id]/page.tsx`):
+- `<DetailHeader>` — breadcrumbs, title, status badge, and the page-level actions.
+  Destructive page-level actions are `variant="destructive"`
+- `<InlineEditWrapper>` — the basic-info card. The edit form replaces the read view in
+  place; an entity's own fields are never edited in a modal
+- `<EntityTabs>` — everything that extends the entity. Tab tables use `table-compact`, an
+  `Añadir X` button, and row-level `Editar` buttons that *do* open a `Dialog`. Pass `lazy`
+  so a tab's queries wait until it is opened
+
+Modals belong inside tabs, not on the entity itself. Lists whose endpoint returns every
+row unpaginated (groups, spaces) filter client-side rather than growing a backend param.
 
 ### Code Style
 - Python: follow existing patterns, type hints on function signatures

--- a/e2e/cypress/e2e/bookings/bookings-flow.cy.ts
+++ b/e2e/cypress/e2e/bookings/bookings-flow.cy.ts
@@ -111,7 +111,7 @@ describe("Simple Bookings", () => {
     cy.loginAsAdmin();
     cy.visit("/en/spaces");
     cy.contains(SPACE).should("be.visible");
-    cy.contains("tr", SPACE).contains("a", "Manage").click();
+    cy.contains("tr", SPACE).click();
     cy.url().should("match", /\/spaces\/\d+/);
     cy.contains("10:00").should("be.visible");
   });

--- a/frontend/app/[locale]/(portal)/billing-runs/page.tsx
+++ b/frontend/app/[locale]/(portal)/billing-runs/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { Link, useRouter } from "@/lib/i18n/routing";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -15,6 +15,7 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
 import { Pagination } from "@/components/entity/pagination";
+import { PageInfo } from "@/components/page-info";
 import { TableSkeleton } from "@/components/ui/skeletons";
 import { toast } from "sonner";
 import { useBillingRuns, useRunBillingNow } from "@/features/settings/hooks/use-billing-runs";
@@ -58,7 +59,10 @@ export default function BillingRunsPage() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">{t("billingRuns.title")}</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold">{t("billingRuns.title")}</h1>
+            <PageInfo text={t("billingRuns.info")} />
+          </div>
           <p className="text-sm text-muted-foreground">{t("billingRuns.subtitle")}</p>
         </div>
         <RunNowButton t={t} />
@@ -92,8 +96,10 @@ export default function BillingRunsPage() {
       {isLoading ? (
         <TableSkeleton />
       ) : items.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">{t("billingRuns.empty")}</p>
+        <div className="py-8 text-center text-muted-foreground">{t("billingRuns.empty")}</div>
       ) : (
+        <>
+        <div className="hidden md:block rounded-md border">
         <Table>
           <TableHeader>
             <TableRow>
@@ -122,6 +128,35 @@ export default function BillingRunsPage() {
             ))}
           </TableBody>
         </Table>
+        </div>
+
+        <div className="space-y-3 md:hidden">
+          {items.map((run: BillingRun) => (
+            <Link
+              key={run.id}
+              href={`/billing-runs/${run.id}`}
+              className="block rounded-lg border p-4 hover:bg-accent transition-colors"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="font-medium">{formatDate(run.started_at)}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formatDate(run.period_start)} — {formatDate(run.period_end)}
+                  </p>
+                </div>
+                <StatusBadge status={run.status} t={t} />
+              </div>
+              <div className="mt-1 flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">
+                  {t(`billingRuns.frequencyValue.${run.frequency}`)} ·{" "}
+                  {t(`billingRuns.triggeredByValue.${run.triggered_by}`)}
+                </span>
+                <span className="font-mono text-sm">{run.receipts_generated}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+        </>
       )}
 
       <Pagination

--- a/frontend/app/[locale]/(portal)/communications/page.tsx
+++ b/frontend/app/[locale]/(portal)/communications/page.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Pagination } from "@/components/entity/pagination";
+import { PageInfo } from "@/components/page-info";
 import { TableSkeleton } from "@/components/ui/skeletons";
 import { useAuth } from "@/features/auth/hooks/use-auth";
 import { usePermissions } from "@/features/auth/hooks/use-permissions";
@@ -46,7 +47,10 @@ export default function CommunicationsPage() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">{t("communications.title")}</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold">{t("communications.title")}</h1>
+            <PageInfo text={t("communications.info")} />
+          </div>
           <p className="text-sm text-muted-foreground">
             {t("communications.subtitle")}
           </p>
@@ -59,10 +63,12 @@ export default function CommunicationsPage() {
       {isLoading ? (
         <TableSkeleton />
       ) : items.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">
+        <div className="py-8 text-center text-muted-foreground">
           {t("communications.empty")}
-        </p>
+        </div>
       ) : (
+        <>
+        <div className="hidden md:block rounded-md border">
         <Table>
           <TableHeader>
             <TableRow>
@@ -99,6 +105,36 @@ export default function CommunicationsPage() {
             ))}
           </TableBody>
         </Table>
+        </div>
+
+        <div className="space-y-3 md:hidden">
+          {items.map((a: AnnouncementData) => (
+            <Link
+              key={a.id}
+              href={`/communications/${a.id}`}
+              className="block rounded-lg border p-4 hover:bg-accent transition-colors"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="truncate font-medium">{a.subject}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {t(`communications.target.${a.target_type}`)}
+                  </p>
+                </div>
+                <Badge variant={a.status === "sent" ? "default" : "secondary"}>
+                  {t(`communications.status.${a.status}`)}
+                </Badge>
+              </div>
+              <div className="mt-1 flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">
+                  {a.sent_at ? formatDate(a.sent_at) : "—"}
+                </span>
+                <span className="font-mono text-sm">{a.recipient_count ?? "—"}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+        </>
       )}
 
       <Pagination

--- a/frontend/app/[locale]/(portal)/mandates/page.tsx
+++ b/frontend/app/[locale]/(portal)/mandates/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { Link, useRouter } from "@/lib/i18n/routing";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -16,6 +16,7 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
 import { SearchInput } from "@/components/entity/search-input";
+import { PageInfo } from "@/components/page-info";
 import { Pagination } from "@/components/entity/pagination";
 import { TableSkeleton } from "@/components/ui/skeletons";
 import { toast } from "sonner";
@@ -65,7 +66,10 @@ export default function MandatesPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">{t("mandates.title")}</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-bold">{t("mandates.title")}</h1>
+          <PageInfo text={t("mandates.info")} />
+        </div>
         {canWrite && (
           <Dialog open={createOpen} onOpenChange={setCreateOpen}>
             <DialogTrigger asChild>
@@ -97,8 +101,10 @@ export default function MandatesPage() {
       </div>
 
       {items.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">{t("mandates.noMandates")}</p>
+        <div className="py-8 text-center text-muted-foreground">{t("mandates.noMandates")}</div>
       ) : (
+        <>
+        <div className="hidden md:block rounded-md border">
         <Table>
           <TableHeader>
             <TableRow>
@@ -125,6 +131,34 @@ export default function MandatesPage() {
             ))}
           </TableBody>
         </Table>
+        </div>
+
+        <div className="space-y-3 md:hidden">
+          {items.map((m) => (
+            <Link
+              key={m.id}
+              href={`/mandates/${m.id}`}
+              className="block rounded-lg border p-4 hover:bg-accent transition-colors"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="font-mono text-sm">{m.mandate_reference}</p>
+                  <p className="truncate font-medium">{m.debtor_name}</p>
+                </div>
+                <StatusBadge status={m.status} t={t} />
+              </div>
+              <div className="mt-1 flex items-center justify-between gap-2">
+                <span className="truncate font-mono text-sm text-muted-foreground">
+                  {m.debtor_iban}
+                </span>
+                <span className="shrink-0 text-sm text-muted-foreground">
+                  {formatDate(m.signed_at)}
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+        </>
       )}
 
       <Pagination

--- a/frontend/app/[locale]/(portal)/receipts/[id]/page.tsx
+++ b/frontend/app/[locale]/(portal)/receipts/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DecimalInput } from "@/components/ui/decimal-input";
@@ -51,7 +51,6 @@ export default function ReceiptDetailPage() {
   const t = useTranslations();
   const { has } = usePermissions();
   const canWrite = has("billing.write");
-  const router = useRouter();
   const { id } = useParams<{ id: string }>();
   const { data: receipt, isLoading } = useReceipt(Number(id));
   const [editOpen, setEditOpen] = useState(false);

--- a/frontend/app/[locale]/(portal)/receipts/page.tsx
+++ b/frontend/app/[locale]/(portal)/receipts/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { Link, useRouter } from "@/lib/i18n/routing";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,6 +17,7 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
 import { SearchInput } from "@/components/entity/search-input";
+import { PageInfo } from "@/components/page-info";
 import { Pagination } from "@/components/entity/pagination";
 import { ExportButton } from "@/components/entity/export-button";
 import { TableSkeleton } from "@/components/ui/skeletons";
@@ -76,7 +77,10 @@ export default function ReceiptsPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">{t("receipts.title")}</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-bold">{t("receipts.title")}</h1>
+          <PageInfo text={t("receipts.info")} />
+        </div>
         <div className="flex items-center gap-2">
           <ExportButton
             path="/api/receipts/export.csv"
@@ -105,8 +109,10 @@ export default function ReceiptsPage() {
       </div>
 
       {items.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">{t("receipts.noReceipts")}</p>
+        <div className="py-8 text-center text-muted-foreground">{t("receipts.noReceipts")}</div>
       ) : (
+        <>
+        <div className="hidden md:block rounded-md border">
         <Table>
           <TableHeader>
             <TableRow>
@@ -137,6 +143,31 @@ export default function ReceiptsPage() {
             ))}
           </TableBody>
         </Table>
+        </div>
+
+        <div className="space-y-3 md:hidden">
+          {items.map((r: ReceiptData) => (
+            <Link
+              key={r.id}
+              href={`/receipts/${r.id}`}
+              className="block rounded-lg border p-4 hover:bg-accent transition-colors"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="font-mono text-sm">{r.receipt_number}</p>
+                  <p className="truncate font-medium">{r.member_name || "—"}</p>
+                </div>
+                <StatusBadge status={r.status} t={t} />
+              </div>
+              <p className="mt-1 truncate text-sm text-muted-foreground">{r.description}</p>
+              <div className="mt-1 flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">{formatDate(r.emission_date)}</span>
+                <span className="font-mono">{formatCurrency(r.total_amount)}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+        </>
       )}
 
       <Pagination

--- a/frontend/app/[locale]/(portal)/remittances/page.tsx
+++ b/frontend/app/[locale]/(portal)/remittances/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { Link, useRouter } from "@/lib/i18n/routing";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/table";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Pagination } from "@/components/entity/pagination";
+import { PageInfo } from "@/components/page-info";
 import { TableSkeleton } from "@/components/ui/skeletons";
 import { toast } from "sonner";
 import { useRemittances, useCreateRemittance } from "@/features/remittances/hooks/use-remittances";
@@ -67,7 +68,10 @@ export default function RemittancesPage() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">{t("remittances.title")}</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-bold">{t("remittances.title")}</h1>
+          <PageInfo text={t("remittances.info")} />
+        </div>
         {canWrite && (
           <Dialog open={createOpen} onOpenChange={setCreateOpen}>
             <DialogTrigger asChild>
@@ -101,8 +105,10 @@ export default function RemittancesPage() {
       </div>
 
       {items.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">{t("remittances.noRemittances")}</p>
+        <div className="py-8 text-center text-muted-foreground">{t("remittances.noRemittances")}</div>
       ) : (
+        <>
+        <div className="hidden md:block rounded-md border">
         <Table>
           <TableHeader>
             <TableRow>
@@ -131,6 +137,34 @@ export default function RemittancesPage() {
             ))}
           </TableBody>
         </Table>
+        </div>
+
+        <div className="space-y-3 md:hidden">
+          {items.map((r) => (
+            <Link
+              key={r.id}
+              href={`/remittances/${r.id}`}
+              className="block rounded-lg border p-4 hover:bg-accent transition-colors"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="font-mono text-sm">{r.remittance_number}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formatDate(r.emission_date)} → {formatDate(r.due_date)}
+                  </p>
+                </div>
+                <StatusBadge status={r.status} t={t} />
+              </div>
+              <div className="mt-1 flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">
+                  {t("remittances.receiptCount")}: {r.receipt_count}
+                </span>
+                <span className="font-mono">{formatCurrency(r.total_amount)}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+        </>
       )}
 
       <Pagination

--- a/frontend/app/[locale]/(portal)/spaces/[id]/page.tsx
+++ b/frontend/app/[locale]/(portal)/spaces/[id]/page.tsx
@@ -4,23 +4,19 @@ import { useState } from "react";
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
-import { Link, useRouter } from "@/lib/i18n/routing";
+import { useRouter } from "@/lib/i18n/routing";
 import { Button } from "@/components/ui/button";
 import { useConfirmDialog } from "@/components/ui/confirm-dialog";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { FormSkeleton } from "@/components/ui/skeletons";
+import { DetailHeader } from "@/components/entity/detail-header";
+import { InlineEditWrapper } from "@/components/entity/inline-edit-wrapper";
+import { EntityTabs } from "@/components/entity/entity-tabs";
+import { DetailSkeleton } from "@/components/ui/skeletons";
 import { useQueryClient } from "@tanstack/react-query";
 import { ClientApiError } from "@/lib/client-api";
-import { useDeleteSpace, useSpace } from "@/features/bookings/hooks/use-bookings";
+import { useDeleteSpace, useSlots, useSpace } from "@/features/bookings/hooks/use-bookings";
 import { deleteSpace as deleteSpaceApi } from "@/features/bookings/services/bookings-api";
 import { SpaceForm } from "@/features/bookings/components/space-form";
+import { SpaceDetailSection } from "@/features/bookings/components/space-detail-section";
 import { SlotsTab } from "@/features/bookings/components/slots-tab";
 import { SpaceBookingsTab } from "@/features/bookings/components/space-bookings-tab";
 import { usePermissions } from "@/features/auth/hooks/use-permissions";
@@ -33,7 +29,10 @@ export default function SpaceDetailPage() {
   const router = useRouter();
   const id = Number(params.id);
   const { data: space, isLoading } = useSpace(id);
-  const [editOpen, setEditOpen] = useState(false);
+  // Read from the same cache the slots tab fills, purely for the tab's count
+  // badge — the tab itself owns the fetch.
+  const { data: slots } = useSlots(id);
+  const [isEditing, setIsEditing] = useState(false);
   const qc = useQueryClient();
   const deleteMutation = useDeleteSpace();
   const [confirmDialog, confirmAction] = useConfirmDialog();
@@ -72,80 +71,84 @@ export default function SpaceDetailPage() {
     }
   }
 
-  if (isLoading) return <FormSkeleton fields={3} />;
+  if (isLoading) return <DetailSkeleton />;
   if (!space)
     return (
-      <p className="text-sm text-muted-foreground">
+      <div className="py-8 text-center text-muted-foreground">
         {t("bookings.spaces.notFound")}
-      </p>
+      </div>
     );
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between">
-        <div>
-          <Link
-            href="/spaces"
-            className="text-xs text-muted-foreground hover:underline"
-          >
-            ← {t("bookings.spaces.title")}
-          </Link>
-          <h1 className="text-2xl font-bold">{space.name}</h1>
-          <p className="text-sm text-muted-foreground">
-            {space.open_time.slice(0, 5)}–{space.close_time.slice(0, 5)}
-            {space.space_type ? ` · ${space.space_type}` : ""}
-          </p>
-        </div>
-        <div className="flex gap-2">
-          {confirmDialog}
-          {canWrite && (<>
-          <Dialog open={editOpen} onOpenChange={setEditOpen}>
-            <DialogTrigger asChild>
-              <Button variant="outline" size="sm">
-                {t("common.edit")}
+      <DetailHeader
+        breadcrumbs={[
+          { label: t("bookings.spaces.title"), href: "/spaces" },
+          { label: space.name },
+        ]}
+        title={space.name}
+        badge={{
+          label: space.is_active
+            ? t("bookings.spaces.active")
+            : t("bookings.spaces.inactive"),
+          variant: space.is_active ? "default" : "secondary",
+        }}
+        actions={
+          canWrite ? (
+            <>
+              {confirmDialog}
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={deleteMutation.isPending}
+                onClick={() =>
+                  confirmAction({
+                    title: t("bookings.spaces.confirmDelete"),
+                    cancelLabel: t("common.cancel"),
+                    confirmLabel: t("common.delete"),
+                    onConfirm: onDelete,
+                  })
+                }
+              >
+                {t("common.delete")}
               </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>{t("bookings.spaces.edit")}</DialogTitle>
-              </DialogHeader>
-              <SpaceForm space={space} onSuccess={() => setEditOpen(false)} />
-            </DialogContent>
-          </Dialog>
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-destructive"
-            disabled={deleteMutation.isPending}
-            onClick={() =>
-              confirmAction({
-                title: t("bookings.spaces.confirmDelete"),
-                cancelLabel: t("common.cancel"),
-                confirmLabel: t("common.delete"),
-                onConfirm: onDelete,
-              })
-            }
-          >
-            {t("common.delete")}
-          </Button>
-          </>)}
-        </div>
-      </div>
+            </>
+          ) : undefined
+        }
+      />
 
-      <Tabs defaultValue="slots">
-        <TabsList>
-          <TabsTrigger value="slots">{t("bookings.slots.tab")}</TabsTrigger>
-          <TabsTrigger value="bookings">
-            {t("bookings.adminBookings.tab")}
-          </TabsTrigger>
-        </TabsList>
-        <TabsContent value="slots">
-          <SlotsTab spaceId={id} />
-        </TabsContent>
-        <TabsContent value="bookings">
-          <SpaceBookingsTab spaceId={id} />
-        </TabsContent>
-      </Tabs>
+      <InlineEditWrapper
+        title={t("common.details")}
+        isEditing={isEditing}
+        onEdit={() => setIsEditing(true)}
+        onCancel={() => setIsEditing(false)}
+        canEdit={canWrite}
+        readContent={<SpaceDetailSection space={space} />}
+        editContent={
+          <SpaceForm
+            space={space}
+            onSuccess={() => setIsEditing(false)}
+            onCancel={() => setIsEditing(false)}
+          />
+        }
+      />
+
+      <EntityTabs
+        lazy
+        tabs={[
+          {
+            id: "slots",
+            label: t("bookings.slots.tab"),
+            badge: slots?.length,
+            content: <SlotsTab spaceId={id} />,
+          },
+          {
+            id: "bookings",
+            label: t("bookings.adminBookings.tab"),
+            content: <SpaceBookingsTab spaceId={id} />,
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/frontend/app/[locale]/(portal)/spaces/page.tsx
+++ b/frontend/app/[locale]/(portal)/spaces/page.tsx
@@ -2,10 +2,9 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { Link } from "@/lib/i18n/routing";
+import { Link, useRouter } from "@/lib/i18n/routing";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -14,6 +13,13 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Table,
   TableBody,
   TableCell,
@@ -21,7 +27,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { TabContentSkeleton } from "@/components/ui/skeletons";
+import { PageInfo } from "@/components/page-info";
+import { SearchInput } from "@/components/entity/search-input";
+import { TableSkeleton } from "@/components/ui/skeletons";
+import { useSearchParam, useStatusParam } from "@/hooks/use-url-state";
 import { useSpaces } from "@/features/bookings/hooks/use-bookings";
 import { SpaceForm } from "@/features/bookings/components/space-form";
 import { usePermissions } from "@/features/auth/hooks/use-permissions";
@@ -30,13 +39,33 @@ export default function SpacesPage() {
   const t = useTranslations();
   const { has } = usePermissions();
   const canWrite = has("bookings.write");
-  const { data: spaces = [], isLoading } = useSpaces();
+  const router = useRouter();
+  const { data: spaces, isLoading } = useSpaces();
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useSearchParam();
+  const [statusFilter, setStatusFilter] = useStatusParam();
+
+  // The spaces endpoint returns every row unpaginated, so search and the
+  // active filter run client-side — the same arrangement Groups uses.
+  const filteredSpaces = spaces?.filter((space) => {
+    if (statusFilter === "active" && !space.is_active) return false;
+    if (statusFilter === "inactive" && space.is_active) return false;
+    if (!search) return true;
+    const term = search.toLowerCase();
+    return (
+      space.name.toLowerCase().includes(term) ||
+      (space.space_type?.toLowerCase().includes(term) ?? false) ||
+      (space.description?.toLowerCase().includes(term) ?? false)
+    );
+  });
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">{t("bookings.spaces.title")}</h1>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-bold">{t("bookings.spaces.title")}</h1>
+          <PageInfo text={t("bookings.spaces.info")} />
+        </div>
         {canWrite && (
           <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
@@ -52,15 +81,38 @@ export default function SpacesPage() {
         )}
       </div>
 
-      <Card>
-        <CardContent className="p-4 table-compact overflow-x-auto">
-          {isLoading ? (
-            <TabContentSkeleton />
-          ) : !spaces.length ? (
-            <p className="text-sm text-muted-foreground">
-              {t("bookings.spaces.noSpaces")}
-            </p>
-          ) : (
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder={t("common.search")}
+          className="sm:max-w-xs"
+        />
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v === "all" ? "" : v)}
+        >
+          <SelectTrigger className="sm:w-48">
+            <SelectValue placeholder={t("bookings.spaces.allStatuses")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t("bookings.spaces.allStatuses")}</SelectItem>
+            <SelectItem value="active">{t("bookings.spaces.active")}</SelectItem>
+            <SelectItem value="inactive">{t("bookings.spaces.inactive")}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {isLoading ? (
+        <TableSkeleton rows={4} columns={4} />
+      ) : !filteredSpaces?.length ? (
+        <div className="py-8 text-center text-muted-foreground">
+          {t("bookings.spaces.noSpaces")}
+        </div>
+      ) : (
+        <>
+          {/* Desktop table */}
+          <div className="hidden md:block rounded-md border">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -68,14 +120,14 @@ export default function SpacesPage() {
                   <TableHead>{t("bookings.spaces.type")}</TableHead>
                   <TableHead>{t("bookings.spaces.hours")}</TableHead>
                   <TableHead>{t("bookings.spaces.status")}</TableHead>
-                  <TableHead>{t("common.actions")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {spaces.map((space) => (
+                {filteredSpaces.map((space) => (
                   <TableRow
                     key={space.id}
-                    className={space.is_active ? undefined : "opacity-60"}
+                    className="cursor-pointer"
+                    onClick={() => router.push(`/spaces/${space.id}`)}
                   >
                     <TableCell className="font-medium">{space.name}</TableCell>
                     <TableCell>{space.space_type ?? "—"}</TableCell>
@@ -89,20 +141,39 @@ export default function SpacesPage() {
                           : t("bookings.spaces.inactive")}
                       </Badge>
                     </TableCell>
-                    <TableCell>
-                      <Button variant="outline" size="sm" asChild>
-                        <Link href={`/spaces/${space.id}`}>
-                          {t("bookings.spaces.manage")}
-                        </Link>
-                      </Button>
-                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+
+          {/* Mobile card view */}
+          <div className="space-y-3 md:hidden">
+            {filteredSpaces.map((space) => (
+              <Link
+                key={space.id}
+                href={`/spaces/${space.id}`}
+                className="block rounded-lg border p-4 hover:bg-accent transition-colors"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="font-medium">{space.name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {space.open_time.slice(0, 5)}–{space.close_time.slice(0, 5)}
+                      {space.space_type ? ` · ${space.space_type}` : ""}
+                    </p>
+                  </div>
+                  <Badge variant={space.is_active ? "default" : "secondary"}>
+                    {space.is_active
+                      ? t("bookings.spaces.active")
+                      : t("bookings.spaces.inactive")}
+                  </Badge>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/components/entity/detail-header.tsx
+++ b/frontend/components/entity/detail-header.tsx
@@ -31,7 +31,7 @@ export function DetailHeader({
       <Breadcrumbs items={breadcrumbs} />
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2 min-w-0">
-          <h1 className="text-lg font-bold truncate">{title}</h1>
+          <h1 className="text-2xl font-bold truncate">{title}</h1>
           {badge && (
             <Badge variant={badge.variant || "default"}>{badge.label}</Badge>
           )}

--- a/frontend/features/bookings/components/slots-tab.tsx
+++ b/frontend/features/bookings/components/slots-tab.tsx
@@ -306,7 +306,6 @@ function SlotRow({
           <Button
             variant="outline"
             size="sm"
-            className="text-destructive"
             disabled={deleteMutation.isPending}
             onClick={() =>
               confirmAction({

--- a/frontend/features/bookings/components/space-detail-section.tsx
+++ b/frontend/features/bookings/components/space-detail-section.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { DetailSection } from "@/components/entity/detail-section";
+import type { Space } from "../services/bookings-api";
+
+interface SpaceDetailSectionProps {
+  space: Space;
+}
+
+export function SpaceDetailSection({ space }: SpaceDetailSectionProps) {
+  const t = useTranslations();
+
+  const fields = [
+    { label: t("bookings.spaces.name"), value: space.name, inline: true },
+    { label: t("bookings.spaces.type"), value: space.space_type, inline: true },
+    {
+      label: t("bookings.spaces.hours"),
+      value: `${space.open_time.slice(0, 5)}–${space.close_time.slice(0, 5)}`,
+      inline: true,
+    },
+    {
+      label: t("bookings.spaces.status"),
+      value: space.is_active
+        ? t("bookings.spaces.active")
+        : t("bookings.spaces.inactive"),
+      inline: true,
+    },
+    { label: t("bookings.spaces.description"), value: space.description },
+  ];
+
+  return <DetailSection fields={fields} columns={2} />;
+}

--- a/frontend/features/bookings/components/space-form.tsx
+++ b/frontend/features/bookings/components/space-form.tsx
@@ -46,9 +46,16 @@ type SpaceFormValues = z.infer<typeof spaceSchema>;
 export function SpaceForm({
   space,
   onSuccess,
+  onCancel,
 }: {
   space: Space | null;
   onSuccess: () => void;
+  /**
+   * Present when the form edits in place inside a card, where the read view it
+   * replaced has to be reachable again. The create dialog has its own dismiss,
+   * so it passes nothing and keeps the single full-width save button.
+   */
+  onCancel?: () => void;
 }) {
   const t = useTranslations();
   const createMutation = useCreateSpace();
@@ -177,9 +184,20 @@ export function SpaceForm({
             </FormItem>
           )}
         />
-        <Button type="submit" disabled={isPending} className="w-full">
-          {isPending ? t("common.loading") : t("common.save")}
-        </Button>
+        {onCancel ? (
+          <div className="flex gap-3">
+            <Button type="submit" disabled={isPending}>
+              {isPending ? t("common.loading") : t("common.save")}
+            </Button>
+            <Button type="button" variant="outline" onClick={onCancel}>
+              {t("common.cancel")}
+            </Button>
+          </div>
+        ) : (
+          <Button type="submit" disabled={isPending} className="w-full">
+            {isPending ? t("common.loading") : t("common.save")}
+          </Button>
+        )}
       </form>
     </Form>
   );

--- a/frontend/features/members/components/member-receipts-tab.tsx
+++ b/frontend/features/members/components/member-receipts-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { useRouter } from "@/lib/i18n/routing";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";

--- a/frontend/locales/ca/billing-runs.json
+++ b/frontend/locales/ca/billing-runs.json
@@ -1,6 +1,7 @@
 {
   "billingRuns": {
     "title": "Execucions de facturació",
+    "info": "La facturació recurrent emet automàticament els rebuts de quota segons un calendari. Cada execució registra el període cobert i els rebuts generats, de manera que un període mai es factura dues vegades.",
     "subtitle": "Historial de la facturació recurrent, automàtica i manual",
     "runNow": "Executar ara",
     "runNowTitle": "Executar facturació ara",

--- a/frontend/locales/ca/bookings.json
+++ b/frontend/locales/ca/bookings.json
@@ -28,6 +28,7 @@
     },
     "spaces": {
       "title": "Espais",
+      "info": "Els espais són les pistes, sales i camps que els socis poden reservar. Cada espai té un horari d'obertura i les seves pròpies franges; desactiva un espai per deixar d'acceptar reserves sense esborrar-ne l'historial.",
       "create": "Nou espai",
       "edit": "Edita l'espai",
       "name": "Nom",
@@ -37,10 +38,10 @@
       "closeTime": "Tancament",
       "hours": "Horari",
       "status": "Estat",
+      "allStatuses": "Tots els estats",
       "active": "Actiu",
       "inactive": "Inactiu",
       "noSpaces": "Encara no hi ha espais. Crea'n un per començar a acceptar reserves.",
-      "manage": "Gestiona",
       "notFound": "Espai no trobat.",
       "confirmDelete": "Vols eliminar aquest espai? Se n'eliminaran les franges i les reserves. Per deixar d'acceptar reserves sense esborrar res, desactiva'l des d'Edita.",
       "deleteAffected": "{count, plural, one {# soci té reserves actives que es cancel·laran i se l'avisarà per correu.} other {# socis tenen reserves actives que es cancel·laran i se'ls avisarà per correu.}}"

--- a/frontend/locales/ca/communications.json
+++ b/frontend/locales/ca/communications.json
@@ -1,6 +1,7 @@
 {
   "communications": {
     "title": "Comunicacions",
+    "info": "Les comunicacions són avisos que s'envien als socis per correu, opcionalment limitats a un grup o a un tipus de soci. Un esborrany es pot previsualitzar i comprovar-ne l'audiència abans d'enviar-lo.",
     "subtitle": "Envia anuncis als teus membres",
     "new": "Nou anunci",
     "empty": "Encara no hi ha anuncis.",

--- a/frontend/locales/ca/mandates.json
+++ b/frontend/locales/ca/mandates.json
@@ -1,6 +1,7 @@
 {
   "mandates": {
     "title": "Mandats SEPA",
+    "info": "Un mandat SEPA és l'autorització signada pel soci per carregar al seu compte bancari. Un rebut només es pot cobrar per domiciliació si el seu soci té un mandat actiu.",
     "createMandate": "Nou mandat",
     "mandateReference": "Referencia",
     "member": "Soci",

--- a/frontend/locales/ca/receipts.json
+++ b/frontend/locales/ca/receipts.json
@@ -1,6 +1,7 @@
 {
   "receipts": {
     "title": "Rebuts",
+    "info": "Els rebuts són els càrrecs individuals emesos als socis: quotes, inscripcions a activitats i càrrecs manuals. S'agrupen en remeses per cobrar-los per domiciliació.",
     "createReceipt": "Nou rebut",
     "editReceipt": "Editar rebut",
     "receiptNumber": "N.º rebut",

--- a/frontend/locales/ca/remittances.json
+++ b/frontend/locales/ca/remittances.json
@@ -1,6 +1,7 @@
 {
   "remittances": {
     "title": "Remeses",
+    "info": "Una remesa agrupa rebuts pendents en un únic fitxer SEPA per enviar al banc. Un cop processada, es poden importar les devolucions per marcar els rebuts que el banc no ha pogut cobrar.",
     "createRemittance": "Nova remesa",
     "remittanceNumber": "Remesa #",
     "receiptCount": "Rebuts",

--- a/frontend/locales/en/billing-runs.json
+++ b/frontend/locales/en/billing-runs.json
@@ -1,6 +1,7 @@
 {
   "billingRuns": {
     "title": "Billing runs",
+    "info": "Recurring billing issues membership-fee receipts automatically on a schedule. Each run records the period it covered and the receipts it generated, so a period is never billed twice.",
     "subtitle": "History of recurring billing, both automatic and manual",
     "runNow": "Run now",
     "runNowTitle": "Run billing now",

--- a/frontend/locales/en/bookings.json
+++ b/frontend/locales/en/bookings.json
@@ -28,6 +28,7 @@
     },
     "spaces": {
       "title": "Spaces",
+      "info": "Spaces are the courts, rooms and pitches members can book. Each space has opening hours and its own slots; deactivate a space to stop taking bookings without deleting its history.",
       "create": "New space",
       "edit": "Edit space",
       "name": "Name",
@@ -37,10 +38,10 @@
       "closeTime": "Closes",
       "hours": "Hours",
       "status": "Status",
+      "allStatuses": "All statuses",
       "active": "Active",
       "inactive": "Inactive",
       "noSpaces": "No spaces yet. Create one to start taking bookings.",
-      "manage": "Manage",
       "notFound": "Space not found.",
       "confirmDelete": "Delete this space? Its slots and bookings will be removed. To stop taking bookings without deleting anything, deactivate it from Edit.",
       "deleteAffected": "{count, plural, one {# member has active bookings that will be cancelled and notified by email.} other {# members have active bookings that will be cancelled and notified by email.}}"

--- a/frontend/locales/en/communications.json
+++ b/frontend/locales/en/communications.json
@@ -1,6 +1,7 @@
 {
   "communications": {
     "title": "Communications",
+    "info": "Communications are announcements sent to members by email, optionally narrowed to a group or a membership type. A draft can be previewed and its audience checked before it is sent.",
     "subtitle": "Send announcements to your members",
     "new": "New announcement",
     "empty": "No announcements yet.",

--- a/frontend/locales/en/mandates.json
+++ b/frontend/locales/en/mandates.json
@@ -1,6 +1,7 @@
 {
   "mandates": {
     "title": "SEPA Mandates",
+    "info": "A SEPA mandate is the member's signed authorisation to charge their bank account. A receipt can only be collected by direct debit if its member has an active mandate.",
     "createMandate": "New Mandate",
     "mandateReference": "Reference",
     "member": "Member",

--- a/frontend/locales/en/receipts.json
+++ b/frontend/locales/en/receipts.json
@@ -1,6 +1,7 @@
 {
   "receipts": {
     "title": "Receipts",
+    "info": "Receipts are the individual charges issued to members — membership fees, activity registrations and manual charges. They are grouped into remittances for collection by direct debit.",
     "createReceipt": "New Receipt",
     "editReceipt": "Edit Receipt",
     "receiptNumber": "Receipt #",

--- a/frontend/locales/en/remittances.json
+++ b/frontend/locales/en/remittances.json
@@ -1,6 +1,7 @@
 {
   "remittances": {
     "title": "Remittances",
+    "info": "A remittance groups pending receipts into a single SEPA file to send to the bank. Once processed, returned receipts can be imported back to mark the ones the bank could not collect.",
     "createRemittance": "New Remittance",
     "remittanceNumber": "Remittance #",
     "receiptCount": "Receipts",

--- a/frontend/locales/es/billing-runs.json
+++ b/frontend/locales/es/billing-runs.json
@@ -1,6 +1,7 @@
 {
   "billingRuns": {
     "title": "Ejecuciones de facturación",
+    "info": "La facturación recurrente emite automáticamente los recibos de cuota según un calendario. Cada ejecución registra el periodo cubierto y los recibos generados, de modo que un periodo nunca se factura dos veces.",
     "subtitle": "Historial de la facturación recurrente, automática y manual",
     "runNow": "Ejecutar ahora",
     "runNowTitle": "Ejecutar facturación ahora",

--- a/frontend/locales/es/bookings.json
+++ b/frontend/locales/es/bookings.json
@@ -28,6 +28,7 @@
     },
     "spaces": {
       "title": "Espacios",
+      "info": "Los espacios son las pistas, salas y campos que los socios pueden reservar. Cada espacio tiene un horario de apertura y sus propias franjas; desactiva un espacio para dejar de aceptar reservas sin borrar su historial.",
       "create": "Nuevo espacio",
       "edit": "Editar espacio",
       "name": "Nombre",
@@ -37,10 +38,10 @@
       "closeTime": "Cierre",
       "hours": "Horario",
       "status": "Estado",
+      "allStatuses": "Todos los estados",
       "active": "Activo",
       "inactive": "Inactivo",
       "noSpaces": "Aún no hay espacios. Crea uno para empezar a aceptar reservas.",
-      "manage": "Gestionar",
       "notFound": "Espacio no encontrado.",
       "confirmDelete": "¿Eliminar este espacio? Se eliminarán sus franjas y reservas. Para dejar de aceptar reservas sin borrar nada, desactívalo desde Editar.",
       "deleteAffected": "{count, plural, one {# socio tiene reservas activas que se cancelarán y se le avisará por correo.} other {# socios tienen reservas activas que se cancelarán y se les avisará por correo.}}"

--- a/frontend/locales/es/communications.json
+++ b/frontend/locales/es/communications.json
@@ -1,6 +1,7 @@
 {
   "communications": {
     "title": "Comunicaciones",
+    "info": "Las comunicaciones son avisos que se envían a los socios por correo, opcionalmente limitados a un grupo o a un tipo de socio. Un borrador se puede previsualizar y comprobar su audiencia antes de enviarlo.",
     "subtitle": "Envía anuncios a tus miembros",
     "new": "Nuevo anuncio",
     "empty": "Aún no hay anuncios.",

--- a/frontend/locales/es/mandates.json
+++ b/frontend/locales/es/mandates.json
@@ -1,6 +1,7 @@
 {
   "mandates": {
     "title": "Mandatos SEPA",
+    "info": "Un mandato SEPA es la autorización firmada por el socio para cargar en su cuenta bancaria. Un recibo solo se puede cobrar por domiciliación si su socio tiene un mandato activo.",
     "createMandate": "Nuevo mandato",
     "mandateReference": "Referencia",
     "member": "Socio",

--- a/frontend/locales/es/receipts.json
+++ b/frontend/locales/es/receipts.json
@@ -1,6 +1,7 @@
 {
   "receipts": {
     "title": "Recibos",
+    "info": "Los recibos son los cargos individuales emitidos a los socios: cuotas, inscripciones a actividades y cargos manuales. Se agrupan en remesas para cobrarlos por domiciliación.",
     "createReceipt": "Nuevo recibo",
     "editReceipt": "Editar recibo",
     "receiptNumber": "N.º recibo",

--- a/frontend/locales/es/remittances.json
+++ b/frontend/locales/es/remittances.json
@@ -1,6 +1,7 @@
 {
   "remittances": {
     "title": "Remesas",
+    "info": "Una remesa agrupa recibos pendientes en un único fichero SEPA para enviar al banco. Una vez procesada, se pueden importar las devoluciones para marcar los recibos que el banco no ha podido cobrar.",
     "createRemittance": "Nueva remesa",
     "remittanceNumber": "Remesa #",
     "receiptCount": "Recibos",


### PR DESCRIPTION
Members, Activities and Groups already render through the shared components in frontend/components/entity/. Spaces used almost none of them and read as a different product; the billing lists used about half. Both are brought onto the same two shells.

Spaces detail now uses DetailHeader (breadcrumbs, title, active/inactive badge) instead of a hand-rolled back link, edits its basic info in place through InlineEditWrapper rather than a modal, and switches the raw Tabs for EntityTabs so Slots carries a count badge and Bookings stops fetching on page load. A new SpaceDetailSection renders the description, which the form has always captured and no view has ever shown.

Spaces list drops the Card and table-compact wrapper for the bordered table every other entity list uses, gains a mobile card fallback, search, an active/inactive filter and a help bubble, and opens a row by clicking it rather than through a Manage column. The endpoint returns every row unpaginated, so filtering is client-side, as Groups already does.

The receipts, mandates, remittances, communications and billing-run lists get the same bordered wrapper, mobile cards and help bubble.

Four of those lists — and the receipts tab on a member — pushed row clicks through next/navigation instead of lib/i18n/routing, so the pushed path carried no locale prefix and the middleware had to redirect and re-derive the locale from the cookie. They now use the locale-aware router, and the rule is written down alongside the entity-view pattern in CLAUDE.md.

DetailHeader titles move from text-lg to text-2xl: detail pages read smaller than the list they came from everywhere in the app.

Refs #125