### PR TITLE
Send new sign-ups to a free default tier, not the oldest row

### DIFF
--- a/backend/alembic/versions/a5b6c7d8e9f0_add_default_membership_type.py
+++ b/backend/alembic/versions/a5b6c7d8e9f0_add_default_membership_type.py
@@ -1,0 +1,113 @@
+"""add_default_membership_type
+
+Marks the membership type new sign-ups land on, and guarantees every install
+has one. Before this, both registration paths took the oldest active row, which
+on a seeded install is the 50 EUR/month plan — so self-registering silently
+started a recurring fee.
+
+An existing free tier is promoted rather than replaced. When a club has none,
+one is created: leaving no default would put NULL on new members' membership
+type, and activities that restrict allowed membership types reject a NULL
+member outright — a worse regression than the bug being fixed.
+
+No member row is touched. Members already sitting on a paid tier they never
+chose are a separate clean-up, deliberately left to a human.
+
+Revision ID: a5b6c7d8e9f0
+Revises: a4b5c6d7e8f9
+Create Date: 2026-09-07 09:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'a5b6c7d8e9f0'
+down_revision: Union[str, None] = 'a4b5c6d7e8f9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FALLBACK_NAME = "Registered"
+FALLBACK_SLUG = "registered"
+FALLBACK_DESCRIPTION = (
+    "Free tier every new sign-up lands on until an administrator "
+    "moves them to a paid plan"
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        'membership_types',
+        sa.Column(
+            'is_default',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text('false'),
+        ),
+    )
+    op.create_index(
+        'uq_membership_types_is_default',
+        'membership_types',
+        ['is_default'],
+        unique=True,
+        postgresql_where=sa.text('is_default'),
+    )
+    op.create_check_constraint(
+        'default_membership_type_is_free',
+        'membership_types',
+        'NOT is_default OR coalesce(base_price, 0) = 0',
+    )
+
+    conn = op.get_bind()
+    # Active first, then the club's own ordering, then id — so two free tiers
+    # resolve the same way on every replica of the same database.
+    promoted = conn.execute(
+        sa.text(
+            """
+            UPDATE membership_types SET is_default = true WHERE id = (
+                SELECT id FROM membership_types
+                WHERE coalesce(base_price, 0) = 0
+                ORDER BY is_active DESC NULLS LAST,
+                         display_order NULLS LAST,
+                         id
+                LIMIT 1
+            )
+            """
+        )
+    ).rowcount
+    if promoted:
+        return
+
+    name, slug = FALLBACK_NAME, FALLBACK_SLUG
+    suffix = 1
+    while conn.execute(
+        sa.text(
+            "SELECT 1 FROM membership_types WHERE name = :name OR slug = :slug"
+        ),
+        {"name": name, "slug": slug},
+    ).first():
+        suffix += 1
+        name, slug = f"{FALLBACK_NAME} {suffix}", f"{FALLBACK_SLUG}-{suffix}"
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO membership_types
+                (name, slug, description, base_price, billing_frequency,
+                 display_order, is_active, is_default)
+            VALUES
+                (:name, :slug, :description, 0, 'annual', 0, true, true)
+            """
+        ),
+        {"name": name, "slug": slug, "description": FALLBACK_DESCRIPTION},
+    )
+
+
+def downgrade() -> None:
+    # A tier created on the way up stays: members may already point at it.
+    op.drop_constraint(
+        'default_membership_type_is_free', 'membership_types', type_='check'
+    )
+    op.drop_index('uq_membership_types_is_default', table_name='membership_types')
+    op.drop_column('membership_types', 'is_default')

--- a/backend/app/api/v1/endpoints/membership_types.py
+++ b/backend/app/api/v1/endpoints/membership_types.py
@@ -93,6 +93,11 @@ def update_membership_type(
 ):
     mt = get_or_404(db, MembershipType, type_id)
     update_data = data.model_dump(exclude_unset=True)
+    if mt.is_default and update_data.get("base_price"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The tier new sign-ups land on must stay free",
+        )
     for key, value in update_data.items():
         setattr(mt, key, value)
     db.commit()

--- a/backend/app/cli/seed.py
+++ b/backend/app/cli/seed.py
@@ -293,7 +293,7 @@ def seed_groups(db) -> dict[str, Group]:
 def seed_membership_types(db, groups: dict[str, Group]) -> MembershipType:
     existing = db.query(MembershipType).count()
     if existing > 0:
-        default = db.query(MembershipType).filter_by(slug="full-member").first()
+        default = db.query(MembershipType).filter_by(is_default=True).first()
         if not default:
             default = db.query(MembershipType).first()
         print(f"  Membership types: already seeded ({existing} records)")
@@ -305,6 +305,12 @@ def seed_membership_types(db, groups: dict[str, Group]) -> MembershipType:
     honorary_group = groups.get("honorary-members")
 
     types = [
+        MembershipType(
+            name="Registered", slug="registered",
+            description="Free tier every new sign-up lands on until an administrator moves them to a paid plan",
+            base_price=0, billing_frequency="annual",
+            display_order=0, is_active=True, is_default=True,
+        ),
         MembershipType(
             name="Full Member", slug="full-member",
             description="Full membership with access to all facilities and voting rights",
@@ -354,7 +360,7 @@ def seed_membership_types(db, groups: dict[str, Group]) -> MembershipType:
     default = None
     for mt in types:
         db.add(mt)
-        if mt.slug == "full-member":
+        if mt.is_default:
             default = mt
     db.flush()
     print(f"  Membership types: created {len(types)} types")

--- a/backend/app/domains/auth/oauth_service.py
+++ b/backend/app/domains/auth/oauth_service.py
@@ -8,8 +8,11 @@ from sqlalchemy.orm import Session
 from app.domains.auth.models import User, UserIdentity
 from app.domains.auth.roles import assign_roles
 from app.domains.auth.service import get_registration_settings
-from app.domains.members.models import Member, MembershipType
-from app.domains.members.service import allocate_member_number
+from app.domains.members.models import Member
+from app.domains.members.service import (
+    allocate_member_number,
+    get_default_membership_type,
+)
 from app.domains.persons.models import Person
 
 
@@ -106,12 +109,7 @@ def find_or_create_from_oauth(db: Session, profile: OAuthProfile) -> tuple[User,
 
     assign_roles(db, user)
 
-    default_type = (
-        db.query(MembershipType)
-        .filter(MembershipType.is_active == True)
-        .order_by(MembershipType.id)
-        .first()
-    )
+    default_type = get_default_membership_type(db)
     member = Member(
         person_id=person.id,
         user_id=user.id,

--- a/backend/app/domains/auth/service.py
+++ b/backend/app/domains/auth/service.py
@@ -9,8 +9,11 @@ from app.core.permissions import SUPER_ADMIN_SLUG
 from app.core.security.password import hash_password, verify_password
 from app.domains.auth.models import User
 from app.domains.auth.roles import assign_roles
-from app.domains.members.models import Member, MembershipType
-from app.domains.members.service import allocate_member_number
+from app.domains.members.models import Member
+from app.domains.members.service import (
+    allocate_member_number,
+    get_default_membership_type,
+)
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
 
@@ -96,13 +99,7 @@ def register_user(
 
     assign_roles(db, user)
 
-    # Create member with default membership type
-    default_type = (
-        db.query(MembershipType)
-        .filter(MembershipType.is_active == True)
-        .order_by(MembershipType.id)
-        .first()
-    )
+    default_type = get_default_membership_type(db)
 
     member = Member(
         person_id=person.id,

--- a/backend/app/domains/members/models.py
+++ b/backend/app/domains/members/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     String,
     Text,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import relationship
@@ -54,9 +55,19 @@ class MembershipType(Base):
             name="valid_billing_frequency",
         ),
         CheckConstraint("slug ~ '^[a-z0-9-]+$'", name="membership_type_slug_format"),
+        CheckConstraint(
+            "NOT is_default OR coalesce(base_price, 0) = 0",
+            name="default_membership_type_is_free",
+        ),
         Index("idx_membership_types_slug", "slug"),
         Index("idx_membership_types_is_active", "is_active"),
         Index("idx_membership_types_display_order", "display_order"),
+        Index(
+            "uq_membership_types_is_default",
+            "is_default",
+            unique=True,
+            postgresql_where=text("is_default"),
+        ),
     )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -76,6 +87,7 @@ class MembershipType(Base):
     display_order = Column(Integer, default=0)
     color = Column(String(7))
     is_active = Column(Boolean, default=True)
+    is_default = Column(Boolean, nullable=False, server_default="false", default=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/app/domains/members/service.py
+++ b/backend/app/domains/members/service.py
@@ -68,6 +68,20 @@ def is_minor_by_dob(date_of_birth: date | None) -> bool:
     return age < MINOR_AGE_THRESHOLD
 
 
+def get_default_membership_type(db: Session) -> MembershipType | None:
+    """The tier a new sign-up lands on.
+
+    At most one row carries ``is_default`` and the database refuses to mark a
+    priced one, so whatever comes back is free. ``is_active`` is deliberately
+    not filtered: an admin who hides the default should get a harmless free tier
+    on the member rather than a NULL ``membership_type_id``, which bars them
+    from every activity that restricts allowed membership types.
+    """
+    return (
+        db.query(MembershipType).filter(MembershipType.is_default == True).first()
+    )
+
+
 def allocate_member_number(db: Session) -> str:
     """Allocate the next member number from the configured prefix + sequence.
 

--- a/backend/tests/integration/api/v1/test_auth.py
+++ b/backend/tests/integration/api/v1/test_auth.py
@@ -42,6 +42,17 @@ def _create_test_user(db, email="test@example.com", password="password123", role
     return user
 
 
+def _default_tier(db, name="General", slug="general"):
+    mt = db.query(MembershipType).filter_by(is_default=True).first()
+    if not mt:
+        mt = MembershipType(
+            name=name, slug=slug, base_price=0, is_active=True, is_default=True
+        )
+        db.add(mt)
+        db.flush()
+    return mt
+
+
 class TestLogin:
     def test_login_success(self, client, db):
         _create_test_user(db, email="login@examplee6e3b1.com", password="password123")
@@ -114,12 +125,7 @@ class TestLogin:
 
 class TestRegister:
     def test_register_success(self, client, db):
-        # Ensure a default membership type exists
-        mt = db.query(MembershipType).first()
-        if not mt:
-            mt = MembershipType(name="General", slug="general", is_active=True)
-            db.add(mt)
-            db.flush()
+        _default_tier(db)
 
         response = client.post(
             "/api/v1/auth/register",
@@ -146,6 +152,36 @@ class TestRegister:
         )
         # The member number is allocated on approval, not at sign-up.
         assert member.member_number is None
+
+    def test_register_lands_on_the_default_tier_not_the_oldest_row(self, client, db):
+        """The bug: sign-up took the lowest id, which on a seeded install is a
+        paid plan, so the new member started accruing a monthly fee."""
+        paid = MembershipType(
+            name="Full Plan", slug="full-plan", base_price=50, is_active=True
+        )
+        db.add(paid)
+        db.flush()
+        free = _default_tier(db, name="Registered Tier", slug="registered-tier")
+
+        response = client.post(
+            "/api/v1/auth/register",
+            json={
+                "first_name": "Tier",
+                "last_name": "Check",
+                "email": "tier@examplee6e3b1.com",
+                "password": "password123",
+            },
+        )
+        assert response.status_code == 201
+
+        member = (
+            db.query(Member)
+            .join(Person, Member.person_id == Person.id)
+            .filter(Person.email == "tier@examplee6e3b1.com")
+            .one()
+        )
+        assert member.membership_type_id == free.id
+        assert member.membership_type_id != paid.id
 
     def test_register_duplicate_email(self, client, db):
         _create_test_user(db, email="dupe@examplee6e3b1.com")

--- a/backend/tests/integration/api/v1/test_membership_types.py
+++ b/backend/tests/integration/api/v1/test_membership_types.py
@@ -1,5 +1,8 @@
 """Integration tests for membership type endpoints."""
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
 from app.core.security.jwt import create_access_token
 from app.core.security.password import hash_password
 from app.domains.auth.models import User
@@ -103,3 +106,34 @@ class TestMembershipTypeCRUD:
             json={"name": "Another", "slug": "existing"},
         )
         assert response.status_code == 409
+
+
+class TestDefaultTier:
+    """The tier new sign-ups land on, and the two rules the database enforces."""
+
+    def test_a_second_default_is_rejected(self, db):
+        db.add(MembershipType(name="First", slug="first", base_price=0, is_default=True))
+        db.flush()
+
+        db.add(MembershipType(name="Second", slug="second", base_price=0, is_default=True))
+        with pytest.raises(IntegrityError):
+            db.flush()
+
+    def test_a_priced_tier_cannot_be_the_default(self, db):
+        db.add(MembershipType(name="Paid", slug="paid", base_price=50, is_default=True))
+        with pytest.raises(IntegrityError):
+            db.flush()
+
+    def test_raising_the_default_price_is_refused_rather_than_crashing(self, client, db):
+        """Without the guard the check constraint would surface as a 500."""
+        user = _create_user(db, "admin")
+        mt = MembershipType(name="Free", slug="free", base_price=0, is_default=True)
+        db.add(mt)
+        db.flush()
+        client.cookies.update(_auth_cookie(user))
+
+        response = client.put(
+            f"/api/v1/membership-types/{mt.id}", json={"base_price": 50.0}
+        )
+
+        assert response.status_code == 400

--- a/backend/tests/integration/api/v1/test_oauth_callback.py
+++ b/backend/tests/integration/api/v1/test_oauth_callback.py
@@ -74,9 +74,11 @@ def stub_provider(monkeypatch):
 
 
 def _ensure_membership_type(db):
-    mt = db.query(MembershipType).first()
+    mt = db.query(MembershipType).filter_by(is_default=True).first()
     if not mt:
-        mt = MembershipType(name="General", slug="general", is_active=True)
+        mt = MembershipType(
+            name="General", slug="general", base_price=0, is_active=True, is_default=True
+        )
         db.add(mt)
         db.flush()
     return mt
@@ -291,6 +293,25 @@ def test_pending_member_still_gets_a_session(client, db, stub_provider):
     user = db.query(User).filter(User.email == "sso@examplee6e3b1.com").one()
     member = db.query(Member).filter(Member.user_id == user.id).one()
     assert member.status == "pending"
+
+
+def test_signup_lands_on_the_default_tier_not_the_oldest_row(client, db, stub_provider):
+    """The SSO path had its own copy of the oldest-row lookup, and its own copy
+    of the silent-billing bug with it."""
+    paid = MembershipType(
+        name="Full Plan", slug="full-plan", base_price=50, is_active=True
+    )
+    db.add(paid)
+    db.flush()
+    free = _ensure_membership_type(db)
+    stub_provider(claims=CLAIMS)
+
+    client.get(GOOGLE_CALLBACK, follow_redirects=False)
+
+    user = db.query(User).filter(User.email == "sso@examplee6e3b1.com").one()
+    member = db.query(Member).filter(Member.user_id == user.id).one()
+    assert member.membership_type_id == free.id
+    assert member.membership_type_id != paid.id
 
 
 # --- Apple sends email_verified as a string --------------------------------

--- a/backend/tests/integration/test_default_tier_migration.py
+++ b/backend/tests/integration/test_default_tier_migration.py
@@ -1,0 +1,172 @@
+"""The default-membership-type migration, run for real against a throwaway database.
+
+The rest of the suite builds its schema with ``create_all`` and never invokes
+alembic, so nothing else would notice if the back-fill regressed on an install
+that upgrades rather than starts fresh — and the install that matters most is
+the one with no free tier at all, which is every club our own seed created.
+"""
+
+import os
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+from app.core.config import settings
+
+BEFORE = "a4b5c6d7e8f9"
+DEFAULT_TIER = "a5b6c7d8e9f0"
+
+BASE_URL = os.getenv("DATABASE_TEST_URL", settings.DATABASE_TEST_URL)
+_WORKER = os.getenv("PYTEST_XDIST_WORKER", "master")
+
+
+def _server_url() -> str:
+    return BASE_URL.rsplit("/", 1)[0] + "/postgres"
+
+
+def _url(database: str) -> str:
+    return BASE_URL.rsplit("/", 1)[0] + f"/{database}"
+
+
+def _alembic_at(database: str, revision: str) -> None:
+    """Migrate the scratch database, not whatever ``DATABASE_URL`` points at.
+
+    ``alembic/env.py`` overrides the URL on the ``Config`` object with
+    ``DATABASE_URL`` whenever it is set, and CI sets it for the whole
+    integration step — so the environment has to be pointed at the scratch
+    database too, or this runs DDL against the shared test database.
+    """
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", _url(database))
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = _url(database)
+    try:
+        command.upgrade(cfg, revision)
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+def _install(name: str, pre_state: str):
+    """A database migrated to just before the default tier, seeded, then upgraded.
+
+    Suffixed per xdist worker so parallel workers don't race DROP/CREATE
+    DATABASE against the same scratch database.
+    """
+    database = f"memship_{name}_migration_test_{_WORKER}"
+    admin = sa.create_engine(_server_url(), isolation_level="AUTOCOMMIT")
+    try:
+        with admin.connect() as conn:
+            conn.execute(sa.text(f'DROP DATABASE IF EXISTS "{database}" WITH (FORCE)'))
+            conn.execute(sa.text(f'CREATE DATABASE "{database}"'))
+    except sa.exc.OperationalError as exc:
+        admin.dispose()
+        pytest.skip(f"no database server for the migration test: {exc}")
+
+    _alembic_at(database, BEFORE)
+    engine = sa.create_engine(_url(database))
+    with engine.begin() as conn:
+        conn.execute(sa.text(pre_state))
+    _alembic_at(database, DEFAULT_TIER)
+
+    yield engine
+
+    engine.dispose()
+    with admin.connect() as conn:
+        conn.execute(sa.text(f'DROP DATABASE IF EXISTS "{database}" WITH (FORCE)'))
+    admin.dispose()
+
+
+PAID_ONLY = """
+    INSERT INTO membership_types (name, slug, base_price, billing_frequency,
+                                  display_order, is_active)
+    VALUES ('Full Member', 'full-member', 50.00, 'monthly', 1, true),
+           ('Student', 'student', 25.00, 'monthly', 2, true);
+
+    INSERT INTO persons (first_name, last_name, email)
+    VALUES ('Billed', 'ByAccident', 'billed@migration.test');
+
+    INSERT INTO members (person_id, membership_type_id, member_number, status, joined_at)
+    SELECT p.id, m.id, 'M-0001', 'active', current_date
+    FROM persons p, membership_types m
+    WHERE p.email = 'billed@migration.test' AND m.slug = 'full-member';
+"""
+
+WITH_FREE_TIERS = """
+    INSERT INTO membership_types (name, slug, base_price, billing_frequency,
+                                  display_order, is_active)
+    VALUES ('Full Member', 'full-member', 50.00, 'monthly', 1, true),
+           ('Retired Free', 'retired-free', 0, 'annual', 1, false),
+           ('Honorary', 'honorary', 0, 'one_time', 2, true);
+"""
+
+
+@pytest.fixture(scope="module")
+def no_free_tier():
+    yield from _install("default_tier_created", PAID_ONLY)
+
+
+@pytest.fixture(scope="module")
+def free_tier_present():
+    yield from _install("default_tier_promoted", WITH_FREE_TIERS)
+
+
+def _defaults(engine) -> list[tuple]:
+    with engine.connect() as conn:
+        return conn.execute(
+            sa.text(
+                "SELECT slug, base_price, is_active FROM membership_types "
+                "WHERE is_default"
+            )
+        ).all()
+
+
+class TestInstallWithNoFreeTier:
+    """Our own seed, and any club that created its paid plans first."""
+
+    def test_a_free_default_is_created(self, no_free_tier):
+        assert _defaults(no_free_tier) == [("registered", 0, True)]
+
+    def test_the_paid_plans_are_left_as_they_are(self, no_free_tier):
+        with no_free_tier.connect() as conn:
+            paid = conn.execute(
+                sa.text(
+                    "SELECT count(*) FROM membership_types WHERE base_price > 0"
+                )
+            ).scalar_one()
+
+        assert paid == 2
+
+    def test_no_member_is_moved(self, no_free_tier):
+        """Cleaning up members the bug already parked on a paid plan is a
+        decision for an admin, not for a migration."""
+        with no_free_tier.connect() as conn:
+            slug = conn.execute(
+                sa.text(
+                    "SELECT t.slug FROM members m "
+                    "JOIN membership_types t ON t.id = m.membership_type_id "
+                    "JOIN persons p ON p.id = m.person_id "
+                    "WHERE p.email = 'billed@migration.test'"
+                )
+            ).scalar_one()
+
+        assert slug == "full-member"
+
+
+class TestInstallWithFreeTiers:
+    def test_the_active_free_tier_wins(self, free_tier_present):
+        """Two free tiers must resolve the same way on every copy of the same
+        database, and a hidden one is not somewhere to send new sign-ups."""
+        assert _defaults(free_tier_present) == [("honorary", 0, True)]
+
+    def test_nothing_is_invented(self, free_tier_present):
+        with free_tier_present.connect() as conn:
+            count = conn.execute(
+                sa.text("SELECT count(*) FROM membership_types")
+            ).scalar_one()
+
+        assert count == 3


### PR DESCRIPTION
**Phase 1 of #143** — the defect only. Phases 2–5 (tier-at-approval, the approval UI, the registration settings panel, the clean-up report) are separate and not in this PR, so #143 stays open.

## The bug

Both self-registration paths picked the new member's membership type with `order_by(MembershipType.id).first()` — not the free tier, but whichever row was created first. On a seeded install that is **Full Member at 50 €/month**, so registering silently started a recurring fee nobody agreed to. The OAuth path carried its own copy of the same query and the same bug.

## The fix

`membership_types.is_default` marks the one tier sign-ups land on, with both rules enforced in the database rather than left to the service:

- a **partial unique index** allows a single default
- a **check constraint** refuses to mark a priced tier default

Both registration paths now go through one `get_default_membership_type` helper, so a future change cannot fix one path and forget the other.

The helper **ignores `is_active` deliberately** — deactivating the default should leave a member on a harmless free tier, not on a `NULL` type, which activities restricted by membership type reject outright.

## Migration

Promotes an existing free tier, resolving active → display_order → id so two free tiers pick the same row on every copy of a database. When a club has none, it creates "Registered".

**It touches no member.** People the bug already parked on a paid plan are for an admin to review one by one — a migration cannot tell an accident from a decision. That clean-up is phase 5. `test_no_member_is_moved` asserts it against a member seeded onto the paid plan.

`upgrade head → downgrade → upgrade head` was verified to re-promote the row it created rather than insert a duplicate.

## Beyond the literal checklist, deliberately

`PUT /membership-types` now returns 400 rather than letting the new check constraint surface as a 500 when someone raises the default tier's price. It is the only new constraint reachable from the existing API.

## Naming

"Registered", in English. `seed_membership_types` runs on every install and every shipped tier is already English — Full Member, Student, Family, Youth, Senior, Honorary — so a single Spanish row would produce a mixed-language list on every fresh install, and a migrated install that disagrees with a fresh one. The `es` default locale governs UI chrome, not this free-text field the club owns and renames. The "this is the system's doing" signal is in the description instead.

## Behaviour change worth noting

Seeded accounts (super admin, demo, `--test`) now attach to `Registered` instead of Full Member — which also stops the recurring billing run invoicing the operator. `e2e/cypress/e2e/settings/settings.cy.ts:24` asserts "Full Member" is visible in the membership-types list, which still holds since that tier is untouched. **Cypress was not run.**

## Testing

Full backend suite: **1413 passed**, 0 failed. New coverage includes a real Alembic migration test against throwaway databases (following `test_roles_migration.py`): a paid-only install gets a created free default with no member moved; an install with two free tiers promotes the active one and invents nothing.

## Gotcha for anyone pulling this branch

`memship-db-test` uses tmpfs but the *container* persists between runs, so `create_all` skips the new column and 8 tests fail with `UndefinedColumn: is_default` until you run `docker compose --profile test --profile tools down` in `backend/docker`.
