### PR TITLE
Leave post-install work in a file on the server, and drop real host details from examples

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,6 +161,27 @@ jobs:
             ./Caddyfile \
             "${TARGET}:${DEPLOY_PATH}/"
 
+      # Whether .env already exists decides what the summary has to say. Asked
+      # before the deploy, because afterwards it always exists — install.sh has
+      # just written it — and a first install is precisely the run whose one
+      # irreversible follow-up nobody can be allowed to miss.
+      - name: Is this a first install?
+        id: state
+        env:
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ vars.DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
+        run: |
+          set -euo pipefail
+          if ssh -i ~/.ssh/deploy_key -p "${DEPLOY_PORT}" -o BatchMode=yes \
+               "${DEPLOY_USER}@${DEPLOY_HOST}" "test -f '${DEPLOY_PATH}/.env'"; then
+            echo "first_install=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "first_install=true" >> "$GITHUB_OUTPUT"
+            echo "No .env on the instance — this is a first install."
+          fi
+
       - name: Deploy and verify
         env:
           DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
@@ -184,6 +205,9 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.what.outputs.image_tag }}
           CHECKOUT: ${{ steps.what.outputs.checkout }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ vars.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
         run: |
           {
             echo "### Deploy to \`${{ inputs.target }}\`"
@@ -192,3 +216,30 @@ jobs:
             echo "- files from: \`${CHECKOUT}\`"
             echo "- result: \`${{ job.status }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+          # install.sh writes the same list to POST-INSTALL.md on the server and
+          # warns on stderr, but that warning lands mid-step among hundreds of
+          # lines of image pulls, where nobody reads it. The summary is the top
+          # of the run page. DEPLOY_PORT is a secret, so it masks to *** here —
+          # the placeholder is deliberate rather than an oversight.
+          if [ "${{ steps.state.outputs.first_install }}" = "true" ] && [ "${{ job.status }}" = "success" ]; then
+            {
+              echo ""
+              echo "> [!WARNING]"
+              echo "> **First install — finish it.** \`${DEPLOY_PATH}/POST-INSTALL.md\` on the"
+              echo "> instance lists what the installer could not do for you."
+              echo ">"
+              echo "> \`.env\` now holds \`SECRET_KEY\` and \`MEMSHIP_SECRET_KEY\`, generated on the"
+              echo "> host just now and copied nowhere. Lose the host without them and a perfect"
+              echo "> database dump restores your payment, SSO and mail credentials as unreadable"
+              echo "> ciphertext. Copy it off, from your own machine:"
+              echo ">"
+              echo "> \`\`\`"
+              echo "> scp -P <ssh-port> ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/.env ~/memship-env-backup"
+              echo "> \`\`\`"
+              echo ">"
+              echo "> Then create the organization and super admin, and set up backups —"
+              echo "> both are in POST-INSTALL.md."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::First install — copy ${DEPLOY_PATH}/.env off ${DEPLOY_HOST} now. See POST-INSTALL.md on the instance."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ e2e/runner-results/
 # Per-repo config for personal agent skills (local, never committed)
 # The skills read these from the working tree; contributors do not need them.
 docs/agents/
+
+# Written on the server by scripts/install.sh at first install
+POST-INSTALL.md

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -86,6 +86,10 @@ without this file a perfect database dump restores those as unreadable ciphertex
 password manager a second administrator can reach — see
 [Backups & restore](../self-hosting/backups-and-restore.md#do-this-on-the-day-you-install).
 
+`install.sh` also writes **`POST-INSTALL.md`** next to `.env` on a first install: this step
+plus creating your organization, scheduling backups and configuring email, with the paths
+already filled in. Work through it and delete it.
+
 **Your install is pinned to a version.** `--tag` becomes `IMAGE_TAG`, so the deployment stays on
 that version until you move it deliberately, and `/api/v1/health` reports which one it runs.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -213,30 +213,96 @@ EOF
     info "wrote .env with generated secrets (mode 600)"
     info "IMAGE_TAG=$NEW_TAG"
 
-    # First install is the only moment this can be said usefully: the keys were
-    # generated seconds ago, they are never regenerated, and no copy exists
-    # anywhere else. A database backup restored without them comes back with the
-    # payment-provider, SSO and mail credentials unreadable.
+    # First install is the only moment these can be said usefully, and a log
+    # line is the wrong place to say them: this script runs unattended from a
+    # deploy pipeline, where its output is one collapsed step among hundreds of
+    # lines of image pulls. So the list goes in a file on the server, which sits
+    # there until somebody deals with it, and the warning below only points at it.
     #
-    # The values are NOT printed. This script also runs unattended from a deploy
-    # pipeline, and that pipeline's log is public on a public repository —
-    # printing them once would publish them permanently.
-    warn "Copy $ENV_FILE off this host now, before going further.
+    # No secret values here or in the file. This output can reach a public CI log.
+    cat > "$REPO_ROOT/POST-INSTALL.md" <<POSTINSTALL
+# memship — before this instance is really yours
 
-    It holds SECRET_KEY and MEMSHIP_SECRET_KEY, just generated and never
-    regenerated. They decrypt the payment-provider, SSO and mail credentials
-    stored in the database. Nothing else holds a copy: lose this host without
-    a copy of this file and a perfect database dump still restores those
-    credentials as unreadable ciphertext.
+Written by \`scripts/install.sh\` at first install. Nothing below can be done
+for you by the installer. **Delete this file once you have worked through it.**
 
-    Store it in a password manager or a secret store that does NOT live on
-    this host. The values are not printed here on purpose — this script also
-    runs from a deploy pipeline whose log may be public.
+## 1. Copy \`.env\` off this server — do this before anything else
 
-      scp this file to somewhere safe, or open it on the host to copy the two
-      keys out by hand.
+\`$ENV_FILE\` holds \`SECRET_KEY\` and \`MEMSHIP_SECRET_KEY\`. They were generated
+here, they are never regenerated, and no other copy exists. They decrypt the
+payment-provider, SSO and mail credentials stored in your database, so a
+perfect database dump restored without them gives those back as unreadable
+ciphertext. Uploads are in no database dump at all.
 
-    Full procedure: docs/self-hosting/backups-and-restore.md"
+From your own machine, not from this server:
+
+\`\`\`bash
+scp -P <ssh-port> $USER@<this-host>:$ENV_FILE ~/memship-env-backup
+chmod 600 ~/memship-env-backup
+\`\`\`
+
+Then put it in a password manager a second administrator can also reach. A
+recovery that depends on one person's laptop stalls exactly when you need it.
+
+## 2. Create your organization and super admin
+
+\`\`\`bash
+cd $REPO_ROOT
+docker compose exec -it api python -m app.cli.seed
+\`\`\`
+
+It prompts, so it needs a terminal — keep the \`-it\`.
+
+## 3. Set up backups, and get them off this machine
+
+\`scripts/db-backup.sh\` dumps the database into \`$DATA_ROOT/backups\`, which is
+the same disk as the database it protects. That covers a bad migration and
+nothing worse. Schedule it, then copy the dumps somewhere with a different
+failure mode:
+
+\`\`\`cron
+30 3 * * *  cd $REPO_ROOT && ./scripts/db-backup.sh
+\`\`\`
+
+\`scripts/pull-backup.sh\` runs on **your** machine and pulls \`.env\`, the dumps
+and optionally uploads and certificates off this one. It is a starting point,
+not a backup system.
+
+Read \`docs/self-hosting/backups-and-restore.md\` before you go live, and test a
+restore once. A backup you have never restored is a guess.
+
+## 4. Configure email
+
+Until a transport is set, registration, password-reset and receipt emails are
+**dropped silently**. Fill in either the Resend key or the SMTP block in
+\`.env\`, or configure it from Settings. See \`docs/self-hosting/email.md\`.
+
+## Where things are
+
+| | |
+|---|---|
+| Deployment | \`$REPO_ROOT\` |
+| Secrets | \`$ENV_FILE\` (mode 600) |
+| Data root | \`$DATA_ROOT\` |
+| Address | \`${SITE:-http://localhost}\` |
+| Version | \`$NEW_TAG\` |
+
+Upgrading: refresh this directory from the release you want, then
+\`./scripts/upgrade.sh <version>\`. See \`docs/self-hosting/upgrading.md\`.
+POSTINSTALL
+    chmod 644 "$REPO_ROOT/POST-INSTALL.md"
+
+    warn "Not finished yet — read $REPO_ROOT/POST-INSTALL.md
+
+    It lists what this installer cannot do for you, starting with the one that
+    cannot be recovered later: $ENV_FILE holds SECRET_KEY and
+    MEMSHIP_SECRET_KEY, generated just now, never regenerated, copied nowhere.
+    Lose this host without a copy of that file and a perfect database dump
+    still restores your payment-provider, SSO and mail credentials as
+    unreadable ciphertext.
+
+    The values are not printed here on purpose — this script also runs from a
+    deploy pipeline whose log may be public."
 fi
 
 # Applying --domain or --tag to an existing .env, in place.

--- a/scripts/pull-backup.sh
+++ b/scripts/pull-backup.sh
@@ -4,9 +4,9 @@
 # machine you run this from. This is the ONLY script here that runs on an
 # administrator's workstation rather than on the instance.
 #
-#   ./scripts/pull-backup.sh ovh-vps-memship
-#   ./scripts/pull-backup.sh ubuntu@203.0.113.10 --port 51337 --dump
-#   ./scripts/pull-backup.sh ovh-vps-memship --with-data --dest ~/memship-backups
+#   ./scripts/pull-backup.sh my-instance          # an ssh config Host entry
+#   ./scripts/pull-backup.sh deploy@203.0.113.10 --port 2222 --dump
+#   ./scripts/pull-backup.sh my-instance --with-data --dest ~/memship-backups
 #
 # It fetches, in this order:
 #


### PR DESCRIPTION
## The problem

The first-install warning added in v2.7.0 fired correctly on the 2.7.0 deploy — and was invisible. It landed at **line 248 of an 1,150-line log**, inside a collapsed step, with ~900 lines of image pulls after it. It also said "scp this file" without giving a command to run.

A warning nobody reads is the failure it was written to prevent.

## What changes

**`install.sh` writes `POST-INSTALL.md`** beside `.env` on a first install, with every path already substituted:

1. copy `.env` off the host — with a real `scp` line
2. create the organization and super admin
3. schedule backups and get them off the machine
4. configure email, before mail is dropped silently

plus a table of where everything lives. A file on the server sits there until somebody deals with it. The stderr warning shrinks to a pointer at it, and still prints no key — `install.sh` runs unattended from the pipeline, whose log is public.

**`deploy.yml` asks whether `.env` exists before running `upgrade.sh`** — afterwards it always does — and on a first install writes the same reminder to the **job summary**, at the top of the run page, with a `::warning::` annotation and the `scp` command carrying host, user and path. The port stays `<ssh-port>`: `DEPLOY_PORT` is a secret and masks to `***`.

`POST-INSTALL.md` is gitignored, since it is generated on the server.

## Also: real host details out of `pull-backup.sh`

Its usage examples carried a maintainer's ssh alias and the **real SSH port** of a live instance — the same value the workflow keeps out of public logs as a masked secret. Now generic. The IP was already RFC 5737 documentation range.

⚠️ Those values are already in `main`'s history and in the **v2.7.0** source tarball. This fixes them going forward; see the PR discussion for whether that warrants anything more.