### PR TITLE
Deploy a release to a VPS that holds no git and no source checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,13 @@
 # Environment secrets are never exposed to workflows triggered from forks, so
 # this is safe in a public repository. Add required reviewers to an Environment
 # to gate deploys to it behind an approval.
+#
+# There is deliberately no `github.repository ==` guard here. Someone who forks
+# memship to self-host it deploys with this same workflow, to their own VPS,
+# using their own Environment and their own secrets — that is the supported
+# path, not an accident to be blocked. The trigger is workflow_dispatch only,
+# so a run can be started only by someone who already has write access to the
+# repository it runs in.
 name: Deploy
 
 on:
@@ -46,7 +53,6 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.repository == 'marcandreuf/memship'
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.target }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,170 @@
+# Deploy
+#
+# Deploys a released version of memship to an instance on a VPS. The instance
+# holds no source checkout and no git: the application arrives as images pulled
+# from the registry, and the handful of files a deployment needs outside the
+# images — the Compose file, the Caddy configuration, the operational scripts —
+# are delivered here over rsync.
+#
+# Each instance is a GitHub Environment, so adding one is configuration rather
+# than a change to this file. Every value below is an Environment secret:
+#
+#   DEPLOY_HOST        hostname or IP
+#   DEPLOY_USER        the user that owns the deployment, in the docker group
+#   DEPLOY_PORT        SSH port
+#   DEPLOY_PATH        directory to deploy into, e.g. /home/ubuntu/memship
+#   DEPLOY_DATA_ROOT   where persistent data lives. MUST be outside DEPLOY_PATH
+#   DEPLOY_DOMAIN      the hostname the instance serves
+#   SSH_PRIVATE_KEY    private key for DEPLOY_USER, dedicated to this workflow
+#   SSH_KNOWN_HOSTS    `ssh-keyscan -p <port> <host>` output, so the host key is
+#                      pinned rather than trusted on first use
+#
+# Environment secrets are never exposed to workflows triggered from forks, so
+# this is safe in a public repository. Add required reviewers to an Environment
+# to gate deploys to it behind an approval.
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Instance to deploy to"
+        type: environment
+        required: true
+      version:
+        description: "Released version to deploy, e.g. 2.6.0"
+        required: false
+      ref:
+        description: "Commit SHA to rehearse instead of a release. Leave empty for a normal deploy."
+        required: false
+
+# One deploy at a time per instance, and never cancel one midway: a cancelled
+# deploy can leave the stack half-updated.
+concurrency:
+  group: deploy-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.repository == 'marcandreuf/memship'
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.target }}
+
+    steps:
+      - name: Resolve what to deploy
+        id: what
+        env:
+          VERSION: ${{ inputs.version }}
+          REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          if [ -n "$VERSION" ] && [ -n "$REF" ]; then
+            echo "::error::Set version or ref, not both."
+            exit 1
+          fi
+          if [ -z "$VERSION" ] && [ -z "$REF" ]; then
+            echo "::error::Set one of: version (a release, e.g. 2.6.0) or ref (a commit SHA to rehearse)."
+            exit 1
+          fi
+
+          if [ -n "$VERSION" ]; then
+            # Repository tags carry a leading v; image tags do not.
+            checkout="v${VERSION#v}"
+            image_tag="${VERSION#v}"
+          else
+            checkout="$REF"
+            image_tag="sha-${REF:0:12}"
+          fi
+
+          # APP_VERSION is baked from IMAGE_TAG, so this is also what the
+          # running instance will report back as its version.
+          {
+            echo "checkout=${checkout}"
+            echo "image_tag=${image_tag}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Deploying ${image_tag} from ${checkout}"
+
+      - name: Check out what is being deployed
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.what.outputs.checkout }}
+
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Deliver the deployment files
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          set -euo pipefail
+          SSH_CMD="ssh -i ~/.ssh/deploy_key -p ${DEPLOY_PORT} -o BatchMode=yes"
+          TARGET="${DEPLOY_USER}@${DEPLOY_HOST}"
+
+          $SSH_CMD "$TARGET" "mkdir -p '${DEPLOY_PATH}'"
+
+          # scripts/ belongs entirely to the release, so --delete is right here:
+          # a script an older version shipped and this one dropped should go.
+          #
+          # Two are excluded because they have no business on a server. dev.sh
+          # drives a local development environment, and release.sh creates and
+          # pushes git tags — on an instance with no git and no source that is
+          # at best dead weight and at worst a footgun.
+          rsync -az --delete -e "$SSH_CMD" \
+            --exclude 'dev.sh' \
+            --exclude 'release.sh' \
+            ./scripts/ "${TARGET}:${DEPLOY_PATH}/scripts/"
+
+          # Never --delete at the top level. .env lives here and is not in the
+          # repository — it holds generated secrets, and losing it means losing
+          # access to everything encrypted with them. So do the top-level files
+          # one by one rather than mirroring the directory.
+          rsync -az -e "$SSH_CMD" \
+            ./docker-compose.yml \
+            ./Caddyfile \
+            "${TARGET}:${DEPLOY_PATH}/"
+
+      - name: Deploy and verify
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_DATA_ROOT: ${{ secrets.DEPLOY_DATA_ROOT }}
+          DEPLOY_DOMAIN: ${{ secrets.DEPLOY_DOMAIN }}
+          IMAGE_TAG: ${{ steps.what.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          # scripts/upgrade.sh backs up, applies the version and verifies the
+          # result. It is the same command an operator runs by hand, which is
+          # deliberate: the automated path and the documented one are one path.
+          ssh -i ~/.ssh/deploy_key -p "${DEPLOY_PORT}" -o BatchMode=yes \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "cd '${DEPLOY_PATH}' && DATA_ROOT='${DEPLOY_DATA_ROOT}' DOMAIN='${DEPLOY_DOMAIN}' ./scripts/upgrade.sh '${IMAGE_TAG}'"
+
+      - name: Summary
+        if: always()
+        env:
+          IMAGE_TAG: ${{ steps.what.outputs.image_tag }}
+          CHECKOUT: ${{ steps.what.outputs.checkout }}
+        run: |
+          {
+            echo "### Deploy to \`${{ inputs.target }}\`"
+            echo ""
+            echo "- version: \`${IMAGE_TAG}\`"
+            echo "- files from: \`${CHECKOUT}\`"
+            echo "- result: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,21 +7,36 @@
 # are delivered here over rsync.
 #
 # Each instance is a GitHub Environment, so adding one is configuration rather
-# than a change to this file. Every value below is an Environment secret:
+# than a change to this file.
+#
+# Environment VARIABLES — addressing, not credentials. These are readable in
+# the Environment's settings, which is the point: a wrong one is diagnosable
+# instead of invisible, and two instances can be compared side by side.
 #
 #   DEPLOY_HOST        hostname or IP
 #   DEPLOY_USER        the user that owns the deployment, in the docker group
-#   DEPLOY_PORT        SSH port
 #   DEPLOY_PATH        directory to deploy into, e.g. /home/ubuntu/memship
 #   DEPLOY_DATA_ROOT   where persistent data lives. MUST be outside DEPLOY_PATH
 #   DEPLOY_DOMAIN      the hostname the instance serves
+#
+# DEPLOY_USER in particular must NOT be a secret. GitHub masks every occurrence
+# of a secret's value in the logs, so a user named `ubuntu` turns `ubuntu-latest`
+# and half of apt's output into `***` — on precisely the failed run you need to
+# read.
+#
+# Environment SECRETS — the things that grant access, plus the SSH port.
+#
+#   DEPLOY_PORT        SSH port. Not a credential, but a non-standard port keeps
+#                      background scanners off the box, and this repository is
+#                      public: an unmasked value would sit in the run log
+#                      forever. Masking costs nothing here, so it stays a secret.
 #   SSH_PRIVATE_KEY    private key for DEPLOY_USER, dedicated to this workflow
 #   SSH_KNOWN_HOSTS    `ssh-keyscan -p <port> <host>` output, so the host key is
 #                      pinned rather than trusted on first use
 #
-# Environment secrets are never exposed to workflows triggered from forks, so
-# this is safe in a public repository. Add required reviewers to an Environment
-# to gate deploys to it behind an approval.
+# Neither Environment secrets nor Environment variables are exposed to workflows
+# triggered from forks, so this is safe in a public repository. Add required
+# reviewers to an Environment to gate deploys to it behind an approval.
 #
 # There is deliberately no `github.repository ==` guard here. Someone who forks
 # memship to self-host it deploys with this same workflow, to their own VPS,
@@ -111,10 +126,10 @@ jobs:
 
       - name: Deliver the deployment files
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ vars.DEPLOY_USER }}
           DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
         run: |
           set -euo pipefail
           SSH_CMD="ssh -i ~/.ssh/deploy_key -p ${DEPLOY_PORT} -o BatchMode=yes"
@@ -125,13 +140,16 @@ jobs:
           # scripts/ belongs entirely to the release, so --delete is right here:
           # a script an older version shipped and this one dropped should go.
           #
-          # Two are excluded because they have no business on a server. dev.sh
-          # drives a local development environment, and release.sh creates and
+          # Three are excluded because they have no business on a server. dev.sh
+          # drives a local development environment; release.sh creates and
           # pushes git tags — on an instance with no git and no source that is
-          # at best dead weight and at worst a footgun.
+          # at best dead weight and at worst a footgun; and pull-backup.sh runs
+          # on an administrator's workstation, pulling state OFF an instance,
+          # so a copy sitting on the instance is pointed the wrong way round.
           rsync -az --delete -e "$SSH_CMD" \
             --exclude 'dev.sh' \
             --exclude 'release.sh' \
+            --exclude 'pull-backup.sh' \
             ./scripts/ "${TARGET}:${DEPLOY_PATH}/scripts/"
 
           # Never --delete at the top level. .env lives here and is not in the
@@ -145,12 +163,12 @@ jobs:
 
       - name: Deploy and verify
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ vars.DEPLOY_USER }}
           DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          DEPLOY_DATA_ROOT: ${{ secrets.DEPLOY_DATA_ROOT }}
-          DEPLOY_DOMAIN: ${{ secrets.DEPLOY_DOMAIN }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
+          DEPLOY_DATA_ROOT: ${{ vars.DEPLOY_DATA_ROOT }}
+          DEPLOY_DOMAIN: ${{ vars.DEPLOY_DOMAIN }}
           IMAGE_TAG: ${{ steps.what.outputs.image_tag }}
         run: |
           set -euo pipefail

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -79,6 +79,13 @@ The bootstrap script in your home directory has done its job now and can be dele
 That creates the data root, generates real secrets into `.env` (mode 600), pulls the published
 images and starts the stack.
 
+**Copy `.env` off the server now, before you put real data in.** `SECRET_KEY` and
+`MEMSHIP_SECRET_KEY` were just generated here, are never regenerated, and exist in no other
+place. They decrypt the payment-provider, SSO and mail credentials stored in the database, so
+without this file a perfect database dump restores those as unreadable ciphertext. Put it in a
+password manager a second administrator can reach — see
+[Backups & restore](../self-hosting/backups-and-restore.md#do-this-on-the-day-you-install).
+
 **Your install is pinned to a version.** `--tag` becomes `IMAGE_TAG`, so the deployment stays on
 that version until you move it deliberately, and `/api/v1/health` reports which one it runs.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,8 +7,10 @@ This guide covers a **production** self-hosted install. For a quick local evalua
 
 - A server running Docker Engine and the Compose plugin
 - An ordinary (non-root) user in the `docker` group — the stack is not installed as root
-- `git`, to clone this repository. Minimal server images often ship without it:
-  `sudo apt-get update && sudo apt-get install -y git`
+- `curl` and `tar`, to fetch a release. `tar` is on every Debian/Ubuntu server; minimal images
+  sometimes lack `curl`: `sudo apt-get update && sudo apt-get install -y curl`
+- **Not `git`.** A release is fetched as a tarball, and the server holds no source checkout —
+  nothing in a running instance uses git, so there is no reason to install it
 - A domain name, with a DNS A record already pointing at the server, if you want automatic HTTPS
 
 > **One memship instance per host.** The Compose file names its containers explicitly
@@ -22,13 +24,20 @@ This guide covers a **production** self-hosted install. For a quick local evalua
 `scripts/vps-bootstrap.sh` does the root half of the preparation. Run it **once, as root**, on a
 fresh Debian 12 or Ubuntu 24.04 box:
 
-Clone it somewhere you can already write — your own home directory. The final checkout lives
-under `/srv`, but nothing can write there until the bootstrap has run:
+Download it somewhere you can already write — your own home directory. The install itself lives
+under `/srv`, but nothing can write there until the bootstrap has run. Pick a release from the
+[releases page](https://github.com/marcandreuf/memship/releases) and use it throughout:
 
 ```bash
-git clone https://github.com/marcandreuf/memship.git ~/memship-bootstrap
-sudo ~/memship-bootstrap/scripts/vps-bootstrap.sh --user deploy --ssh-key-file ~/.ssh/authorized_keys
+MEMSHIP_VERSION=2.6.0
+
+curl -fsSLO "https://raw.githubusercontent.com/marcandreuf/memship/v${MEMSHIP_VERSION}/scripts/vps-bootstrap.sh"
+chmod +x vps-bootstrap.sh
+sudo ./vps-bootstrap.sh --user deploy --ssh-key-file ~/.ssh/authorized_keys
 ```
+
+The script is self-contained — it needs no other file from the repository, which is why one
+`curl` is enough.
 
 `--user` names the account that will own the install; pass the account you are already logged in
 as (`--user "$USER"`) to use it instead of creating a separate `deploy`. `--ssh-key-file` takes a
@@ -53,28 +62,33 @@ Log out and back in afterwards, so the deploy user's `docker` group membership t
 ## Install
 
 As the deploy user — **not** as root. `/srv` belongs to root, so create the install directory and
-hand it to yourself before cloning into it; `install.sh` writes `.env` inside the checkout and
-needs to own it:
+hand it to yourself before unpacking into it; `install.sh` writes `.env` inside that directory
+and needs to own it:
 
 ```bash
-sudo install -d -o "$USER" -g "$USER" /srv/openmemship
-git clone https://github.com/marcandreuf/memship.git /srv/openmemship/app
+sudo install -d -o "$USER" -g "$USER" /srv/openmemship/app
+curl -fsSL "https://github.com/marcandreuf/memship/archive/refs/tags/v${MEMSHIP_VERSION}.tar.gz" \
+  | tar -xz -C /srv/openmemship/app --strip-components=1
 cd /srv/openmemship/app
-./scripts/install.sh --data-root /srv/openmemship/data --domain memship.example.com
+./scripts/install.sh --data-root /srv/openmemship/data --domain memship.example.com \
+                     --tag "$MEMSHIP_VERSION"
 ```
 
-The bootstrap clone in your home directory has done its job now and can be deleted.
+The bootstrap script in your home directory has done its job now and can be deleted.
 
 That creates the data root, generates real secrets into `.env` (mode 600), pulls the published
 images and starts the stack.
 
-**Your install is pinned to a version.** `install.sh` sets `IMAGE_TAG` to the most recent release
-tag in the checkout, so the deployment stays on that version until you move it deliberately, and
-`/api/v1/health` reports which one it runs. Pass `--tag 2.2.0` to pin a different one.
+**Your install is pinned to a version.** `--tag` becomes `IMAGE_TAG`, so the deployment stays on
+that version until you move it deliberately, and `/api/v1/health` reports which one it runs.
+
+**Pass `--tag` explicitly.** With no git checkout to read a release tag from, omitting it falls
+back to `latest` — a moving target, and an instance that reports its own version as the literal
+string `latest`.
 
 **To upgrade later, follow [Upgrading](../self-hosting/upgrading.md).** Moving `IMAGE_TAG` on its
-own is not enough — part of a release ships in the git checkout rather than in the images, so an
-upgrade starts with `git pull`.
+own is not enough — `docker-compose.yml`, the `Caddyfile` and `scripts/` ship alongside the images
+rather than inside them, so an upgrade starts by refreshing those files from the new release.
 
 **Point DNS at the server first.** `install.sh` refuses to start when the hostname does not
 resolve to this host, because Caddy validates over HTTP-01 and Let's Encrypt rate-limits *failed*
@@ -170,7 +184,11 @@ Debian and Ubuntu hosts are unaffected.
 If you would rather not use `install.sh`, the equivalent manual steps are:
 
 ```bash
-git clone https://github.com/marcandreuf/memship.git
+MEMSHIP_VERSION=2.6.0
+
+mkdir -p memship
+curl -fsSL "https://github.com/marcandreuf/memship/archive/refs/tags/v${MEMSHIP_VERSION}.tar.gz" \
+  | tar -xz -C memship --strip-components=1
 cd memship
 cp .env.example .env
 ```

--- a/docs/self-hosting/backups-and-restore.md
+++ b/docs/self-hosting/backups-and-restore.md
@@ -24,6 +24,26 @@ sudo tar czf memship-$(date +%F).tar.gz \
 `sudo` is needed because `data/postgres` is owned by uid 70 and mode `0700` — that is Postgres
 protecting its own files, not a misconfiguration.
 
+### Do this on the day you install
+
+`install.sh` generates `SECRET_KEY` and `MEMSHIP_SECRET_KEY` on the server, once, at first
+install. They are never regenerated and no copy exists anywhere else — not in the repository,
+not in your CI secrets, not in any dump. The install prints a warning saying so; it does not
+print the values, because the same script runs from a deploy pipeline whose log may be public.
+
+So before you put real data in, take `.env` off the server and put it somewhere that survives
+the server:
+
+```bash
+scp -P <ssh-port> <user>@<host>:/srv/openmemship/app/.env  ~/memship-env-backup
+```
+
+Store it in a password manager, not only on your laptop, and give a second administrator
+access. A recovery that depends on one person's machine stalls exactly when you need it.
+
+This applies to a first deploy through the pipeline too — the pipeline creates `.env` on the
+server the same way, and copies nothing back.
+
 > **A file-level copy of `data/postgres` while the database is running is not
 > crash-consistent.** For a dependable database backup use `db-backup.sh` below, which runs
 > `pg_dump` inside the container. Use the `tar` copy for uploads, certificates and config — or
@@ -97,3 +117,26 @@ The `backups/` directory sits on the same disk as the database it protects, so o
 survives nothing worse than a bad migration. Copy the dumps somewhere else on a schedule —
 object storage, another host, anywhere with a different failure mode — or a single server loss
 takes your only copy with it.
+
+The same is true of the pre-upgrade snapshot the deploy pipeline takes: `upgrade.sh` runs
+`db-backup.sh` before applying a release, but that dump lands in `backups/` on the instance.
+It covers a failed migration. It does not cover losing the machine, and a green deploy log is
+not evidence that anything left the building.
+
+`scripts/pull-backup.sh` is a starting point you run from your own machine, not from the
+server:
+
+```bash
+./scripts/pull-backup.sh <ssh-host> --dump              # fresh dump, then fetch .env + dumps
+./scripts/pull-backup.sh <ssh-host> --with-data         # also uploads and TLS certificates
+```
+
+It needs root on neither machine, and it skips `data/postgres` on purpose — those files need
+sudo and a file-level copy of a running database is not crash-consistent. The `pg_dump` in
+`backups/` is the consistent copy.
+
+It is deliberately not a backup system: no schedule, no retention, no verification, no
+encryption at rest. Run it from cron on a machine that stays on, and point `--dest` at storage
+that is itself backed up. A fuller system — S3 and other object stores, push to another host
+over SSH or rsync, retention and restore testing — is tracked in
+[#137](https://github.com/marcandreuf/memship/issues/137).

--- a/docs/self-hosting/upgrading.md
+++ b/docs/self-hosting/upgrading.md
@@ -23,16 +23,21 @@ IMAGE_TAG=1.2.0
 2. **Review the release notes** for the target version (breaking changes, new required
    settings) on the [releases page](https://github.com/marcandreuf/memship/releases).
 
-3. **Pull the repository, not only the image tag:**
+3. **Refresh the deployment files, not only the image tag:**
 
    ```bash
-   cd /path/to/memship
-   git pull
+   MEMSHIP_VERSION=1.3.0
+   cd /srv/openmemship/app
+   curl -fsSL "https://github.com/marcandreuf/memship/archive/refs/tags/v${MEMSHIP_VERSION}.tar.gz" \
+     | tar -xz --strip-components=1
    ```
 
-   Part of a release ships in the git checkout rather than in the images — `docker-compose.yml`,
-   the `Caddyfile`, `scripts/install.sh`. Bumping `IMAGE_TAG` alone leaves an install
-   half-upgraded: the new backend running behind the old proxy configuration.
+   Part of a release ships alongside the images rather than inside them —
+   `docker-compose.yml`, the `Caddyfile`, `scripts/`. Bumping `IMAGE_TAG` alone leaves an
+   install half-upgraded: the new backend running behind the old proxy configuration.
+
+   Unpacking over the directory replaces those files and leaves `.env` untouched — it is not in
+   the archive. The server needs no git and no source checkout for this.
 
 4. **Bump the tag** in `.env`:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -213,6 +213,30 @@ EOF
     info "wrote .env with generated secrets (mode 600)"
     info "IMAGE_TAG=$NEW_TAG"
 
+    # First install is the only moment this can be said usefully: the keys were
+    # generated seconds ago, they are never regenerated, and no copy exists
+    # anywhere else. A database backup restored without them comes back with the
+    # payment-provider, SSO and mail credentials unreadable.
+    #
+    # The values are NOT printed. This script also runs unattended from a deploy
+    # pipeline, and that pipeline's log is public on a public repository —
+    # printing them once would publish them permanently.
+    warn "Copy $ENV_FILE off this host now, before going further.
+
+    It holds SECRET_KEY and MEMSHIP_SECRET_KEY, just generated and never
+    regenerated. They decrypt the payment-provider, SSO and mail credentials
+    stored in the database. Nothing else holds a copy: lose this host without
+    a copy of this file and a perfect database dump still restores those
+    credentials as unreadable ciphertext.
+
+    Store it in a password manager or a secret store that does NOT live on
+    this host. The values are not printed here on purpose — this script also
+    runs from a deploy pipeline whose log may be public.
+
+      scp this file to somewhere safe, or open it on the host to copy the two
+      keys out by hand.
+
+    Full procedure: docs/self-hosting/backups-and-restore.md"
 fi
 
 # Applying --domain or --tag to an existing .env, in place.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -212,6 +212,7 @@ EOF
     chmod 600 "$ENV_FILE"
     info "wrote .env with generated secrets (mode 600)"
     info "IMAGE_TAG=$NEW_TAG"
+
 fi
 
 # Applying --domain or --tag to an existing .env, in place.
@@ -336,7 +337,11 @@ cat <<EOF
   Then:  docker compose ps       # check everything is up
          docker compose logs -f  # watch it start
 
-  Upgrading later: git pull, set IMAGE_TAG in .env, re-run this script.
+  Upgrading later: refresh this directory from the release you want, then
+                   ./scripts/upgrade.sh <version>
+                   Pulling images alone is a half-upgrade: part of a release
+                   ships here, beside the images — this Compose file, the
+                   Caddyfile, these scripts.
                    Full procedure: docs/self-hosting/upgrading.md
   Backups: docs/self-hosting/backups-and-restore.md
 

--- a/scripts/pull-backup.sh
+++ b/scripts/pull-backup.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# memship — pull a deployment's irreplaceable state off the server, onto the
+# machine you run this from. This is the ONLY script here that runs on an
+# administrator's workstation rather than on the instance.
+#
+#   ./scripts/pull-backup.sh ovh-vps-memship
+#   ./scripts/pull-backup.sh ubuntu@203.0.113.10 --port 51337 --dump
+#   ./scripts/pull-backup.sh ovh-vps-memship --with-data --dest ~/memship-backups
+#
+# It fetches, in this order:
+#
+#   .env          the generated secrets. SECRET_KEY and MEMSHIP_SECRET_KEY
+#                 decrypt the payment-provider, SSO and mail credentials held
+#                 in the database. Without this file a perfect database dump
+#                 restores those as unreadable ciphertext.
+#   backups/      the pg_dump archives db-backup.sh writes
+#   storage/      uploads, and secret.key   (--with-data)
+#   caddy/        TLS certificates          (--with-data)
+#
+# It deliberately does NOT copy $MEMSHIP_DATA_ROOT/postgres. Those files are
+# owned by uid 70 mode 0700, so copying them would need sudo on the far side,
+# and a file-level copy of a running database is not crash-consistent anyway.
+# The pg_dump in backups/ is the consistent copy — that is what it is for.
+# Nothing here needs root on either machine.
+#
+# This is a STARTING POINT, not a backup system. It has no schedule, no
+# retention, no verification and no encryption at rest. Run it from cron on a
+# machine that stays on, point --dest at storage that is itself backed up, and
+# see docs/self-hosting/backups-and-restore.md.
+
+set -euo pipefail
+
+TARGET=""
+PORT=""
+REMOTE_PATH="/srv/openmemship/app"
+DEST=""
+DO_DUMP=0
+WITH_DATA=0
+
+die() { printf '\nError: %s\n' "$*" >&2; exit 1; }
+info() { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+warn() { printf '\n!!  %s\n' "$*" >&2; }
+
+usage() {
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+    exit 0
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage ;;
+        --port) PORT="${2:?--port needs a value}"; shift 2 ;;
+        --remote-path) REMOTE_PATH="${2:?--remote-path needs a value}"; shift 2 ;;
+        --dest) DEST="${2:?--dest needs a value}"; shift 2 ;;
+        --dump) DO_DUMP=1; shift ;;
+        --with-data) WITH_DATA=1; shift ;;
+        -*) die "unknown option: $1" ;;
+        *) [ -z "$TARGET" ] || die "give exactly one ssh target"; TARGET="$1"; shift ;;
+    esac
+done
+
+[ -n "$TARGET" ] || usage
+
+command -v rsync >/dev/null 2>&1 || die "rsync is required on this machine."
+
+SSH_OPTS=(-o BatchMode=yes)
+[ -n "$PORT" ] && SSH_OPTS+=(-p "$PORT")
+SSH_CMD="ssh $(printf '%s ' "${SSH_OPTS[@]}")"
+
+DEST="${DEST:-./memship-backups/${TARGET//[^A-Za-z0-9._-]/_}}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+
+step "Checking $TARGET"
+ssh "${SSH_OPTS[@]}" "$TARGET" "test -f '$REMOTE_PATH/.env'" \
+    || die "no .env at $REMOTE_PATH on $TARGET. Pass --remote-path if the deployment lives elsewhere."
+
+# Resolve the data root the way Compose does — from .env on the instance — so
+# this script has no second copy of a setting that can drift.
+DATA_ROOT="$(ssh "${SSH_OPTS[@]}" "$TARGET" \
+    "grep -E '^MEMSHIP_DATA_ROOT=' '$REMOTE_PATH/.env' | tail -1 | cut -d= -f2-" || true)"
+[ -n "$DATA_ROOT" ] || die "could not read MEMSHIP_DATA_ROOT from $REMOTE_PATH/.env"
+info "data root: $DATA_ROOT"
+
+if [ "$DO_DUMP" -eq 1 ]; then
+    step "Taking a fresh dump on $TARGET"
+    ssh "${SSH_OPTS[@]}" "$TARGET" "cd '$REMOTE_PATH' && ./scripts/db-backup.sh"
+fi
+
+mkdir -p "$DEST/env" "$DEST/dumps"
+chmod 700 "$DEST/env"
+
+step "Fetching .env"
+rsync -a -e "$SSH_CMD" "$TARGET:$REMOTE_PATH/.env" "$DEST/env/env-$STAMP"
+chmod 600 "$DEST/env/env-$STAMP"
+info "$DEST/env/env-$STAMP"
+
+step "Fetching database dumps"
+rsync -a --info=stats1 -e "$SSH_CMD" "$TARGET:$DATA_ROOT/backups/" "$DEST/dumps/"
+info "$(find "$DEST/dumps" -name '*.sql.gz' | wc -l | tr -d ' ') dump(s) in $DEST/dumps"
+
+if [ "$WITH_DATA" -eq 1 ]; then
+    step "Fetching uploads and certificates"
+    rsync -a --info=stats1 -e "$SSH_CMD" "$TARGET:$DATA_ROOT/storage/" "$DEST/storage/"
+    rsync -a --info=stats1 -e "$SSH_CMD" "$TARGET:$DATA_ROOT/caddy/" "$DEST/caddy/"
+    info "$DEST/storage, $DEST/caddy"
+else
+    info "skipping uploads and certificates — pass --with-data to include them"
+fi
+
+printf '\nPulled to %s\n' "$DEST"
+
+warn "What you just copied decrypts and contains everything.
+
+    env/env-$STAMP holds the keys, and dumps/ holds every member record. This
+    directory now deserves the same protection as the server it came from:
+    keep it off shared storage, and make sure whatever backs THIS machine up
+    is somewhere you would still trust with it.
+
+    A copy on one workstation is one disk failure from nothing. Put the .env
+    in a password manager as well, and point --dest at storage that is itself
+    backed up."

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4,7 +4,7 @@
 #
 #   ./scripts/upgrade.sh 2.7.0
 #
-# This is the whole upgrade procedure in one command: back up, apply, check.
+# This is the whole upgrade procedure in one command: snapshot, apply, check.
 # Run it by hand on the host, or let the deploy workflow run it for you — both
 # do exactly the same thing, which is the point. What is automated and what an
 # operator types must not drift apart.
@@ -31,15 +31,22 @@ cd "$REPO_ROOT"
 
 step() { printf '\n==> %s\n' "$*"; }
 
-# Back up before anything touches the database. A release that carries a schema
+# Snapshot before anything touches the database. A release that carries a schema
 # migration cannot be rolled back by re-pinning IMAGE_TAG — the images go back,
-# the migrated schema does not — so this backup is the only way out of a bad
+# the migrated schema does not — so this snapshot is the only way out of a bad
 # upgrade. If it fails, the upgrade does not happen.
+#
+# It is NOT a backup in the sense that matters for losing the host: db-backup.sh
+# writes into $MEMSHIP_DATA_ROOT/backups, on this machine, beside the database it
+# just dumped. It also captures no uploads and no .env. Saying "backing up" here
+# would let a green deploy log stand in for disaster recovery, which it is not.
 if [ -f .env ] && [ -n "$(docker compose ps --quiet db 2>/dev/null)" ]; then
-    step "Backing up the database"
+    step "Pre-upgrade snapshot — rollback cover only, stays on this host"
     ./scripts/db-backup.sh
+    printf '  This protects against a bad migration, not against losing this\n'
+    printf '  machine. Off-host copies: docs/self-hosting/backups-and-restore.md\n'
 else
-    step "No running database — treating this as a first install, nothing to back up"
+    step "No running database — first install, nothing to snapshot"
 fi
 
 step "Applying $VERSION"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# memship — install or upgrade an instance to a given version, and verify it.
+#
+#   ./scripts/upgrade.sh 2.7.0
+#
+# This is the whole upgrade procedure in one command: back up, apply, check.
+# Run it by hand on the host, or let the deploy workflow run it for you — both
+# do exactly the same thing, which is the point. What is automated and what an
+# operator types must not drift apart.
+#
+# On a first install there is nothing to back up and no .env yet, so pass the
+# two things install.sh needs to create one:
+#
+#   DOMAIN=memship.example.org DATA_ROOT=/home/you/memship-data ./scripts/upgrade.sh 2.7.0
+#
+# On an upgrade both are read from the existing .env and can be omitted; it
+# never overwrites a .env that exists.
+#
+# Keep DATA_ROOT OUTSIDE this directory. Deployments deliver files here by
+# copying over the top of it, and persistent data must never sit in the path
+# something might one day mirror or clean.
+
+set -euo pipefail
+
+VERSION="${1:?usage: upgrade.sh <version>, e.g. 2.7.0}"
+VERSION="${VERSION#v}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+step() { printf '\n==> %s\n' "$*"; }
+
+# Back up before anything touches the database. A release that carries a schema
+# migration cannot be rolled back by re-pinning IMAGE_TAG — the images go back,
+# the migrated schema does not — so this backup is the only way out of a bad
+# upgrade. If it fails, the upgrade does not happen.
+if [ -f .env ] && [ -n "$(docker compose ps --quiet db 2>/dev/null)" ]; then
+    step "Backing up the database"
+    ./scripts/db-backup.sh
+else
+    step "No running database — treating this as a first install, nothing to back up"
+fi
+
+step "Applying $VERSION"
+install_args=(--tag "$VERSION")
+if [ -n "${DATA_ROOT:-}" ]; then
+    install_args+=(--data-root "$DATA_ROOT")
+fi
+if [ -n "${DOMAIN:-}" ]; then
+    install_args+=(--domain "$DOMAIN")
+fi
+./scripts/install.sh "${install_args[@]}"
+
+step "Verifying"
+./scripts/verify-deployment.sh "$VERSION"

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# memship — confirm a deployment came back on the version you asked for.
+#
+#   ./scripts/verify-deployment.sh 2.7.0
+#
+# Run this after an install or upgrade. `docker compose up -d` returning says
+# only that the containers were created; the API applies database migrations
+# before it starts serving, so a failed migration looks like an API that never
+# answers rather than a container that failed to start. The only way to know a
+# deployment landed is to ask it.
+#
+# Checks, in order:
+#   1. the API answers /api/v1/health
+#   2. it reports the version that was deployed, not the one it was running
+#   3. the Celery worker answers a ping — it is the half that fails quietly,
+#      and without it no mail and no scheduled billing job runs
+
+set -euo pipefail
+
+EXPECTED="${1:?usage: verify-deployment.sh <version>, e.g. 2.7.0}"
+EXPECTED="${EXPECTED#v}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TIMEOUT="${VERIFY_TIMEOUT:-300}"
+INTERVAL=5
+
+# The API is published on the loopback interface only, which is where we probe
+# it: going in through the public hostname would test DNS and the certificate
+# too, and those fail for reasons that have nothing to do with the deployment.
+# The backend image carries no curl, so this cannot be an `exec` into the
+# container — read the published port and probe from the host.
+env_value() {
+    [ -f .env ] || return 0
+    grep -E "^$1=" .env | tail -1 | cut -d= -f2- || true
+}
+
+API_PORT="$(env_value API_PORT)"
+API_PORT="${API_PORT:-8003}"
+HEALTH_URL="http://127.0.0.1:${API_PORT}/api/v1/health"
+
+printf '==> Waiting for the API on %s\n' "$HEALTH_URL"
+
+deadline=$((SECONDS + TIMEOUT))
+body=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+    if body="$(curl -fsS --max-time 5 "$HEALTH_URL" 2>/dev/null)"; then
+        break
+    fi
+    body=""
+    printf '.'
+    sleep "$INTERVAL"
+done
+
+if [ -z "$body" ]; then
+    printf '\n'
+    printf 'ERROR: the API did not answer within %ss.\n' "$TIMEOUT" >&2
+    printf 'A failed migration is the usual cause. Check:  docker compose logs api\n' >&2
+    exit 1
+fi
+
+printf '\n  %s\n' "$body"
+
+reported="$(printf '%s' "$body" | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+if [ "$reported" != "$EXPECTED" ]; then
+    printf 'ERROR: deployed %s but the API reports %s.\n' "$EXPECTED" "${reported:-<none>}" >&2
+    printf 'IMAGE_TAG in .env and the running containers disagree — the upgrade did not take.\n' >&2
+    exit 1
+fi
+printf '  version %s — as deployed\n' "$reported"
+
+printf '==> Pinging the Celery worker\n'
+# Call celery directly. `uv run` needs write access to /app/.venv and fails as
+# the non-root runtime user the containers run as.
+if ! docker compose exec -T celery-worker \
+        celery -A app.core.celery_app inspect ping -t 10 </dev/null >/dev/null 2>&1; then
+    printf 'ERROR: the API is up but the Celery worker did not answer.\n' >&2
+    printf 'Mail and the scheduled billing jobs will not run. Check:  docker compose logs celery-worker\n' >&2
+    exit 1
+fi
+printf '  worker responding\n'
+
+printf '\nDeployment verified: %s\n' "$EXPECTED"

--- a/scripts/vps-bootstrap.sh
+++ b/scripts/vps-bootstrap.sh
@@ -110,7 +110,11 @@ export DEBIAN_FRONTEND=noninteractive
 
 step "Updating the package index"
 apt-get update -qq
-apt-get install -y -qq ca-certificates curl gnupg git >/dev/null
+# No git. An instance holds no source checkout: the deployment files arrive
+# as a release tarball over curl, or over rsync from the deploy workflow.
+# Installing git here would put a tool on the box that nothing uses and that
+# invites someone to clone a working copy next to a production deployment.
+apt-get install -y -qq ca-certificates curl gnupg >/dev/null
 
 # ---------------------------------------------------------------- deploy user
 
@@ -376,12 +380,23 @@ cat <<EOF
   2. INSTALL MEMSHIP as $DEPLOY_USER — not as root:
 
        su - $DEPLOY_USER          # or log in again over SSH, so the docker group applies
-       sudo install -d -o $DEPLOY_USER -g $DEPLOY_USER /srv/openmemship
-       git clone https://github.com/marcandreuf/memship.git /srv/openmemship/app
+       sudo install -d -o $DEPLOY_USER -g $DEPLOY_USER /srv/openmemship/app
+       curl -fsSL https://github.com/marcandreuf/memship/archive/refs/tags/v<version>.tar.gz \\
+         | tar -xz -C /srv/openmemship/app --strip-components=1
        cd /srv/openmemship/app
-       ./scripts/install.sh --data-root /srv/openmemship/data --domain <your-domain>
+       ./scripts/install.sh --data-root /srv/openmemship/data --domain <your-domain> --tag <version>
+
+     Pass --tag explicitly. It is the version you just downloaded, without the
+     leading v. Without git the script cannot read a tag from the checkout, and
+     it falls back to 'latest' — a moving target, and an instance that reports
+     its own version as the literal string "latest".
 
      Point the DNS A record at this host before running it. install.sh checks,
      because failed Let's Encrypt validations are rate-limited at 5 per hour.
+
+  3. UPGRADING later: repeat step 2 with the new version over the same
+     directory, then re-run install.sh with the new --tag. Releases ship part
+     of a deployment outside the images — the Compose file, the Caddyfile, the
+     scripts — so pulling images alone applies an upgrade only halfway.
 
 EOF


### PR DESCRIPTION
Deploys a released version to an instance on a VPS that holds no source checkout and no git: the application arrives as images from the registry, and the handful of files a deployment needs outside the images — the Compose file, the Caddy configuration, the operational scripts — are delivered over rsync.

## Three pieces, one path

**`.github/workflows/deploy.yml`** takes a version to deploy, or a commit SHA to rehearse one that has not been tagged yet — exactly one of the two, checked rather than assumed. With no environment to validate a build on, rehearsing a commit on a real box is the only pre-release check there is. Each instance is a GitHub Environment, so a second one is configuration rather than an edit to this file.

Two rsync rules earn their comments. `scripts/` is mirrored with `--delete` because it belongs wholly to the release, minus `dev.sh` and `release.sh`, which have no business on a server — `release.sh` creates and pushes git tags. The top level is never mirrored, because `.env` lives there: it holds generated secrets, and losing it means losing access to everything encrypted with them.

**`scripts/upgrade.sh`** backs up, applies, verifies. The pipeline runs it over SSH and an operator runs it by hand, and it is the same script both times, so the automated path and the documented one cannot drift. The backup comes first and a failure aborts: a release carrying a schema migration cannot be rolled back by re-pinning `IMAGE_TAG`, since the images go back and the migrated schema does not.

**`scripts/verify-deployment.sh`** asks the instance what it is running, because `compose up -d` returning only means containers were created — the API applies migrations before serving, so a failed migration presents as an API that never answers. It probes the published port from the host loopback rather than `exec`-ing curl into the container (the backend image has no curl), and pings the worker with a direct `celery` call (`uv run` needs write access to `/app/.venv` that the non-root runtime user does not have). Tested against the live instance before the box was wiped: passes on the deployed version, exits 1 when told to expect another.

## Forks deploy with this too

The job originally carried `if: github.repository == 'marcandreuf/memship'`. On a fork that condition is false, so the job would be **skipped while the run still reported green** — someone self-hosting would dispatch a deploy, see success, and have deployed nothing. The guard bought nothing: the trigger is `workflow_dispatch` only, so a run can be started only by someone who already has write access to the repository it runs in, and Environment secrets are never handed to fork-triggered workflows either way. Removed, with a header comment saying why so it is not restored as a safety measure.

Deploying from a fork is a supported path: the images are public, so a fork pulls the same released images rather than building its own, and everything that varies between instances is already an Environment secret.

Note this is not the *recommended* path for a third-party self-hoster — that should be a script run on the box, since the fork model asks an operator to place a production SSH key into GitHub Actions and to accept SSH from GitHub's runner ranges. #129 covers building that path.

## Merging is a prerequisite for testing it

GitHub registers a `workflow_dispatch` trigger only for workflow files present on the **default branch**, so `deploy.yml` cannot be dispatched from this branch at all. Merging is mild: the workflow is dispatch-only, so it cannot run by itself, and it touches nothing `ci.yml` or `build-images.yml` uses. Once it is on `main` once, later dispatches can select a branch ref to iterate.

The `production` Environment and its eight secrets are configured, and the deploy key has been verified end to end against the target host with the exact flags the workflow uses. The instance has been wiped to a clean state, so the first run exercises a genuine first install.

## Test plan once merged

1. Dispatch with `version: 2.5.0` — first install: no `.env`, no database, so `upgrade.sh` skips the backup and `install.sh` creates everything.
2. Dispatch with `version: 2.6.0` — the upgrade path, including a real schema migration and the pre-flight backup.

Refs #128
