### PR TITLE
Slide the session window and end it visibly when it runs out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,14 @@ SESSION_KEY_FILE=
 # load balancer that talks plain HTTP to Caddy.
 COOKIE_SECURE=
 
+# How long a session lasts, in minutes. Drives both the token's expiry and the
+# cookie's Max-Age. An active session renews itself, so this is an idle timeout
+# rather than a cap on how long someone can stay signed in.
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+# How far into that window an active session renews, as a percentage. 50 leaves
+# half the window as margin to retry a failed refresh. Clamped to 10-90.
+SESSION_REFRESH_PERCENT=50
+
 # Fernet key encrypting SSO provider secrets stored via the settings screen.
 # OPTIONAL: leave blank and the app auto-generates a per-install key on first use,
 # persisting it to SECRETS_KEY_FILE (never the database). Set this only to supply

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,7 +14,11 @@ DATABASE_TEST_URL=postgresql://memship:memship@localhost:5434/memship_test_db
 
 # Security
 SECRET_KEY=change-me-in-production-use-a-random-64-char-string
+# Session window. Drives both the JWT expiry and the session cookie's Max-Age.
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+# How far into that window an active session renews itself, as a percentage.
+# 50 leaves half the window as margin to retry a failed refresh. Clamped to 10-90.
+SESSION_REFRESH_PERCENT=50
 
 # Application
 APP_ENV=development

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -39,6 +39,7 @@ from app.domains.auth.schemas import (
     RegisterRequest,
     RoleSummary,
     RegisterResponse,
+    SessionRefreshResponse,
     ResendVerificationRequest,
     SsoProvidersResponse,
     TokenResponse,
@@ -67,8 +68,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-SESSION_MAX_AGE = 60 * 30  # 30 minutes, matching ACCESS_TOKEN_EXPIRE_MINUTES
-
 
 def _dev_tokens_allowed() -> bool:
     """Whether a verification / reset token may be returned in the response body.
@@ -95,7 +94,7 @@ def _set_session_cookie(response: Response, user: User) -> None:
         httponly=True,
         secure=settings.session_cookie_secure,
         samesite="lax",
-        max_age=SESSION_MAX_AGE,
+        max_age=settings.session_max_age,
         path="/",
     )
 
@@ -361,6 +360,28 @@ def get_me(current_user: User = Depends(require_permission("self.profile.read"))
         photo_url=current_user.person.photo_url,
         email_verified=bool(current_user.email_verified),
         member_status=member.status if member else None,
+        session_expires_in=settings.session_max_age,
+        session_refresh_after=settings.session_refresh_after,
+    )
+
+
+@router.post("/refresh", response_model=SessionRefreshResponse)
+def refresh_session(
+    response: Response,
+    current_user: User = Depends(get_current_user),
+):
+    """Slide the session window forward for a client that is still working.
+
+    The cookie is only otherwise issued at login, so a session was an absolute
+    window from sign-in: someone mid-form at minute 31 was logged out with no
+    warning. This re-issues it — same flags, a fresh token — but only for a
+    caller whose current token is still valid, so an idle client past the window
+    gets the usual 401 and the timeout still means something.
+    """
+    _set_session_cookie(response, current_user)
+    return SessionRefreshResponse(
+        expires_in=settings.session_max_age,
+        refresh_after=settings.session_refresh_after,
     )
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -58,7 +58,16 @@ class Settings(BaseSettings):
     # Force the Secure attribute on the session cookie on/off. Empty → derived
     # from the FRONTEND_URL scheme (see session_cookie_secure).
     COOKIE_SECURE: str = ""
+    # How long a session lasts. Drives the JWT's own expiry AND the session
+    # cookie's Max-Age — see session_max_age below, which must never diverge
+    # from this or the browser drops a cookie the token still considers valid.
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    # How far into that window an *active* session renews itself, as a
+    # percentage. 50 → a 30 minute session refreshes after 15 minutes, leaving
+    # the other half as margin to retry a failed refresh. Lower means more
+    # refresh calls for no benefit; higher leaves no room to recover from one
+    # dropped request before the cookie dies. Clamped to 10-90 on read.
+    SESSION_REFRESH_PERCENT: int = 50
     # Fernet key (urlsafe base64, 32 bytes) used to encrypt provider secrets stored
     # in the DB via the SSO settings screen. Optional OVERRIDE: when set (e.g. from a
     # secrets manager) it wins. When empty, the app auto-generates a per-install key
@@ -139,6 +148,27 @@ class Settings(BaseSettings):
         if override:
             return override in ("1", "true", "yes", "on")
         return self.FRONTEND_URL.strip().lower().startswith("https://")
+
+    @property
+    def session_max_age(self) -> int:
+        """The session cookie's Max-Age, in seconds.
+
+        Derived from ``ACCESS_TOKEN_EXPIRE_MINUTES`` rather than hardcoded: the
+        two used to be set independently, so raising the token lifetime left the
+        browser still dropping the cookie on the old schedule.
+        """
+        return self.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+
+    @property
+    def session_refresh_after(self) -> int:
+        """Seconds of session life after which an active client renews it.
+
+        The percentage is clamped to 10-90 so a misconfigured install cannot
+        either hammer the refresh endpoint or push renewal so close to expiry
+        that a single dropped request logs the user out.
+        """
+        percent = min(90, max(10, self.SESSION_REFRESH_PERCENT))
+        return max(1, self.session_max_age * percent // 100)
 
     @property
     def google_sso_enabled(self) -> bool:

--- a/backend/app/domains/auth/schemas.py
+++ b/backend/app/domains/auth/schemas.py
@@ -61,12 +61,24 @@ class UserResponse(BaseModel):
     # Drives the portal's "awaiting approval" gate — None for staff accounts
     # that have no member record.
     member_status: str | None = None
+    # Session window, in seconds, and how far into it an active client renews.
+    # Resolved here so the frontend never has to duplicate the arithmetic behind
+    # ACCESS_TOKEN_EXPIRE_MINUTES / SESSION_REFRESH_PERCENT.
+    session_expires_in: int = 0
+    session_refresh_after: int = 0
 
     model_config = {"from_attributes": True}
 
 
 class TokenResponse(BaseModel):
     message: str = "Login successful"
+
+
+class SessionRefreshResponse(BaseModel):
+    """What the renewed session is good for, so the client can reschedule."""
+
+    expires_in: int
+    refresh_after: int
 
 
 class MessageResponse(BaseModel):

--- a/backend/tests/integration/api/v1/test_auth.py
+++ b/backend/tests/integration/api/v1/test_auth.py
@@ -196,6 +196,95 @@ class TestMe:
         response = client.get("/api/v1/auth/me")
         assert response.status_code == 401
 
+    def test_me_reports_the_session_window(self, client, db, monkeypatch):
+        """The frontend schedules its renewal off these, rather than
+        re-deriving ACCESS_TOKEN_EXPIRE_MINUTES on its own."""
+        from app.core.config import settings as app_settings
+
+        _create_test_user(db, email="window@examplee6e3b1.com", password="password123")
+        monkeypatch.setattr(app_settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 40)
+        monkeypatch.setattr(app_settings, "SESSION_REFRESH_PERCENT", 50)
+
+        client.post(
+            "/api/v1/auth/login",
+            json={"email": "window@examplee6e3b1.com", "password": "password123"},
+        )
+        data = client.get("/api/v1/auth/me").json()
+
+        assert data["session_expires_in"] == 40 * 60
+        assert data["session_refresh_after"] == 20 * 60
+
+
+class TestSessionRefresh:
+    def test_refresh_reissues_the_cookie(self, client, db):
+        _create_test_user(db, email="refresh@examplee6e3b1.com", password="password123")
+        client.post(
+            "/api/v1/auth/login",
+            json={"email": "refresh@examplee6e3b1.com", "password": "password123"},
+        )
+
+        response = client.post("/api/v1/auth/refresh")
+
+        assert response.status_code == 200, response.text
+        assert "access_token" in response.headers["set-cookie"]
+
+    def test_refresh_slides_the_cookie_deadline(self, client, db, monkeypatch):
+        """The renewed cookie carries a full window, not the remainder of the
+        old one — otherwise the session would still die on its original
+        schedule."""
+        from app.core.config import settings as app_settings
+
+        _create_test_user(db, email="slide@examplee6e3b1.com", password="password123")
+        monkeypatch.setattr(app_settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 45)
+        client.post(
+            "/api/v1/auth/login",
+            json={"email": "slide@examplee6e3b1.com", "password": "password123"},
+        )
+
+        response = client.post("/api/v1/auth/refresh")
+
+        assert "Max-Age=2700" in response.headers["set-cookie"]
+        assert response.json() == {"expires_in": 2700, "refresh_after": 1350}
+
+    def test_refresh_requires_a_live_session(self, client):
+        """An idle client past the window gets the usual 401, so the timeout
+        still means something."""
+        response = client.post("/api/v1/auth/refresh")
+
+        assert response.status_code == 401
+
+
+class TestSessionWindowConfig:
+    def test_cookie_max_age_follows_the_configured_lifetime(
+        self, client, db, monkeypatch
+    ):
+        """These were set independently, so raising the token lifetime left the
+        browser dropping the cookie on the old 30 minute schedule."""
+        from app.core.config import settings as app_settings
+
+        _create_test_user(db, email="maxage@examplee6e3b1.com", password="password123")
+        monkeypatch.setattr(app_settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 120)
+
+        response = client.post(
+            "/api/v1/auth/login",
+            json={"email": "maxage@examplee6e3b1.com", "password": "password123"},
+        )
+
+        assert "Max-Age=7200" in response.headers["set-cookie"]
+
+    def test_refresh_percent_is_clamped(self, monkeypatch):
+        """A misconfigured install must not hammer the endpoint, nor renew so
+        late that one dropped request logs the user out."""
+        from app.core.config import settings as app_settings
+
+        monkeypatch.setattr(app_settings, "ACCESS_TOKEN_EXPIRE_MINUTES", 60)
+
+        monkeypatch.setattr(app_settings, "SESSION_REFRESH_PERCENT", 0)
+        assert app_settings.session_refresh_after == 6 * 60
+
+        monkeypatch.setattr(app_settings, "SESSION_REFRESH_PERCENT", 500)
+        assert app_settings.session_refresh_after == 54 * 60
+
 
 class TestPasswordReset:
     def test_password_reset_flow(self, client, db):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ x-backend-env: &backend-env
   SECRET_KEY: ${SECRET_KEY:-}
   SESSION_KEY_FILE: ${SESSION_KEY_FILE:-}
   COOKIE_SECURE: ${COOKIE_SECURE:-}
+  ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-30}
+  SESSION_REFRESH_PERCENT: ${SESSION_REFRESH_PERCENT:-50}
   # Encrypts the SSO and payment-provider secrets held in the database. Unset,
   # the app mints a per-install key under storage/ — which a restored database
   # dump on a rebuilt host cannot decrypt, because the key lived on the old one.

--- a/frontend/app/[locale]/(portal)/layout.tsx
+++ b/frontend/app/[locale]/(portal)/layout.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from "@/features/auth/hooks/use-auth";
 import { usePermissions } from "@/features/auth/hooks/use-permissions";
 import { PendingApproval } from "@/features/auth/components/pending-approval";
+import { SessionGuard } from "@/features/auth/components/session-guard";
 import { AppSidebar } from "@/components/layout/sidebar";
 import { Header } from "@/components/layout/header";
 import { AppFooter } from "@/components/layout/footer";
@@ -73,6 +74,7 @@ export default function PortalLayout({
   if (!isAdmin && user.member_status === "pending") {
     return (
       <>
+        <SessionGuard refreshAfterSeconds={user.session_refresh_after} />
         <BrandTheme />
         <PendingApproval user={user} />
       </>
@@ -81,6 +83,7 @@ export default function PortalLayout({
 
   return (
     <SidebarProvider>
+      <SessionGuard refreshAfterSeconds={user.session_refresh_after} />
       <BrandTheme />
       <AppSidebar user={user} />
       <SidebarInset>

--- a/frontend/app/api/auth/refresh/route.ts
+++ b/frontend/app/api/auth/refresh/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8003";
+
+export async function POST(request: NextRequest) {
+  const cookie = request.headers.get("cookie") || "";
+
+  const res = await fetch(`${API_BASE_URL}/api/v1/auth/refresh`, {
+    method: "POST",
+    headers: { Cookie: cookie },
+  });
+
+  const data = await res.json();
+  const response = NextResponse.json(data, { status: res.status });
+
+  // The whole point of this route: the renewed cookie has to reach the browser.
+  // Every other proxy here returns NextResponse.json alone and drops the
+  // backend's response headers, which is why the session could not slide.
+  const setCookie = res.headers.get("set-cookie");
+  if (setCookie) {
+    response.headers.set("set-cookie", setCookie);
+  }
+
+  return response;
+}

--- a/frontend/features/auth/components/login-form.tsx
+++ b/frontend/features/auth/components/login-form.tsx
@@ -62,6 +62,10 @@ export function LoginForm() {
   }
 
   const ssoErrorKey = SSO_ERROR_KEYS[searchParams.get("error") ?? ""];
+  // SessionGuard sends an expired portal session here. Without saying so, being
+  // dropped onto the login screen mid-task reads as the app logging you out at
+  // random.
+  const sessionExpired = searchParams.get("expired") === "1";
 
   const errorMessage =
     loginError instanceof ClientApiError
@@ -70,7 +74,9 @@ export function LoginForm() {
         ? t("auth.loginError")
         : ssoErrorKey
           ? t(ssoErrorKey)
-          : null;
+          : sessionExpired
+            ? t("auth.sessionExpired")
+            : null;
 
   return (
     <Card className="w-full max-w-md">

--- a/frontend/features/auth/components/session-guard.tsx
+++ b/frontend/features/auth/components/session-guard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "@/lib/i18n/routing";
+import { setUnauthorizedHandler } from "@/lib/client-api";
+import { useSessionRefresh } from "../hooks/use-session-refresh";
+
+/**
+ * Keeps the portal's session honest: renews it while the user works, and sends
+ * them to the login page the moment it is gone.
+ *
+ * Mounted inside the portal only. That placement is the whole guard against
+ * hijacking an expected 401 — the login form's own "wrong password" never
+ * reaches a registered handler, because no handler exists on that page.
+ */
+export function SessionGuard({
+  refreshAfterSeconds,
+}: {
+  refreshAfterSeconds: number | undefined;
+}) {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  useSessionRefresh(refreshAfterSeconds);
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      // Clear first: the cached user is what let the portal keep rendering as
+      // if signed in, and the login page must not read anything from it.
+      queryClient.clear();
+      router.replace("/login?expired=1");
+    });
+    return () => setUnauthorizedHandler(null);
+  }, [queryClient, router]);
+
+  return null;
+}

--- a/frontend/features/auth/hooks/use-auth.ts
+++ b/frontend/features/auth/hooks/use-auth.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@/lib/i18n/routing";
 import {
+  ClientApiError,
   getMe,
   login,
   logout,
@@ -57,10 +58,17 @@ export function useAuth() {
     },
   });
 
+  // React Query keeps the last successful data when a refetch fails, so an
+  // expired session left `user` populated and every consumer believing the
+  // visitor was still signed in — the portal kept rendering a shell whose every
+  // request 401ed, until a manual reload finally emptied the cache.
+  const sessionExpired =
+    error instanceof ClientApiError && error.status === 401;
+
   return {
-    user: user ?? null,
+    user: sessionExpired ? null : (user ?? null),
     isLoading,
-    isAuthenticated: !!user,
+    isAuthenticated: !!user && !sessionExpired,
     error,
     login: loginMutation.mutateAsync,
     loginError: loginMutation.error,

--- a/frontend/features/auth/hooks/use-session-refresh.ts
+++ b/frontend/features/auth/hooks/use-session-refresh.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { refreshSession } from "../services/auth-api";
+
+// Anything that means a person is still there. Kept cheap: the throttle below
+// turns all but one of these into a single timestamp comparison, so scroll —
+// the only signal a long report gives off — can be listened to safely.
+const ACTIVITY_EVENTS = ["pointerdown", "keydown", "scroll"] as const;
+
+/**
+ * Renews the session cookie while the user is actually working.
+ *
+ * The window is an idle timeout, not a cap on the visit: the backend re-issues
+ * the cookie for anyone whose current token is still valid, so activity slides
+ * the deadline forward and only real inactivity ends the session. Renewal is
+ * driven by the user's own events rather than a bare interval, so a tab left
+ * open on a dashboard still times out on schedule.
+ *
+ * @param refreshAfterSeconds `session_refresh_after` from /auth/me — how far
+ *   into the window the backend wants an active client to renew. Undefined
+ *   until that query resolves, which disables the hook.
+ */
+export function useSessionRefresh(refreshAfterSeconds: number | undefined) {
+  // Mounting means a full page load, which is itself activity and restarts the
+  // window — so this is a true starting point, not an assumption about when the
+  // session began.
+  const lastRefresh = useRef(Date.now());
+
+  useEffect(() => {
+    if (!refreshAfterSeconds) return;
+    const intervalMs = refreshAfterSeconds * 1000;
+
+    function onActivity() {
+      if (Date.now() - lastRefresh.current < intervalMs) return;
+      // Set before awaiting: a burst of events must not fire several renewals.
+      lastRefresh.current = Date.now();
+      // A 401 here is a session that already died; apiClient's handler sends
+      // the user to the login page, so there is nothing to do with the error.
+      refreshSession().catch(() => {});
+    }
+
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, onActivity, { passive: true });
+    }
+    return () => {
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, onActivity);
+      }
+    };
+  }, [refreshAfterSeconds]);
+}

--- a/frontend/features/auth/services/auth-api.ts
+++ b/frontend/features/auth/services/auth-api.ts
@@ -30,6 +30,20 @@ export interface User {
   email_verified: boolean;
   /** null for staff accounts that have no member record */
   member_status: MemberStatus | null;
+  /** Session window in seconds, as configured by ACCESS_TOKEN_EXPIRE_MINUTES. */
+  session_expires_in: number;
+  /** Seconds into that window at which an active client renews the session. */
+  session_refresh_after: number;
+}
+
+export interface SessionRefreshResult {
+  expires_in: number;
+  refresh_after: number;
+}
+
+/** Slides the session window forward. 401 when the current token already died. */
+export async function refreshSession(): Promise<SessionRefreshResult> {
+  return apiClient("/auth/refresh", { method: "POST" });
 }
 
 export interface LoginData {

--- a/frontend/lib/client-api.ts
+++ b/frontend/lib/client-api.ts
@@ -3,6 +3,33 @@
  * Used in React Client Components via hooks.
  */
 
+type UnauthorizedHandler = () => void;
+
+let unauthorizedHandler: UnauthorizedHandler | null = null;
+let handlingUnauthorized = false;
+
+/**
+ * Register what happens when a signed-in session turns out to be dead.
+ *
+ * Only the portal registers one (see SessionGuard), so a 401 on the login page
+ * — a wrong password — stays an ordinary error the form renders itself.
+ */
+export function setUnauthorizedHandler(handler: UnauthorizedHandler | null) {
+  unauthorizedHandler = handler;
+  if (!handler) handlingUnauthorized = false;
+}
+
+/**
+ * Endpoints that answer 401 as a normal outcome rather than as an expired
+ * session. Bad credentials must not read as "you were signed out".
+ */
+const EXPECTED_401_ENDPOINTS = ["/auth/login", "/auth/register"];
+
+function isSessionExpiry(endpoint: string, status: number): boolean {
+  if (status !== 401) return false;
+  return !EXPECTED_401_ENDPOINTS.some((path) => endpoint.startsWith(path));
+}
+
 export async function apiClient<T>(
   endpoint: string,
   options?: RequestInit
@@ -18,6 +45,14 @@ export async function apiClient<T>(
 
   if (!res.ok) {
     const error = await res.json().catch(() => ({ detail: res.statusText }));
+
+    // A page mid-session fires several requests at once, so they all fail
+    // together — send the user to the login screen once, not once per request.
+    if (isSessionExpiry(endpoint, res.status) && !handlingUnauthorized) {
+      handlingUnauthorized = true;
+      unauthorizedHandler?.();
+    }
+
     throw new ClientApiError(res.status, error.detail ?? res.statusText);
   }
 

--- a/frontend/locales/ca/auth.json
+++ b/frontend/locales/ca/auth.json
@@ -3,6 +3,7 @@
     "login": "Iniciar sessió",
     "loginDescription": "Introdueix les teves credencials per accedir",
     "loginError": "Error en iniciar sessió",
+    "sessionExpired": "La teva sessió ha caducat. Torna a iniciar sessió.",
     "register": "Registrar-se",
     "registerDescription": "Crea un compte per començar",
     "registerError": "Error en registrar-se",

--- a/frontend/locales/en/auth.json
+++ b/frontend/locales/en/auth.json
@@ -3,6 +3,7 @@
     "login": "Log in",
     "loginDescription": "Enter your credentials to access your account",
     "loginError": "Login failed",
+    "sessionExpired": "Your session expired. Please sign in again.",
     "register": "Sign up",
     "registerDescription": "Create an account to get started",
     "registerError": "Registration failed",

--- a/frontend/locales/es/auth.json
+++ b/frontend/locales/es/auth.json
@@ -3,6 +3,7 @@
     "login": "Iniciar sesión",
     "loginDescription": "Introduce tus credenciales para acceder",
     "loginError": "Error al iniciar sesión",
+    "sessionExpired": "Tu sesión ha caducado. Vuelve a iniciar sesión.",
     "register": "Registrarse",
     "registerDescription": "Crea una cuenta para empezar",
     "registerError": "Error al registrarse",


### PR DESCRIPTION
A session was an absolute 30 minutes from sign-in: no renewal, no warning. When it ran out mid-task the portal did not react. React Query keeps the last successful data when a refetch fails, so the 401 from /auth/me left `user` populated, `isAuthenticated` true, and the layout rendering a full shell whose every request failed — empty tables and stray error toasts until a manual reload finally emptied the cache and bounced the visitor to /login.

Three changes, one flow:

- /auth/me's 401 now empties `user`, so the portal's existing redirect fires instead of trusting a corpse of a cached session.
- apiClient escalates any unexpected 401 to a handler the portal registers (SessionGuard): it clears the cache and lands on /login?expired=1, which says what happened. Only the portal registers one, so the login form's own 401 — a wrong password — stays an ordinary error it renders itself.
- POST /auth/refresh re-issues the cookie for a caller whose token is still valid, and the client calls it off the user's own activity once the session is far enough through its window. The window becomes an idle timeout rather than a cap on the visit, while a tab parked on a dashboard still expires.

SESSION_MAX_AGE was hardcoded at 60 * 30 next to a configurable ACCESS_TOKEN_EXPIRE_MINUTES, so raising the token lifetime left the browser dropping the cookie on the old schedule. It derives from the setting now, and SESSION_REFRESH_PERCENT (default 50, clamped 10-90) decides how far into the window an active client renews. /auth/me returns both resolved, so changing either in .env needs no frontend change.

Closes #134

Assisted-by: Claude Code (claude-opus-5)