### PR TITLE
Give a paid receipt one place to become paid, and reconcile SEPA on close

### DIFF
--- a/backend/app/api/v1/endpoints/receipts.py
+++ b/backend/app/api/v1/endpoints/receipts.py
@@ -29,9 +29,10 @@ from app.domains.billing.service import (
     build_receipts_query,
     cancel_receipt,
     create_receipt,
+    dispatch_payment_notifications,
     emit_receipt,
     generate_membership_fees,
-    pay_receipt,
+    mark_receipt_paid,
     reemit_receipt,
     return_receipt,
     update_receipt,
@@ -378,8 +379,14 @@ def pay_receipt_endpoint(
     if not receipt:
         raise HTTPException(status_code=404, detail="Receipt not found")
 
-    receipt = pay_receipt(db, receipt, data)
+    pending = mark_receipt_paid(
+        db,
+        receipt,
+        payment_method=data.payment_method,
+        payment_date=data.payment_date,
+    )
     db.commit()
+    dispatch_payment_notifications(pending)
     db.refresh(receipt)
     return receipt
 

--- a/backend/app/api/v1/endpoints/remittances.py
+++ b/backend/app/api/v1/endpoints/remittances.py
@@ -25,6 +25,7 @@ from app.domains.billing.remittance_service import (
     import_returns,
     mark_submitted,
 )
+from app.domains.billing.service import dispatch_payment_notifications
 
 router = APIRouter(prefix="/remittances", tags=["remittances"])
 
@@ -200,15 +201,20 @@ def close_remittance_endpoint(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_permission("billing.write")),
 ):
-    """Close a remittance — finalize the batch."""
+    """Close a remittance — the settlement window has passed.
+
+    Every receipt still awaiting settlement is marked paid: SEPA reports only
+    the collections that failed. Returns can no longer be imported afterwards.
+    """
     remittance = db.query(Remittance).filter(
         Remittance.id == remittance_id, Remittance.is_active.is_(True)
     ).first()
     if not remittance:
         raise HTTPException(status_code=404, detail="Remittance not found")
 
-    remittance = close_remittance(db, remittance)
+    remittance, pending = close_remittance(db, remittance)
     db.commit()
+    dispatch_payment_notifications(pending)
     db.refresh(remittance)
     return remittance
 

--- a/backend/app/api/v1/endpoints/webhooks.py
+++ b/backend/app/api/v1/endpoints/webhooks.py
@@ -13,6 +13,7 @@ from app.core.encryption import decrypt_config
 from app.db.session import get_db
 from app.domains.billing.models import PaymentProvider
 from app.domains.billing.provider_config import get_sensitive_fields
+from app.domains.billing.service import dispatch_payment_notifications
 from app.domains.billing import webhook_service
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,10 @@ async def receive_webhook(
             status_code=500,
             media_type="application/json",
         )
+
+    # After the commit, never before: a worker must not read a receipt whose row
+    # is not visible yet, and a handler that rolled back must not leave mail sent.
+    dispatch_payment_notifications((result or {}).get("payment_notifications") or [])
 
     return Response(
         content='{"detail":"OK"}',

--- a/backend/app/domains/billing/providers/redsys_provider.py
+++ b/backend/app/domains/billing/providers/redsys_provider.py
@@ -17,7 +17,6 @@ Crypto (3DES key derivation + HMAC-SHA256) is delegated to `python-redsys`.
 import logging
 import re
 import secrets
-from datetime import date
 from decimal import Decimal, InvalidOperation
 from urllib.parse import parse_qs
 
@@ -252,7 +251,10 @@ class RedsysAdapter(PaymentProviderAdapter):
     def handle_webhook(self, db: Session, event_data: dict) -> dict:
         """Apply a verified Redsys notification to the matching receipt."""
         from app.domains.billing.models import Receipt
-        from app.domains.billing.service import validate_status_transition
+        from app.domains.billing.service import (
+            mark_receipt_paid,
+            validate_status_transition,
+        )
 
         ds_order = event_data.get("ds_order")
         ds_response = event_data.get("ds_response", "")
@@ -323,16 +325,19 @@ class RedsysAdapter(PaymentProviderAdapter):
                 "receipt_id": receipt.id,
             }
 
-        receipt.status = "paid"
-        # Preserve 'bizum' if create_payment set it; otherwise default to 'redsys'
-        if receipt.payment_method not in ("redsys", "bizum"):
-            receipt.payment_method = "redsys"
-        receipt.payment_date = date.today()
-        receipt.redsys_auth_code = ds_auth_code[:8]
-        receipt.transaction_id = ds_auth_code or None
-        db.flush()
+        pending = mark_receipt_paid(
+            db,
+            receipt,
+            payment_method="redsys",
+            transaction_id=ds_auth_code or None,
+            redsys_auth_code=ds_auth_code[:8],
+        )
 
-        return {"receipt_id": receipt.id, "outcome": "paid"}
+        return {
+            "receipt_id": receipt.id,
+            "outcome": "paid",
+            "payment_notifications": pending,
+        }
 
     def check_payment_status(self, payment_id: str) -> dict:
         raise NotImplementedError("Redsys REST query API not in scope for v0.4.3")

--- a/backend/app/domains/billing/providers/stripe_provider.py
+++ b/backend/app/domains/billing/providers/stripe_provider.py
@@ -159,7 +159,10 @@ class StripeAdapter(PaymentProviderAdapter):
     def _handle_checkout_completed(self, db: Session, session_obj: dict) -> dict:
         """Handle successful Checkout payment."""
         from app.domains.billing.models import Receipt
-        from app.domains.billing.service import validate_status_transition
+        from app.domains.billing.service import (
+            mark_receipt_paid,
+            validate_status_transition,
+        )
 
         receipt_id = session_obj.get("metadata", {}).get("receipt_id")
         if not receipt_id:
@@ -217,14 +220,15 @@ class StripeAdapter(PaymentProviderAdapter):
                 "receipt_id": receipt.id,
             }
 
-        receipt.status = "paid"
-        receipt.payment_method = "stripe_checkout"
-        receipt.payment_date = date.today()
-        receipt.stripe_payment_intent_id = session_obj.get("payment_intent")
-        receipt.transaction_id = session_obj.get("payment_intent")
-        db.flush()
+        pending = mark_receipt_paid(
+            db,
+            receipt,
+            payment_method="stripe_checkout",
+            transaction_id=session_obj.get("payment_intent"),
+            stripe_payment_intent_id=session_obj.get("payment_intent"),
+        )
 
-        return {"receipt_id": receipt.id}
+        return {"receipt_id": receipt.id, "payment_notifications": pending}
 
     def _handle_checkout_expired(self, db: Session, session_obj: dict) -> dict:
         """Handle expired Checkout session."""

--- a/backend/app/domains/billing/remittance_service.py
+++ b/backend/app/domains/billing/remittance_service.py
@@ -12,6 +12,7 @@ from app.core.config import settings
 from app.domains.billing.models import Receipt, Remittance, SepaMandate
 from app.domains.billing.schemas import RemittanceCreate
 from app.domains.billing.sepa_xml import SepaExportError, generate_sepa_xml
+from app.domains.billing.service import mark_receipts_paid
 from app.domains.organizations.models import OrganizationSettings
 
 
@@ -45,7 +46,12 @@ def generate_remittance_number(db: Session, emission_date: date) -> str:
 VALID_REMITTANCE_TRANSITIONS = {
     "draft": {"ready", "cancelled"},
     "ready": {"submitted", "cancelled"},
-    "submitted": {"processed"},
+    # 'submitted' closes directly. A bank that has nothing to return sends
+    # nothing, and import_returns — the only thing that sets 'processed' —
+    # exists to record failures. Without this the batch where everyone paid is
+    # the one that could never be closed, which is exactly the batch that most
+    # needs reconciling.
+    "submitted": {"processed", "closed"},
     "processed": {"closed"},
     "closed": set(),
     "cancelled": set(),
@@ -301,12 +307,50 @@ def import_returns(
     return {"processed": processed, "returned": returned, "not_found": not_found}
 
 
-def close_remittance(db: Session, remittance: Remittance) -> Remittance:
-    """Close a remittance — finalize the batch."""
+# Statuses a receipt is left in while its collection is still in flight. Anything
+# else in the batch has already been settled by hand or reported back by the bank.
+AWAITING_SETTLEMENT = ("emitted", "overdue")
+
+
+def close_remittance(db: Session, remittance: Remittance) -> tuple[Remittance, list[int]]:
+    """Close a remittance — the settlement window has passed, so reconcile it.
+
+    SEPA confirms nothing. The bank reports the collections that failed and says
+    nothing at all about the rest, so closing is a human asserting that the
+    window has passed: every receipt still awaiting settlement is taken as
+    collected and marked paid. Receipts ``import_returns`` already flipped to
+    'returned', and cancelled or deactivated ones, are left alone.
+
+    The payment date is the remittance's own due date — the SEPA collection
+    date, when the money actually moved — rather than the moment the admin got
+    round to finishing the batch, which would book a March collection in April.
+
+    The whole batch is marked in the caller's transaction, so a remittance can
+    never end up 'closed' with some of its receipts still awaiting settlement.
+    Returns the remittance and the receipts owed a payment notification, for the
+    caller to dispatch once it has committed.
+    """
     validate_remittance_transition(remittance.status, "closed")
+
+    receipts = (
+        db.query(Receipt)
+        .filter(
+            Receipt.remittance_id == remittance.id,
+            Receipt.is_active.is_(True),
+            Receipt.status.in_(AWAITING_SETTLEMENT),
+        )
+        .all()
+    )
+    pending = mark_receipts_paid(
+        db,
+        receipts,
+        payment_method="direct_debit",
+        payment_date=remittance.due_date,
+    )
+
     remittance.status = "closed"
     db.flush()
-    return remittance
+    return remittance, pending
 
 
 def cancel_remittance(db: Session, remittance: Remittance) -> Remittance:

--- a/backend/app/domains/billing/service.py
+++ b/backend/app/domains/billing/service.py
@@ -1,5 +1,7 @@
 """Billing service layer — receipt creation, numbering, status transitions, fee generation."""
 
+import logging
+from collections.abc import Sequence
 from datetime import date, datetime, timezone
 from decimal import ROUND_HALF_UP, Decimal
 
@@ -13,13 +15,14 @@ from app.domains.billing.models import Concept, InvoiceSequence, Receipt
 from app.domains.billing.schemas import (
     GenerateMembershipFeesRequest,
     ReceiptCreate,
-    ReceiptPayRequest,
     ReceiptReturnRequest,
     ReceiptUpdate,
 )
 from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
+
+logger = logging.getLogger(__name__)
 
 
 # --- Query builders ---
@@ -277,16 +280,108 @@ def emit_receipt(db: Session, receipt: Receipt) -> Receipt:
     return receipt
 
 
-def pay_receipt(
-    db: Session, receipt: Receipt, data: ReceiptPayRequest
-) -> Receipt:
-    """Mark a receipt as paid."""
+def mark_receipt_paid(
+    db: Session,
+    receipt: Receipt,
+    *,
+    payment_method: str,
+    payment_date: date | None = None,
+    transaction_id: str | None = None,
+    stripe_payment_intent_id: str | None = None,
+    redsys_auth_code: str | None = None,
+) -> list[int]:
+    """Record a payment against a receipt — the one place a receipt becomes paid.
+
+    Every payment path goes through here: an admin marking cash or a bank
+    transfer by hand, the Stripe webhook, the Redsys/Bizum webhook, and closing
+    a SEPA remittance. **Anything that must happen when a receipt is paid is
+    attached here**, so it fires for all of them and for whatever payment method
+    is added next.
+
+    Effects that must be atomic with the payment — activating something the
+    member has just bought — belong inline, in the caller's transaction. Emails
+    and other outbound notifications must not fire until that transaction has
+    committed, so they are not sent here: the ids of the receipts needing one
+    are returned, and the caller passes them to
+    ``dispatch_payment_notifications`` after ``db.commit()``.
+
+    Idempotent — an already-paid receipt is left untouched and nothing is
+    returned. Both webhook paths can and do deliver the same payment twice.
+    """
+    if receipt.status == "paid":
+        return []
+
     validate_status_transition(receipt.status, "paid")
+
     receipt.status = "paid"
-    receipt.payment_method = data.payment_method
-    receipt.payment_date = data.payment_date or date.today()
+    if not (payment_method == "redsys" and receipt.payment_method == "bizum"):
+        # A Redsys notification only says the money came through Redsys;
+        # create_payment already recorded 'bizum' when that is how it was paid.
+        receipt.payment_method = payment_method
+    receipt.payment_date = payment_date or date.today()
+    if transaction_id is not None:
+        receipt.transaction_id = transaction_id
+    if stripe_payment_intent_id is not None:
+        receipt.stripe_payment_intent_id = stripe_payment_intent_id
+    if redsys_auth_code is not None:
+        receipt.redsys_auth_code = redsys_auth_code
+
     db.flush()
-    return receipt
+    return [receipt.id]
+
+
+def mark_receipts_paid(
+    db: Session,
+    receipts: Sequence[Receipt],
+    *,
+    payment_method: str,
+    payment_date: date | None = None,
+) -> list[int]:
+    """Mark a batch of receipts paid, in the caller's single transaction.
+
+    For the cases where one human action settles many receipts at once —
+    closing a SEPA remittance. The database work stays atomic, so a batch can
+    never end up half-settled; the returned ids are dispatched as one fan-out
+    job rather than one queue round-trip per receipt.
+    """
+    pending: list[int] = []
+    for receipt in receipts:
+        pending.extend(
+            mark_receipt_paid(
+                db,
+                receipt,
+                payment_method=payment_method,
+                payment_date=payment_date,
+            )
+        )
+    return pending
+
+
+def dispatch_payment_notifications(receipt_ids: list[int]) -> None:
+    """Queue the notifications for receipts that have just been marked paid.
+
+    Call this **after** ``db.commit()``. A worker can read the database before
+    an uncommitted row is visible, and a transaction that rolls back must not
+    leave mail already sent — so dispatch happens once the payment is durable.
+
+    One fan-out job is enqueued whatever the batch size; it queues one task per
+    receipt, so each retries and fails on its own. Dispatch is best-effort — a
+    broker that is down must not fail a payment that is already recorded — but
+    it is logged, or an undelivered notification is indistinguishable from one
+    that was never wanted.
+    """
+    if not receipt_ids:
+        return
+
+    try:
+        from app.tasks.billing_tasks import payment_notifications_fanout
+
+        payment_notifications_fanout.delay(receipt_ids)
+    except Exception as exc:  # noqa: BLE001 — dispatch is best-effort
+        logger.error(
+            f"Failed to dispatch payment notifications: "
+            f"receipt_ids={receipt_ids}, error={exc}"
+        )
 
 
 def return_receipt(

--- a/backend/app/tasks/billing_tasks.py
+++ b/backend/app/tasks/billing_tasks.py
@@ -87,3 +87,32 @@ def scheduled_payment_reminders() -> dict:
         raise
     finally:
         db.close()
+
+
+@celery.task
+def payment_notifications_fanout(receipt_ids: list[int]) -> int:
+    """Queue one notification task per receipt that has just been paid.
+
+    Enqueued once by ``dispatch_payment_notifications``, whatever the batch
+    size: closing a SEPA remittance can settle hundreds of receipts, and the
+    request that does it must not make hundreds of queue round-trips. Fanning
+    out from a worker instead gives every receipt its own task, so one that
+    fails — a bad address, a template error — cannot strand the rest.
+    """
+    for receipt_id in receipt_ids:
+        send_payment_notification.delay(receipt_id)
+    return len(receipt_ids)
+
+
+@celery.task(bind=True, max_retries=3, default_retry_delay=60)
+def send_payment_notification(self, receipt_id: int) -> bool:
+    """Send the outbound notifications owed for one paid receipt.
+
+    The seam for anything that must be *sent* after a payment, as opposed to
+    written: those effects run inline in ``mark_receipt_paid``, inside the
+    transaction that records the payment. Nothing is sent today — the club has
+    no payment-confirmation mail configured — so this is the place to add one
+    rather than a fourth call site to wire up.
+    """
+    logger.debug(f"No payment notification configured for receipt {receipt_id}")
+    return False

--- a/backend/tests/integration/api/v1/test_redsys_flow.py
+++ b/backend/tests/integration/api/v1/test_redsys_flow.py
@@ -402,6 +402,28 @@ class TestRedsysWebhookFlow:
         assert receipt.status == "paid"
         assert receipt.payment_method == "bizum"
 
+    def test_paid_notification_queues_the_payment_notifications(self, client, db):
+        """Redsys reaches the same shared function, so the same fan-out fires."""
+        from unittest.mock import patch
+
+        _create_org(db)
+        person = _create_person(db, suffix="wh-notify")
+        _create_user(db, person=person, suffix="wh-notify")
+        member = _create_member(db, person)
+        receipt = _create_receipt(db, member, ds_order="000000001601")
+        _create_redsys_provider(db)
+
+        envelope = _sign_notification(
+            ds_order=receipt.redsys_ds_order, ds_response="0000"
+        )
+        with patch(
+            "app.tasks.billing_tasks.payment_notifications_fanout.delay"
+        ) as delay:
+            resp = _post_webhook(client, envelope)
+
+        assert resp.status_code == 200
+        delay.assert_called_once_with([receipt.id])
+
     def test_denied_notification_leaves_receipt_unchanged(self, client, db):
         _create_org(db)
         person = _create_person(db, suffix="wh-den")

--- a/backend/tests/integration/api/v1/test_remittances.py
+++ b/backend/tests/integration/api/v1/test_remittances.py
@@ -2,11 +2,12 @@
 
 from datetime import date, timedelta
 from decimal import Decimal
+from unittest.mock import patch
 
 from app.core.security.jwt import create_access_token
 from app.core.security.password import hash_password
 from app.domains.auth.models import User
-from app.domains.billing.models import Concept, Receipt, SepaMandate
+from app.domains.billing.models import Concept, Receipt, Remittance, SepaMandate
 from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
@@ -475,3 +476,158 @@ class TestRemittanceAuth:
         member_user = _create_user(db, role="member", suffix="rem-auth2")
         resp = client.get("/api/v1/remittances/", cookies=_auth_cookie(member_user))
         assert resp.status_code == 403
+
+
+class TestCloseReconcilesPayments:
+    """SEPA reports only failures, so closing settles everything still in flight."""
+
+    FANOUT = "app.tasks.billing_tasks.payment_notifications_fanout.delay"
+
+    def _submitted_remittance(self, client, admin, receipt_ids, due_date="2026-05-01"):
+        create_resp = client.post(
+            "/api/v1/remittances/",
+            json={"receipt_ids": receipt_ids, "due_date": due_date},
+            cookies=_auth_cookie(admin),
+        )
+        rem_id = create_resp.json()["id"]
+        client.post(f"/api/v1/remittances/{rem_id}/generate-xml", cookies=_auth_cookie(admin))
+        client.post(f"/api/v1/remittances/{rem_id}/mark-submitted", cookies=_auth_cookie(admin))
+        return rem_id
+
+    def test_a_clean_batch_closes_straight_from_submitted(self, client, db):
+        """Nothing to import means nothing ever set 'processed'."""
+        _ensure_org_settings(db)
+        admin = _create_user(db, suffix="rem-cl1")
+        m1, _ = _create_member_with_mandate(db, suffix="rem-cl1")
+        r1 = _create_receipt(db, m1.id, admin.id, suffix="rem-cl1-01")
+        r2 = _create_receipt(db, m1.id, admin.id, suffix="rem-cl1-02")
+        rem_id = self._submitted_remittance(client, admin, [r1.id, r2.id])
+
+        resp = client.post(f"/api/v1/remittances/{rem_id}/close", cookies=_auth_cookie(admin))
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "closed"
+
+        db.expire_all()
+        for receipt_id in (r1.id, r2.id):
+            receipt = db.query(Receipt).filter(Receipt.id == receipt_id).first()
+            assert receipt.status == "paid"
+            assert receipt.payment_method == "direct_debit"
+            assert receipt.payment_date == date(2026, 5, 1)
+
+    def test_returned_receipts_are_left_alone(self, client, db):
+        _ensure_org_settings(db)
+        admin = _create_user(db, suffix="rem-cl2")
+        m1, _ = _create_member_with_mandate(db, suffix="rem-cl2")
+        settled = _create_receipt(db, m1.id, admin.id, suffix="rem-cl2-01")
+        bounced = _create_receipt(db, m1.id, admin.id, suffix="rem-cl2-02")
+        bounced_number = bounced.receipt_number
+        rem_id = self._submitted_remittance(client, admin, [settled.id, bounced.id])
+
+        client.post(
+            f"/api/v1/remittances/{rem_id}/import-returns",
+            json=[{"receipt_number": bounced_number, "reason": "Insufficient funds"}],
+            cookies=_auth_cookie(admin),
+        )
+        client.post(f"/api/v1/remittances/{rem_id}/close", cookies=_auth_cookie(admin))
+
+        db.expire_all()
+        assert db.query(Receipt).filter(Receipt.id == settled.id).first().status == "paid"
+        returned = db.query(Receipt).filter(Receipt.id == bounced.id).first()
+        assert returned.status == "returned"
+        assert returned.payment_date is None
+
+    def test_cancelled_and_inactive_receipts_are_left_alone(self, client, db):
+        _ensure_org_settings(db)
+        admin = _create_user(db, suffix="rem-cl3")
+        m1, _ = _create_member_with_mandate(db, suffix="rem-cl3")
+        settled = _create_receipt(db, m1.id, admin.id, suffix="rem-cl3-01")
+        gone = _create_receipt(db, m1.id, admin.id, suffix="rem-cl3-02")
+        rem_id = self._submitted_remittance(client, admin, [settled.id, gone.id])
+
+        gone.status = "cancelled"
+        gone.is_active = False
+        db.flush()
+
+        client.post(f"/api/v1/remittances/{rem_id}/close", cookies=_auth_cookie(admin))
+
+        db.expire_all()
+        assert db.query(Receipt).filter(Receipt.id == settled.id).first().status == "paid"
+        assert db.query(Receipt).filter(Receipt.id == gone.id).first().status == "cancelled"
+
+    def test_an_overdue_receipt_settles_too(self, client, db):
+        """A batched receipt past its due date is still collected by the bank."""
+        _ensure_org_settings(db)
+        admin = _create_user(db, suffix="rem-cl4")
+        m1, _ = _create_member_with_mandate(db, suffix="rem-cl4")
+        late = _create_receipt(db, m1.id, admin.id, suffix="rem-cl4-01", status="overdue")
+        rem_id = self._submitted_remittance(client, admin, [late.id])
+
+        client.post(f"/api/v1/remittances/{rem_id}/close", cookies=_auth_cookie(admin))
+
+        db.expire_all()
+        assert db.query(Receipt).filter(Receipt.id == late.id).first().status == "paid"
+
+    def test_a_second_close_changes_nothing(self, client, db):
+        _ensure_org_settings(db)
+        admin = _create_user(db, suffix="rem-cl5")
+        m1, _ = _create_member_with_mandate(db, suffix="rem-cl5")
+        r1 = _create_receipt(db, m1.id, admin.id, suffix="rem-cl5-01")
+        rem_id = self._submitted_remittance(client, admin, [r1.id])
+
+        client.post(f"/api/v1/remittances/{rem_id}/close", cookies=_auth_cookie(admin))
+        db.expire_all()
+        first_payment_date = (
+            db.query(Receipt).filter(Receipt.id == r1.id).first().payment_date
+        )
+
+        with patch(self.FANOUT) as delay:
+            resp = client.post(
+                f"/api/v1/remittances/{rem_id}/close", cookies=_auth_cookie(admin)
+            )
+
+        assert resp.status_code == 400
+        delay.assert_not_called()
+        db.expire_all()
+        receipt = db.query(Receipt).filter(Receipt.id == r1.id).first()
+        assert receipt.status == "paid"
+        assert receipt.payment_date == first_payment_date
+        remittance = db.query(Remittance).filter(Remittance.id == rem_id).first()
+        assert remittance.status == "closed"
+
+    def test_closing_queues_one_fanout_job_for_the_batch(self, client, db):
+        _ensure_org_settings(db)
+        admin = _create_user(db, suffix="rem-cl6")
+        m1, _ = _create_member_with_mandate(db, suffix="rem-cl6")
+        r1 = _create_receipt(db, m1.id, admin.id, suffix="rem-cl6-01")
+        r2 = _create_receipt(db, m1.id, admin.id, suffix="rem-cl6-02")
+        rem_id = self._submitted_remittance(client, admin, [r1.id, r2.id])
+
+        with patch(self.FANOUT) as delay:
+            resp = client.post(
+                f"/api/v1/remittances/{rem_id}/close", cookies=_auth_cookie(admin)
+            )
+
+        assert resp.status_code == 200
+        delay.assert_called_once_with([r1.id, r2.id])
+
+    def test_a_batch_with_nothing_left_to_settle_notifies_nothing(self, client, db):
+        _ensure_org_settings(db)
+        admin = _create_user(db, suffix="rem-cl7")
+        m1, _ = _create_member_with_mandate(db, suffix="rem-cl7")
+        r1 = _create_receipt(db, m1.id, admin.id, suffix="rem-cl7-01")
+        receipt_number = r1.receipt_number
+        rem_id = self._submitted_remittance(client, admin, [r1.id])
+
+        client.post(
+            f"/api/v1/remittances/{rem_id}/import-returns",
+            json=[{"receipt_number": receipt_number, "reason": "No account"}],
+            cookies=_auth_cookie(admin),
+        )
+
+        with patch(self.FANOUT) as delay:
+            resp = client.post(
+                f"/api/v1/remittances/{rem_id}/close", cookies=_auth_cookie(admin)
+            )
+
+        assert resp.status_code == 200
+        delay.assert_not_called()

--- a/backend/tests/integration/test_receipt_payment.py
+++ b/backend/tests/integration/test_receipt_payment.py
@@ -1,0 +1,410 @@
+"""Every payment path lands in ``mark_receipt_paid``, and notifies after commit."""
+
+import json
+from datetime import date
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.security.jwt import create_access_token
+from app.core.security.password import hash_password
+from app.domains.auth.models import User
+from app.domains.billing.models import PaymentProvider, Receipt
+from app.domains.billing.service import (
+    dispatch_payment_notifications,
+    mark_receipt_paid,
+    mark_receipts_paid,
+)
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+FANOUT = "app.tasks.billing_tasks.payment_notifications_fanout.delay"
+
+
+# --- Fixtures ---
+
+
+def _create_org(db):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if org:
+        return org
+    org = OrganizationSettings(
+        id=1,
+        name="Test Club",
+        currency="EUR",
+        invoice_prefix="FAC",
+        invoice_annual_reset=True,
+        default_vat_rate=Decimal("21.00"),
+    )
+    db.add(org)
+    db.flush()
+    return org
+
+
+def _create_member(db, suffix):
+    person = Person(
+        first_name="Pay",
+        last_name=f"Test-{suffix}",
+        email=f"{suffix}@pay-test.example",
+    )
+    db.add(person)
+    db.flush()
+    mtype = MembershipType(
+        name=f"Standard-{suffix}",
+        slug=f"standard-{suffix}",
+        base_price=Decimal("100.00"),
+        billing_frequency="monthly",
+    )
+    db.add(mtype)
+    db.flush()
+    member = Member(
+        person_id=person.id,
+        membership_type_id=mtype.id,
+        member_number=f"MP-{suffix}",
+        status="active",
+        joined_at=date(2026, 1, 1),
+        is_active=True,
+    )
+    db.add(member)
+    db.flush()
+    return member
+
+
+def _create_receipt(db, member, suffix, status="emitted"):
+    _create_org(db)
+    receipt = Receipt(
+        receipt_number=f"FAC-2026-PAY-{suffix}",
+        member_id=member.id,
+        origin="membership",
+        description="Membership fee",
+        base_amount=Decimal("100.00"),
+        vat_rate=Decimal("21.00"),
+        vat_amount=Decimal("21.00"),
+        total_amount=Decimal("121.00"),
+        status=status,
+        emission_date=date(2026, 4, 1),
+        is_active=True,
+    )
+    db.add(receipt)
+    db.flush()
+    return receipt
+
+
+def _create_admin(db, suffix):
+    person = Person(
+        first_name="Admin",
+        last_name=f"Pay-{suffix}",
+        email=f"admin-{suffix}@pay-test.example",
+    )
+    db.add(person)
+    db.flush()
+    user = User(
+        person_id=person.id,
+        email=person.email,
+        password_hash=hash_password("password123"),
+        role="admin",
+        is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _auth_cookie(user):
+    return {"access_token": create_access_token(user.id)}
+
+
+# --- The shared function ---
+
+
+class TestMarkReceiptPaid:
+    def test_manual_payment_records_method_and_date(self, db):
+        member = _create_member(db, "manual")
+        receipt = _create_receipt(db, member, "manual")
+
+        pending = mark_receipt_paid(
+            db,
+            receipt,
+            payment_method="cash",
+            payment_date=date(2026, 4, 15),
+        )
+
+        assert pending == [receipt.id]
+        assert receipt.status == "paid"
+        assert receipt.payment_method == "cash"
+        assert receipt.payment_date == date(2026, 4, 15)
+
+    def test_payment_date_defaults_to_today(self, db):
+        member = _create_member(db, "today")
+        receipt = _create_receipt(db, member, "today")
+
+        mark_receipt_paid(db, receipt, payment_method="bank_transfer")
+
+        assert receipt.payment_date == date.today()
+
+    def test_stripe_fields_are_recorded(self, db):
+        member = _create_member(db, "stripe")
+        receipt = _create_receipt(db, member, "stripe")
+
+        mark_receipt_paid(
+            db,
+            receipt,
+            payment_method="stripe_checkout",
+            transaction_id="pi_abc",
+            stripe_payment_intent_id="pi_abc",
+        )
+
+        assert receipt.payment_method == "stripe_checkout"
+        assert receipt.stripe_payment_intent_id == "pi_abc"
+        assert receipt.transaction_id == "pi_abc"
+
+    def test_redsys_fields_are_recorded(self, db):
+        member = _create_member(db, "redsys")
+        receipt = _create_receipt(db, member, "redsys")
+
+        mark_receipt_paid(
+            db,
+            receipt,
+            payment_method="redsys",
+            transaction_id="AUTH999",
+            redsys_auth_code="AUTH999",
+        )
+
+        assert receipt.payment_method == "redsys"
+        assert receipt.redsys_auth_code == "AUTH999"
+        assert receipt.transaction_id == "AUTH999"
+
+    def test_bizum_survives_a_redsys_notification(self, db):
+        """Redsys only knows the money came through it; initiate knew it was Bizum."""
+        member = _create_member(db, "bizum")
+        receipt = _create_receipt(db, member, "bizum")
+        receipt.payment_method = "bizum"
+        db.flush()
+
+        mark_receipt_paid(db, receipt, payment_method="redsys")
+
+        assert receipt.payment_method == "bizum"
+
+    def test_paying_twice_is_a_no_op(self, db):
+        """Both webhook paths can deliver the same payment twice."""
+        member = _create_member(db, "twice")
+        receipt = _create_receipt(db, member, "twice")
+
+        first = mark_receipt_paid(
+            db, receipt, payment_method="cash", payment_date=date(2026, 4, 15)
+        )
+        second = mark_receipt_paid(
+            db,
+            receipt,
+            payment_method="stripe_checkout",
+            payment_date=date(2026, 5, 1),
+            stripe_payment_intent_id="pi_late",
+        )
+
+        assert first == [receipt.id]
+        assert second == []
+        assert receipt.payment_method == "cash"
+        assert receipt.payment_date == date(2026, 4, 15)
+        assert receipt.stripe_payment_intent_id is None
+
+    def test_a_cancelled_receipt_cannot_be_paid(self, db):
+        member = _create_member(db, "cancelled")
+        receipt = _create_receipt(db, member, "cancelled", status="cancelled")
+
+        with pytest.raises(HTTPException) as exc:
+            mark_receipt_paid(db, receipt, payment_method="cash")
+
+        assert exc.value.status_code == 400
+
+
+class TestMarkReceiptsPaid:
+    def test_the_whole_batch_is_marked_and_returned(self, db):
+        member = _create_member(db, "bulk")
+        receipts = [_create_receipt(db, member, f"bulk-{i}") for i in range(3)]
+
+        pending = mark_receipts_paid(
+            db,
+            receipts,
+            payment_method="direct_debit",
+            payment_date=date(2026, 5, 5),
+        )
+
+        assert pending == [r.id for r in receipts]
+        assert all(r.status == "paid" for r in receipts)
+        assert all(r.payment_method == "direct_debit" for r in receipts)
+        assert all(r.payment_date == date(2026, 5, 5) for r in receipts)
+
+    def test_an_already_paid_receipt_is_skipped(self, db):
+        member = _create_member(db, "bulk-dup")
+        already = _create_receipt(db, member, "bulk-dup-0")
+        fresh = _create_receipt(db, member, "bulk-dup-1")
+        mark_receipt_paid(db, already, payment_method="cash")
+
+        pending = mark_receipts_paid(
+            db, [already, fresh], payment_method="direct_debit"
+        )
+
+        assert pending == [fresh.id]
+        assert already.payment_method == "cash"
+
+
+# --- Dispatch ---
+
+
+class TestDispatchPaymentNotifications:
+    def test_one_fanout_job_covers_the_whole_batch(self):
+        with patch(FANOUT) as delay:
+            dispatch_payment_notifications([1, 2, 3])
+
+        delay.assert_called_once_with([1, 2, 3])
+
+    def test_nothing_to_notify_enqueues_nothing(self):
+        with patch(FANOUT) as delay:
+            dispatch_payment_notifications([])
+
+        delay.assert_not_called()
+
+    def test_a_broker_failure_does_not_propagate(self):
+        """The payment is already recorded — dispatch must not undo it."""
+        with patch(FANOUT, side_effect=RuntimeError("broker down")):
+            dispatch_payment_notifications([1])
+
+    def test_the_fanout_queues_one_task_per_receipt(self):
+        from app.tasks.billing_tasks import payment_notifications_fanout
+
+        with patch("app.tasks.billing_tasks.send_payment_notification.delay") as delay:
+            queued = payment_notifications_fanout([7, 8])
+
+        assert queued == 2
+        assert [call.args[0] for call in delay.call_args_list] == [7, 8]
+
+
+# --- The three write sites ---
+
+
+class TestManualPaymentEndpoint:
+    def test_paying_by_hand_notifies_after_the_commit(self, client, db):
+        member = _create_member(db, "ep-pay")
+        receipt = _create_receipt(db, member, "ep-pay")
+        admin = _create_admin(db, "ep-pay")
+
+        with patch(FANOUT) as delay:
+            resp = client.post(
+                f"/api/v1/receipts/{receipt.id}/pay",
+                json={"payment_method": "cash", "payment_date": "2026-04-15"},
+                cookies=_auth_cookie(admin),
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "paid"
+        delay.assert_called_once_with([receipt.id])
+
+    def test_a_rejected_payment_notifies_nothing(self, client, db):
+        """The transaction never commits, so no notification may go out."""
+        member = _create_member(db, "ep-bad")
+        receipt = _create_receipt(db, member, "ep-bad", status="new")
+        admin = _create_admin(db, "ep-bad")
+
+        with patch(FANOUT) as delay:
+            resp = client.post(
+                f"/api/v1/receipts/{receipt.id}/pay",
+                json={"payment_method": "cash"},
+                cookies=_auth_cookie(admin),
+            )
+
+        assert resp.status_code == 400
+        delay.assert_not_called()
+        db.refresh(receipt)
+        assert receipt.status == "new"
+
+
+class TestStripeWebhookNotifies:
+    def _provider(self, db):
+        from app.core.encryption import encrypt_config
+
+        provider = PaymentProvider(
+            provider_type="stripe",
+            display_name="Stripe",
+            status="active",
+            config=encrypt_config(
+                {
+                    "secret_key": "sk_test_abc",
+                    "publishable_key": "pk_test_abc",
+                    "webhook_secret": "whsec_abc",
+                },
+                ["secret_key", "webhook_secret"],
+            ),
+            is_default=False,
+        )
+        db.add(provider)
+        db.flush()
+        return provider
+
+    def _post(self, client, payload):
+        from app.domains.billing.providers.stripe_provider import StripeAdapter
+
+        with patch.object(StripeAdapter, "verify_signature", return_value=payload):
+            return client.post(
+                "/api/v1/webhooks/stripe",
+                content=json.dumps(payload).encode(),
+                headers={
+                    "content-type": "application/json",
+                    "stripe-signature": "t=1,v1=fake",
+                },
+            )
+
+    def test_a_redelivered_webhook_notifies_once(self, client, db):
+        member = _create_member(db, "wh-dup")
+        receipt = _create_receipt(db, member, "wh-dup")
+        self._provider(db)
+
+        payload = {
+            "id": "evt_notify_dup_001",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "id": "cs_notify_dup",
+                    "metadata": {"receipt_id": str(receipt.id)},
+                    "payment_intent": "pi_notify_dup",
+                }
+            },
+        }
+
+        with patch(FANOUT) as delay:
+            first = self._post(client, payload)
+            second = self._post(client, payload)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        delay.assert_called_once_with([receipt.id])
+
+        db.expire_all()
+        receipt = db.query(Receipt).filter(Receipt.id == receipt.id).first()
+        assert receipt.status == "paid"
+        assert receipt.payment_method == "stripe_checkout"
+
+    def test_an_ignored_event_notifies_nothing(self, client, db):
+        member = _create_member(db, "wh-ign")
+        receipt = _create_receipt(db, member, "wh-ign", status="cancelled")
+        self._provider(db)
+
+        payload = {
+            "id": "evt_notify_ign_001",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "id": "cs_notify_ign",
+                    "metadata": {"receipt_id": str(receipt.id)},
+                    "payment_intent": "pi_notify_ign",
+                }
+            },
+        }
+
+        with patch(FANOUT) as delay:
+            resp = self._post(client, payload)
+
+        assert resp.status_code == 200
+        delay.assert_not_called()

--- a/backend/tests/unit/test_remittance_service.py
+++ b/backend/tests/unit/test_remittance_service.py
@@ -24,6 +24,10 @@ class TestRemittanceTransitions:
     def test_processed_to_closed(self):
         validate_remittance_transition("processed", "closed")
 
+    def test_submitted_to_closed(self):
+        """The batch nobody returned never reaches 'processed', and must still close."""
+        validate_remittance_transition("submitted", "closed")
+
     def test_closed_is_terminal(self):
         from fastapi import HTTPException
         with pytest.raises(HTTPException):

--- a/docs/admin-guide/sepa.es.md
+++ b/docs/admin-guide/sepa.es.md
@@ -32,8 +32,15 @@ Una **remesa** agrupa recibos domiciliados en un lote para enviarlo al banco.
 3. **Marcar enviada** cuando lo hayas presentado al banco.
 4. **Importar devoluciones** — sube el fichero de devoluciones para actualizar el estado de los
    recibos afectados (se marcan como **Devuelto**). El resultado indica los recibos
-   *procesados*, *devueltos* y *no encontrados*.
-5. **Cerrar** la remesa para finalizar el lote.
+   *procesados*, *devueltos* y *no encontrados*. Si el banco no ha devuelto nada, sáltate
+   este paso.
+5. **Cerrar** la remesa cuando haya pasado el plazo de devoluciones. SEPA solo informa de los
+   cobros que fallan, así que al cerrar se marcan como **Cobrados** todos los recibos del lote
+   que sigan pendientes, con la fecha de cobro de la remesa. Antes de confirmar verás cuántos
+   recibos se van a marcar: **una vez cerrada la remesa ya no se pueden importar devoluciones**,
+   así que no la cierres antes de que venza el plazo de tu banco.
 
 Estados de una remesa: **Borrador → Lista → Enviada → Procesada → Cerrada** (o **Cancelada**;
-al cancelar se desvinculan todos los recibos).
+al cancelar se desvinculan todos los recibos). Una remesa **Enviada** se puede cerrar
+directamente, sin pasar por **Procesada**: el lote en el que ha pagado todo el mundo no tiene
+devoluciones que importar.

--- a/frontend/app/[locale]/(portal)/remittances/[id]/page.tsx
+++ b/frontend/app/[locale]/(portal)/remittances/[id]/page.tsx
@@ -75,7 +75,10 @@ export default function RemittanceDetailPage() {
   const canDownloadXml = remittance.sepa_file_path !== null;
   const canSubmit = canWrite && remittance.status === "ready";
   const canImportReturns = canWrite && ["submitted", "processed"].includes(remittance.status);
-  const canClose = canWrite && remittance.status === "processed";
+  const canClose = canWrite && ["submitted", "processed"].includes(remittance.status);
+  const awaitingSettlement = (remittance.receipts ?? []).filter((r) =>
+    ["emitted", "overdue"].includes(r.status)
+  ).length;
   const canCancel = canWrite && ["draft", "ready"].includes(remittance.status);
   const isTerminal = ["closed", "cancelled"].includes(remittance.status);
 
@@ -103,6 +106,7 @@ export default function RemittanceDetailPage() {
   function handleClose() {
     confirmAction({
       title: t("remittances.confirmClose"),
+      description: t("remittances.confirmCloseDescription", { count: awaitingSettlement }),
       cancelLabel: t("common.cancel"),
       confirmLabel: t("remittances.closeRemittance"),
       onConfirm: async () => {

--- a/frontend/locales/ca/remittances.json
+++ b/frontend/locales/ca/remittances.json
@@ -24,6 +24,7 @@
     "cancelRemittance": "Cancel\u00b7lar",
     "confirmSubmit": "Marcar aquesta remesa com a enviada al banc?",
     "confirmClose": "Tancar aquesta remesa? Es finalitzara el lot.",
+    "confirmCloseDescription": "Es marcaran com a cobrats {count} rebuts. Un cop tancada la remesa ja no es podran importar devolucions.",
     "confirmCancel": "Cancel\u00b7lar aquesta remesa? Es desvincularan tots els rebuts.",
     "noRemittances": "No s'han trobat remeses",
     "detail": "Detall de la remesa",

--- a/frontend/locales/en/remittances.json
+++ b/frontend/locales/en/remittances.json
@@ -24,6 +24,7 @@
     "cancelRemittance": "Cancel",
     "confirmSubmit": "Mark this remittance as submitted to the bank?",
     "confirmClose": "Close this remittance? This finalizes the batch.",
+    "confirmCloseDescription": "{count} receipts will be marked as paid. Once the remittance is closed, returns can no longer be imported.",
     "confirmCancel": "Cancel this remittance? All receipts will be unlinked.",
     "noRemittances": "No remittances found",
     "detail": "Remittance Detail",

--- a/frontend/locales/es/remittances.json
+++ b/frontend/locales/es/remittances.json
@@ -24,6 +24,7 @@
     "cancelRemittance": "Cancelar",
     "confirmSubmit": "Marcar esta remesa como enviada al banco?",
     "confirmClose": "Cerrar esta remesa? Se finalizara el lote.",
+    "confirmCloseDescription": "Se marcarán como cobrados {count} recibos. Una vez cerrada la remesa ya no se podrán importar devoluciones.",
     "confirmCancel": "Cancelar esta remesa? Se desvincularan todos los recibos.",
     "noRemittances": "No se encontraron remesas",
     "detail": "Detalle de la remesa",


### PR DESCRIPTION
Two commits, in order. The first is a refactor the second needs; neither is useful alone.

Closes #144. Closes #142.

## `4e44399` — Give a paid receipt one place to become paid

`Receipt.status` was set to `"paid"` in three unrelated places: the manual pay endpoint, the Stripe webhook and the Redsys/Bizum webhook. Each set the payment method and its provider fields its own way, and each had its own idea of what a second delivery of the same payment meant. Nothing could hook onto "this receipt just became paid" without being wired into all three.

`mark_receipt_paid` is now that place. It carries the provider fields, keeps `bizum` where `initiate` recorded it, and is a no-op on an already-paid receipt so a redelivered webhook cannot fire the same side effects twice.

Effects that must be atomic with the payment run inline in the caller's transaction. Notifications must not — a worker can read the database before the row is visible, and a rolled-back transaction must not leave mail already sent (this is #96's failure mode). So the function returns the receipts needing one and the caller dispatches after committing: one fan-out job whatever the batch size, which queues one task per receipt so a bad address cannot strand the rest.

`send_payment_notification` is a **deliberate stub** — no payment-confirmation email exists in this codebase. The mechanism is real and tested; the message is #150.

## `05c7b5d` — Reconcile a SEPA remittance when it is closed

A receipt paid by direct debit never reached `paid`. `mark_submitted` set the remittance submitted, `import_returns` flipped the rejected receipts to `returned`, and `close_remittance` touched no receipt at all — so every collection that actually settled sat at `emitted` forever. Revenue reporting undercounted every direct debit, and the dunning pipeline chased members who had paid on time.

"No news is good news" is how SEPA works: the bank reports the collections that failed and says nothing about the rest. Recording only failures is right; never reconciling is not.

Closing was also **unreachable on the happy path**: `processed` is set only by `import_returns`, which exists to record failures, so the batch where everyone paid was the one that could never be closed. `submitted → closed` is now a legal transition.

Payment date is the remittance's own `due_date` — the SEPA collection date, already mapped to `collection_date` in the generated XML — so an admin finishing a batch three weeks late still books the money in the right month.

### One deliberate widening

The issue said still-`emitted` receipts; this settles `("emitted", "overdue")`. `create_remittance` accepts both, `import_returns` returns on both, and an overdue receipt in a batch the bank collected would otherwise stay stuck forever — the exact bug being fixed. Covered by `test_an_overdue_receipt_settles_too`.

### Closing early

Nothing transitions out of `closed`, and closing now asserts payments that could still bounce. Rather than grow the state machine with a reopen, the close dialog states how many receipts it will mark paid and warns that returns can no longer be imported.

## Testing

Full backend suite green: **1429 passed**, 0 failed. New coverage: `test_receipt_payment.py` (17 tests), `TestCloseReconcilesPayments` (7), a Redsys fan-out test, and a unit test for the new transition.

No migrations — no schema change in either commit. The remittance status CHECK already permitted all six values; only the in-Python transition table changed.
