### PR TITLE
Make the upgrade doc the procedure the scripts actually implement

### DIFF
--- a/docs/self-hosting/upgrading.md
+++ b/docs/self-hosting/upgrading.md
@@ -1,61 +1,71 @@
 # Upgrading
 
-Memship is released as versioned Docker images. Upgrading means pointing at a newer image tag,
-pulling, and recreating the stack — database migrations run automatically on startup.
+Memship is released as versioned Docker images, plus a handful of files that live beside them —
+the Compose file, the Caddy configuration, the scripts. Upgrading means refreshing both, then
+running one command that backs up, applies the version and verifies it. Database migrations run
+automatically on startup.
 
 ## Versioning
 
 Memship follows [semantic versioning](https://semver.org/). **Git tags are the single source
 of truth** for the version — there is no `VERSION` file. Published images are tagged with the
-release version (e.g. `1.2.0`) and `latest`.
+release version (e.g. `2.7.1`) and `latest`.
 
-Pin a specific version in production rather than tracking `latest`, so upgrades are
-deliberate. Set it in `.env`:
+Every install is pinned to a version rather than tracking `latest`, so upgrades are deliberate
+and an instance can say which release it runs. `IMAGE_TAG` in `.env` holds it; `install.sh
+--tag` and `upgrade.sh` write it for you, and `/api/v1/health` reports it back:
 
 ```bash
-IMAGE_TAG=1.2.0
+curl -s http://127.0.0.1:8003/api/v1/health
+{"status":"healthy","version":"2.7.1","environment":"production"}
 ```
 
 ## Upgrade procedure
 
-1. **Back up first.** See [Backups & restore](backups-and-restore.md).
+**Review the release notes** for the target version first — breaking changes and new required
+settings are called out there, on the [releases page](https://github.com/marcandreuf/memship/releases).
 
-2. **Review the release notes** for the target version (breaking changes, new required
-   settings) on the [releases page](https://github.com/marcandreuf/memship/releases).
+Then two commands. Refresh the deployment files, then apply the version:
 
-3. **Refresh the deployment files, not only the image tag:**
+```bash
+MEMSHIP_VERSION=2.7.1
+cd /srv/openmemship/app          # wherever your install lives
 
-   ```bash
-   MEMSHIP_VERSION=1.3.0
-   cd /srv/openmemship/app
-   curl -fsSL "https://github.com/marcandreuf/memship/archive/refs/tags/v${MEMSHIP_VERSION}.tar.gz" \
-     | tar -xz --strip-components=1
-   ```
+curl -fsSL "https://github.com/marcandreuf/memship/archive/refs/tags/v${MEMSHIP_VERSION}.tar.gz" \
+  | tar -xz --strip-components=1
 
-   Part of a release ships alongside the images rather than inside them —
-   `docker-compose.yml`, the `Caddyfile`, `scripts/`. Bumping `IMAGE_TAG` alone leaves an
-   install half-upgraded: the new backend running behind the old proxy configuration.
+./scripts/upgrade.sh "$MEMSHIP_VERSION"
+```
 
-   Unpacking over the directory replaces those files and leaves `.env` untouched — it is not in
-   the archive. The server needs no git and no source checkout for this.
+**Why the first command.** Part of a release ships alongside the images rather than inside
+them — `docker-compose.yml`, the `Caddyfile`, `scripts/`. Bumping `IMAGE_TAG` alone leaves an
+install half-upgraded: the new backend running behind the old proxy configuration. Unpacking
+over the directory replaces those files and leaves `.env` untouched, since `.env` is not in the
+archive. No git and no source checkout are involved.
 
-4. **Bump the tag** in `.env`:
+**What the second one does**, in order, stopping if any step fails:
 
-   ```bash
-   IMAGE_TAG=1.3.0
-   ```
+1. **Backs up the database** with `scripts/db-backup.sh`. A release carrying a schema migration
+   cannot be rolled back by re-pinning `IMAGE_TAG` — the images go back, the migrated schema
+   does not — so this dump is the only way out of a bad upgrade. If it fails, the upgrade does
+   not happen. On a first install there is no database yet and it says so instead.
+2. **Applies the version** through `scripts/install.sh --tag "$MEMSHIP_VERSION"`, which writes
+   `IMAGE_TAG`, pulls, and recreates the stack. It never overwrites an existing `.env`. It also
+   force-recreates Caddy, which matters: the `Caddyfile` is bind-mounted, so changing its
+   contents gives `docker compose up -d` no reason to recreate the container, and it would
+   otherwise keep serving the old configuration.
+3. **Verifies the result** with `scripts/verify-deployment.sh`, which waits for the API, checks
+   that it reports the version you just deployed, and pings the Celery worker. `docker compose
+   up -d` returning says only that containers were created — migrations run before the API
+   serves, so a failed one looks like an API that never answers rather than a container that
+   died.
 
-5. **Pull and recreate:**
+This is the same command the deploy workflow runs over SSH, deliberately: what is automated and
+what an operator types should not drift apart.
 
-   ```bash
-   docker compose pull
-   docker compose up -d
-   docker compose up -d --force-recreate caddy
-   ```
-
-   The last line matters. The `Caddyfile` is bind-mounted, so changing its contents does not
-   change the container's configuration — `docker compose up -d` sees no reason to recreate
-   Caddy and leaves it serving the old one.
+> The pre-upgrade dump lands in `$MEMSHIP_DATA_ROOT/backups`, on the same disk as the database
+> it protects. It covers a bad upgrade, not a lost machine — see
+> [Backups & restore](backups-and-restore.md#off-server-copies) for getting copies off the host.
 
 ## Upgrading from a release before the non-root backend
 
@@ -97,6 +107,11 @@ the backend container after pulling the new image.
 
 ## Rolling back
 
-Roll back by setting `IMAGE_TAG` to the previous version and recreating the stack. Note that
-**database migrations are not automatically reversed** — if a release included a migration,
-restore the database backup you took in step 1 rather than only downgrading the image.
+Roll back by re-running the upgrade against the older version — refresh the files from that
+release's tarball, then `./scripts/upgrade.sh <older-version>`. Going back through the same path
+you came in by keeps the deployment files and the images on the same release.
+
+Note that **database migrations are not automatically reversed.** If the release you are leaving
+included one, the images go back and the migrated schema does not, so restore the dump
+`upgrade.sh` took before it applied that version — it is in `$MEMSHIP_DATA_ROOT/backups`, named
+by timestamp — rather than only downgrading the image.


### PR DESCRIPTION
Found while checking whether a self-hoster could install and upgrade a VPS without the pipeline.

`docs/self-hosting/upgrading.md` step 3 had been updated to fetch a release tarball, but steps 4–5 were still the old hand procedure — edit `IMAGE_TAG`, `docker compose pull`, `up -d`, `--force-recreate caddy`.

Four other places already say `./scripts/upgrade.sh <version>`: `install.sh`'s closing text, `vps-bootstrap.sh`'s step 3, the `POST-INSTALL.md` written at first install, and the v2.7.0 release notes.

So anyone following the guide **skipped the pre-upgrade database dump and the post-upgrade verification**, and hand-rolled a Caddy force-recreate that `install.sh:390` already performs — for exactly the reason the guide gave for doing it manually.

## Now

Two commands, then what `upgrade.sh` does in between: backs up and stops if that fails; applies the version without overwriting an existing `.env`; verifies the API reports the version deployed and that Celery answers. Rolling back goes back through the same path instead of re-pinning a tag, and names which dump to restore when the release being left carried a migration.

Version examples move off 1.2.0/1.3.0.

Closes the documentation half of #129.