### PR TITLE
Put the registration rules where an admin can read them, and list who the bug caught

### DIFF
--- a/backend/app/api/v1/endpoints/membership_types.py
+++ b/backend/app/api/v1/endpoints/membership_types.py
@@ -96,11 +96,31 @@ def update_membership_type(
 ):
     mt = get_or_404(db, MembershipType, type_id)
     update_data = data.model_dump(exclude_unset=True)
-    if mt.is_default and update_data.get("base_price"):
+
+    # The database refuses a priced default and a second default outright, so
+    # both rules are checked here first — an IntegrityError would reach the
+    # admin as a 500 with nothing to act on.
+    will_be_default = update_data.get("is_default", mt.is_default)
+    will_cost = float(update_data.get("base_price", mt.base_price) or 0)
+    if will_be_default and will_cost > 0:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="The tier new sign-ups land on must stay free",
         )
+    if mt.is_default and update_data.get("is_default") is False:
+        # Clearing it outright would leave sign-ups with no tier at all, and a
+        # member with no tier is barred from every activity that restricts
+        # membership types. Moving the flag to another tier is the way out.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New sign-ups need a tier — mark another one the default instead",
+        )
+    if update_data.get("is_default") and not mt.is_default:
+        db.query(MembershipType).filter(
+            MembershipType.is_default == True, MembershipType.id != mt.id
+        ).update({"is_default": False}, synchronize_session=False)
+        db.flush()
+
     for key, value in update_data.items():
         setattr(mt, key, value)
     db.commit()

--- a/backend/app/api/v1/endpoints/reports.py
+++ b/backend/app/api/v1/endpoints/reports.py
@@ -8,8 +8,8 @@ from sqlalchemy.orm import Session
 from app.core.authorization import require_permission
 from app.db.session import get_db
 from app.domains.auth.models import User
-from app.domains.reports.schemas import AnnualSummary
-from app.domains.reports.service import annual_summary
+from app.domains.reports.schemas import AnnualSummary, PaidTierWithoutPurchase
+from app.domains.reports.service import annual_summary, paid_tier_without_purchase
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
@@ -22,3 +22,16 @@ def get_annual_summary(
 ):
     """Annual financial + membership summary (defaults to the current year)."""
     return annual_summary(db, year or date.today().year)
+
+
+@router.get("/paid-tier-without-purchase", response_model=PaidTierWithoutPurchase)
+def get_paid_tier_without_purchase(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    # Named rows about individual members, and the fix is per member on their
+    # own record — so this reads member data, not aggregates like the summary.
+    current_user: User = Depends(require_permission("members.read")),
+):
+    """Members on a priced tier that no membership receipt has ever paid for."""
+    return paid_tier_without_purchase(db, page, per_page)

--- a/backend/app/domains/members/schemas.py
+++ b/backend/app/domains/members/schemas.py
@@ -29,6 +29,7 @@ class MembershipTypeUpdate(BaseModel):
     base_price: float | None = Field(default=None, ge=0)
     billing_frequency: str | None = None
     is_active: bool | None = None
+    is_default: bool | None = None
 
 
 class MembershipTypeResponse(BaseModel):

--- a/backend/app/domains/reports/schemas.py
+++ b/backend/app/domains/reports/schemas.py
@@ -1,6 +1,10 @@
-"""Reports schemas — annual summary aggregates."""
+"""Reports schemas — annual summary aggregates and the paid-tier clean-up list."""
+
+from datetime import date
 
 from pydantic import BaseModel
+
+from app.core.pagination import PageMeta
 
 
 class ActivityParticipation(BaseModel):
@@ -20,3 +24,23 @@ class AnnualSummary(BaseModel):
     lost_members: int
     net_growth: int
     activity_participation: list[ActivityParticipation]
+
+
+class PaidTierMember(BaseModel):
+    member_id: int
+    member_number: str | None
+    full_name: str
+    email: str | None
+    status: str
+    joined_at: date
+    membership_type_id: int
+    membership_type_name: str
+    base_price: float
+    billing_frequency: str
+    unpaid_receipts: int
+    unpaid_amount: float
+
+
+class PaidTierWithoutPurchase(BaseModel):
+    meta: PageMeta
+    items: list[PaidTierMember]

--- a/backend/app/domains/reports/service.py
+++ b/backend/app/domains/reports/service.py
@@ -1,19 +1,34 @@
-"""Reports service — annual summary aggregates.
+"""Reports service — annual summary aggregates and the paid-tier clean-up list.
 
-Feeds both the Annual Summary page (any year) and the admin dashboard's central
-finance graph (current year: revenue + outstanding by month). Keeping the
-aggregation here means both surfaces read the same numbers.
+The annual summary feeds both the Annual Summary page (any year) and the admin
+dashboard's central finance graph (current year: revenue + outstanding by
+month). Keeping the aggregation here means both surfaces read the same numbers.
 """
 
 from sqlalchemy import extract, func
 from sqlalchemy.orm import Session
 
+from app.core.pagination import paginate
 from app.domains.activities.models import Activity, Registration
 from app.domains.billing.models import Receipt
-from app.domains.members.models import Member
-from app.domains.reports.schemas import ActivityParticipation, AnnualSummary
+from app.domains.members.models import Member, MembershipType
+from app.domains.persons.models import Person
+from app.domains.reports.schemas import (
+    ActivityParticipation,
+    AnnualSummary,
+    PaidTierMember,
+    PaidTierWithoutPurchase,
+)
 
 OUTSTANDING_STATUSES = ("pending", "emitted", "overdue")
+
+# Everything a membership receipt can be while the money has not arrived. A
+# cancelled one is a charge the club withdrew, so it counts as no charge at all.
+UNPAID_STATUSES = ("new", "pending", "emitted", "overdue")
+
+# Statuses the club has already closed: nobody bills them and nobody is waiting
+# on a decision about them, so they are not clean-up work.
+SETTLED_MEMBER_STATUSES = ("cancelled", "expired")
 
 
 def _buckets_float(rows) -> list[float]:
@@ -116,5 +131,92 @@ def annual_summary(db: Session, year: int) -> AnnualSummary:
         activity_participation=[
             ActivityParticipation(activity_name=name, count=count)
             for name, count in participation_rows
+        ],
+    )
+
+
+def paid_tier_without_purchase(
+    db: Session, page: int = 1, per_page: int = 20
+) -> PaidTierWithoutPurchase:
+    """Members sitting on a priced tier that nobody has ever paid for.
+
+    Until sign-ups landed on a free default tier, self-registration put the new
+    member on whichever membership type happened to have the lowest id — a
+    50 EUR plan on a seeded install. This lists who that left behind.
+
+    "No purchase behind them" is read as *no membership receipt has ever reached
+    ``paid``*. There is no record of buying a membership yet, and a settled
+    receipt is the closest thing the schema has: money changed hands against a
+    membership fee, which takes a human on both sides. Anything weaker would
+    clear the very people the bug hurt — a member the recurring run has already
+    billed has membership receipts, they are simply unpaid, and those are the
+    damage rather than the evidence. So the unpaid ones are counted and totalled
+    per row instead of excluding anybody: that total is what the club is
+    currently asking for and may want to withdraw.
+
+    Members the club has already closed (cancelled, expired, deactivated) are
+    left out — nothing bills them and no decision is pending. The dearest tier
+    comes first, since that is where the accruing fee is largest.
+    """
+    has_paid_membership_receipt = (
+        db.query(Receipt.id)
+        .filter(
+            Receipt.member_id == Member.id,
+            Receipt.origin == "membership",
+            Receipt.status == "paid",
+            Receipt.is_active.is_(True),
+        )
+        .exists()
+    )
+
+    unpaid = (
+        db.query(
+            Receipt.member_id.label("member_id"),
+            func.count(Receipt.id).label("receipts"),
+            func.coalesce(func.sum(Receipt.total_amount), 0).label("amount"),
+        )
+        .filter(
+            Receipt.origin == "membership",
+            Receipt.status.in_(UNPAID_STATUSES),
+            Receipt.is_active.is_(True),
+        )
+        .group_by(Receipt.member_id)
+        .subquery()
+    )
+
+    query = (
+        db.query(Member, Person, MembershipType, unpaid.c.receipts, unpaid.c.amount)
+        .join(Person, Member.person_id == Person.id)
+        .join(MembershipType, Member.membership_type_id == MembershipType.id)
+        .outerjoin(unpaid, unpaid.c.member_id == Member.id)
+        .filter(
+            MembershipType.base_price > 0,
+            Member.is_active.is_(True),
+            Member.status.notin_(SETTLED_MEMBER_STATUSES),
+            ~has_paid_membership_receipt,
+        )
+        .order_by(MembershipType.base_price.desc(), Member.id)
+    )
+
+    rows, meta = paginate(query, page, per_page)
+
+    return PaidTierWithoutPurchase(
+        meta=meta,
+        items=[
+            PaidTierMember(
+                member_id=member.id,
+                member_number=member.member_number,
+                full_name=f"{person.first_name} {person.last_name}",
+                email=person.email,
+                status=member.status,
+                joined_at=member.joined_at,
+                membership_type_id=mtype.id,
+                membership_type_name=mtype.name,
+                base_price=float(mtype.base_price or 0),
+                billing_frequency=mtype.billing_frequency,
+                unpaid_receipts=int(receipts or 0),
+                unpaid_amount=round(float(amount or 0), 2),
+            )
+            for member, person, mtype, receipts, amount in rows
         ],
     )

--- a/backend/tests/integration/api/v1/test_membership_types.py
+++ b/backend/tests/integration/api/v1/test_membership_types.py
@@ -161,3 +161,63 @@ class TestDefaultTier:
         )
 
         assert response.status_code == 400
+
+    def test_the_default_moves_to_the_tier_the_admin_picks(self, client, db):
+        user = _create_user(db, "admin")
+        current = MembershipType(name="Free", slug="free", base_price=0, is_default=True)
+        wanted = MembershipType(name="Welcome", slug="welcome", base_price=0)
+        db.add_all([current, wanted])
+        db.flush()
+        client.cookies.update(_auth_cookie(user))
+
+        response = client.put(
+            f"/api/v1/membership-types/{wanted.id}", json={"is_default": True}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["is_default"] is True
+        db.expire_all()
+        assert current.is_default is False
+
+    def test_a_priced_tier_cannot_be_made_the_default(self, client, db):
+        user = _create_user(db, "admin")
+        mt = MembershipType(name="Premium", slug="premium", base_price=50)
+        db.add(mt)
+        db.flush()
+        client.cookies.update(_auth_cookie(user))
+
+        response = client.put(
+            f"/api/v1/membership-types/{mt.id}", json={"is_default": True}
+        )
+
+        assert response.status_code == 400
+
+    def test_the_default_cannot_be_left_unset(self, client, db):
+        """A sign-up with no tier is barred from membership-restricted activities."""
+        user = _create_user(db, "admin")
+        mt = MembershipType(name="Free", slug="free", base_price=0, is_default=True)
+        db.add(mt)
+        db.flush()
+        client.cookies.update(_auth_cookie(user))
+
+        response = client.put(
+            f"/api/v1/membership-types/{mt.id}", json={"is_default": False}
+        )
+
+        assert response.status_code == 400
+        db.expire_all()
+        assert mt.is_default is True
+
+    def test_the_listing_says_which_tier_is_the_default(self, client, db):
+        user = _create_user(db, "admin")
+        db.add(MembershipType(name="Free", slug="free", base_price=0, is_default=True))
+        db.add(MembershipType(name="Premium", slug="premium", base_price=50))
+        db.flush()
+        client.cookies.update(_auth_cookie(user))
+
+        response = client.get("/api/v1/membership-types/")
+
+        assert response.status_code == 200
+        defaults = {t["name"]: t["is_default"] for t in response.json()}
+        assert defaults["Free"] is True
+        assert defaults["Premium"] is False

--- a/backend/tests/integration/api/v1/test_reports.py
+++ b/backend/tests/integration/api/v1/test_reports.py
@@ -8,7 +8,7 @@ from app.core.security.password import hash_password
 from app.domains.activities.models import Activity, Registration
 from app.domains.auth.models import User
 from app.domains.billing.models import Receipt
-from app.domains.members.models import Member
+from app.domains.members.models import Member, MembershipType
 from app.domains.persons.models import Person
 
 YEAR = 2026
@@ -34,7 +34,8 @@ def _admin(db, suffix):
     return user
 
 
-def _member(db, suffix, *, status="active", joined_at=None, status_changed_at=None, with_user=False):
+def _member(db, suffix, *, status="active", joined_at=None, status_changed_at=None, with_user=False,
+            membership_type_id=None, is_active=True):
     person = Person(first_name="Mem", last_name=f"Ber-{suffix}", email=f"m-rep-{suffix}@examplee6e3b1.com")
     db.add(person)
     db.flush()
@@ -58,6 +59,8 @@ def _member(db, suffix, *, status="active", joined_at=None, status_changed_at=No
         status=status,
         joined_at=joined_at or date(YEAR, 1, 1),
         status_changed_at=status_changed_at,
+        membership_type_id=membership_type_id,
+        is_active=is_active,
     )
     db.add(member)
     db.flush()
@@ -193,4 +196,123 @@ class TestAnnualSummary:
         client.cookies.update(_auth_cookie(user))
 
         resp = client.get(f"/api/v1/reports/annual-summary?year={YEAR}")
+        assert resp.status_code == 403
+
+
+def _tier(db, suffix, price, *, frequency="monthly"):
+    mtype = MembershipType(
+        name=f"Tier {suffix}",
+        slug=f"tier-rep-{suffix}",
+        base_price=Decimal(str(price)),
+        billing_frequency=frequency,
+        is_active=True,
+    )
+    db.add(mtype)
+    db.flush()
+    return mtype
+
+
+class TestPaidTierWithoutPurchase:
+    """Who the sign-up bug parked on a priced tier, and who merely looks like it."""
+
+    URL = "/api/v1/reports/paid-tier-without-purchase"
+
+    def test_a_paid_tier_with_no_receipts_at_all_is_listed(self, client, db):
+        admin = _admin(db, "ptp-plain")
+        tier = _tier(db, "plain", 50)
+        member = _member(db, "ptp-plain", membership_type_id=tier.id)
+        client.cookies.update(_auth_cookie(admin))
+
+        resp = client.get(self.URL)
+
+        assert resp.status_code == 200
+        rows = {r["member_id"]: r for r in resp.json()["items"]}
+        assert member.id in rows
+        assert rows[member.id]["membership_type_name"] == "Tier plain"
+        assert rows[member.id]["base_price"] == 50.0
+        assert rows[member.id]["unpaid_receipts"] == 0
+        assert rows[member.id]["unpaid_amount"] == 0.0
+
+    def test_a_free_tier_and_a_missing_tier_are_not_damage(self, client, db):
+        admin = _admin(db, "ptp-free")
+        free = _tier(db, "free", 0)
+        on_free = _member(db, "ptp-free", membership_type_id=free.id)
+        on_nothing = _member(db, "ptp-none")
+        client.cookies.update(_auth_cookie(admin))
+
+        resp = client.get(self.URL)
+
+        listed = {r["member_id"] for r in resp.json()["items"]}
+        assert on_free.id not in listed
+        assert on_nothing.id not in listed
+
+    def test_a_settled_membership_receipt_clears_the_member(self, client, db):
+        """Money that arrived against a membership fee is the purchase."""
+        admin = _admin(db, "ptp-paid")
+        tier = _tier(db, "paid", 50)
+        member = _member(db, "ptp-paid", membership_type_id=tier.id)
+        _receipt(db, member, suffix="ptp-paid", status="paid",
+                 emission_date=date(YEAR, 3, 1), payment_date=date(YEAR, 3, 15))
+        client.cookies.update(_auth_cookie(admin))
+
+        resp = client.get(self.URL)
+
+        assert member.id not in {r["member_id"] for r in resp.json()["items"]}
+
+    def test_unpaid_membership_receipts_are_counted_not_excused(self, client, db):
+        """Being billed already is the damage, not evidence of a purchase."""
+        admin = _admin(db, "ptp-unpaid")
+        tier = _tier(db, "unpaid", 50)
+        member = _member(db, "ptp-unpaid", membership_type_id=tier.id)
+        _receipt(db, member, suffix="ptp-emit", status="emitted",
+                 emission_date=date(YEAR, 4, 1))
+        _receipt(db, member, suffix="ptp-over", status="overdue",
+                 emission_date=date(YEAR, 5, 1))
+        _receipt(db, member, suffix="ptp-cxl", status="cancelled",
+                 emission_date=date(YEAR, 6, 1))
+        client.cookies.update(_auth_cookie(admin))
+
+        resp = client.get(self.URL)
+
+        row = next(r for r in resp.json()["items"] if r["member_id"] == member.id)
+        assert row["unpaid_receipts"] == 2
+        assert row["unpaid_amount"] == 242.0
+
+    def test_members_the_club_has_closed_are_left_out(self, client, db):
+        admin = _admin(db, "ptp-closed")
+        tier = _tier(db, "closed", 50)
+        cancelled = _member(db, "ptp-cxl", status="cancelled", membership_type_id=tier.id)
+        expired = _member(db, "ptp-exp", status="expired", membership_type_id=tier.id)
+        deactivated = _member(db, "ptp-off", membership_type_id=tier.id, is_active=False)
+        pending = _member(db, "ptp-pend", status="pending", membership_type_id=tier.id)
+        client.cookies.update(_auth_cookie(admin))
+
+        resp = client.get(self.URL)
+
+        listed = {r["member_id"] for r in resp.json()["items"]}
+        assert cancelled.id not in listed
+        assert expired.id not in listed
+        assert deactivated.id not in listed
+        assert pending.id in listed
+
+    def test_the_dearest_tier_comes_first(self, client, db):
+        admin = _admin(db, "ptp-order")
+        cheap = _tier(db, "cheap", 10)
+        dear = _tier(db, "dear", 90)
+        on_cheap = _member(db, "ptp-cheap", membership_type_id=cheap.id)
+        on_dear = _member(db, "ptp-dear", membership_type_id=dear.id)
+        client.cookies.update(_auth_cookie(admin))
+
+        resp = client.get(self.URL)
+
+        ordered = [r["member_id"] for r in resp.json()["items"]]
+        assert ordered.index(on_dear.id) < ordered.index(on_cheap.id)
+
+    def test_a_member_account_cannot_read_it(self, client, db):
+        _member(db, "ptp-forbidden", with_user=True)
+        _, user = _member(db, "ptp-forbidden2", with_user=True)
+        client.cookies.update(_auth_cookie(user))
+
+        resp = client.get(self.URL)
+
         assert resp.status_code == 403

--- a/frontend/app/[locale]/(portal)/paid-tier-without-purchase/page.tsx
+++ b/frontend/app/[locale]/(portal)/paid-tier-without-purchase/page.tsx
@@ -1,0 +1,5 @@
+import { PaidTierWithoutPurchase } from "@/features/reports/components/paid-tier-without-purchase";
+
+export default function PaidTierWithoutPurchasePage() {
+  return <PaidTierWithoutPurchase />;
+}

--- a/frontend/app/[locale]/(portal)/settings/page.tsx
+++ b/frontend/app/[locale]/(portal)/settings/page.tsx
@@ -53,6 +53,7 @@ import { MemberCardSettings } from "@/features/settings/components/member-card-s
 import { SsoSettings } from "@/features/settings/components/sso-settings";
 import { MailingSettings } from "@/features/settings/components/mailing-settings";
 import { ProfileFieldsSettings } from "@/features/settings/components/profile-fields-settings";
+import { RegistrationSettings } from "@/features/settings/components/registration-settings";
 import { BookingsSettings } from "@/features/settings/components/bookings-settings";
 import { RolesSettings } from "@/features/roles/components/roles-settings";
 import { UsersSettings } from "@/features/roles/components/users-settings";
@@ -518,6 +519,9 @@ export default function SettingsPage() {
                 <TabsTrigger value="profile-fields" className={SUBTAB_TRIGGER}>{t("profileFields.tab")}</TabsTrigger>
               )}
               <TabsTrigger value="membership-types" className={SUBTAB_TRIGGER}>{t("nav.membershipTypes")}</TabsTrigger>
+              {isSuperAdmin && (
+                <TabsTrigger value="registration" className={SUBTAB_TRIGGER}>{t("settings.registration.tab")}</TabsTrigger>
+              )}
             </TabsList>
 
             {isSuperAdmin && <TabsContent value="communications" className="space-y-3">
@@ -533,6 +537,11 @@ export default function SettingsPage() {
             <TabsContent value="membership-types">
               <MembershipTypesSettings />
             </TabsContent>
+            {/* Sits beside membership types because the tier new sign-ups land
+                on is edited here, and it is one of those rows. */}
+            {isSuperAdmin && <TabsContent value="registration">
+              <RegistrationSettings />
+            </TabsContent>}
           </Tabs>
         </TabsContent>
 

--- a/frontend/app/api/reports/paid-tier-without-purchase/route.ts
+++ b/frontend/app/api/reports/paid-tier-without-purchase/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8003";
+
+export async function GET(request: NextRequest) {
+  const cookie = request.headers.get("cookie") || "";
+  const res = await fetch(
+    `${API_BASE_URL}/api/v1/reports/paid-tier-without-purchase${request.nextUrl.search}`,
+    { headers: { Cookie: cookie } }
+  );
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   IdCard,
   ScanLine,
   TrendingUp,
+  TriangleAlert,
   MapPin,
   LogOut,
   ChevronsUpDown,
@@ -94,6 +95,7 @@ export function AppSidebar({ user }: AppSidebarProps) {
           [
             { href: "/members", label: t("nav.members"), icon: Users, show: has("members.read") },
             { href: "/members/pending", label: t("nav.pendingRegistrations"), icon: UserCheck, show: has("members.approve") },
+            { href: "/paid-tier-without-purchase", label: t("reports.paidTierWithoutPurchase.nav"), icon: TriangleAlert, show: has("members.read") },
             { href: "/groups", label: t("nav.groups"), icon: FolderOpen, show: has("membership.read") },
             { href: "/activities", label: t("nav.activities"), icon: CalendarDays, show: has("activities.read") },
             { href: "/spaces", label: t("bookings.nav"), icon: MapPin, show: bookingsEnabled && has("bookings.read") },

--- a/frontend/features/reports/components/paid-tier-without-purchase.tsx
+++ b/frontend/features/reports/components/paid-tier-without-purchase.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link, useRouter } from "@/lib/i18n/routing";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TableSkeleton } from "@/components/ui/skeletons";
+import { PageInfo } from "@/components/page-info";
+import { Pagination } from "@/components/entity/pagination";
+import { usePageParam } from "@/hooks/use-url-state";
+import { useFormatters } from "@/hooks/use-formatters";
+import { MEMBER_STATUS_VARIANTS } from "@/lib/status-variants";
+import { usePaidTierWithoutPurchase } from "../hooks/use-paid-tier-without-purchase";
+
+/**
+ * Members the old sign-up path parked on a priced tier nobody bought. Read-only
+ * on purpose: the report cannot tell an accident from a decision, so each row
+ * is a prompt to open the member and choose, not something to fix in bulk.
+ */
+export function PaidTierWithoutPurchase() {
+  const t = useTranslations();
+  const router = useRouter();
+  const { formatCurrency, formatDate } = useFormatters();
+  const [page, setPage] = usePageParam();
+  const { data, isLoading } = usePaidTierWithoutPurchase(page);
+
+  const items = data?.items ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <h1 className="text-2xl font-bold">
+          {t("reports.paidTierWithoutPurchase.title")}
+        </h1>
+        <PageInfo text={t("reports.paidTierWithoutPurchase.info")} />
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {t("reports.paidTierWithoutPurchase.description")}
+      </p>
+
+      {isLoading ? (
+        <TableSkeleton />
+      ) : items.length === 0 ? (
+        <div className="py-8 text-center text-muted-foreground">
+          {t("reports.paidTierWithoutPurchase.empty")}
+        </div>
+      ) : (
+        <>
+          <div className="hidden md:block rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("members.name")}</TableHead>
+                  <TableHead>{t("members.memberNumber")}</TableHead>
+                  <TableHead>{t("common.status")}</TableHead>
+                  <TableHead>{t("members.membershipType")}</TableHead>
+                  <TableHead className="text-right">
+                    {t("members.typePrice")}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t("reports.paidTierWithoutPurchase.unpaidReceipts")}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t("reports.paidTierWithoutPurchase.unpaidAmount")}
+                  </TableHead>
+                  <TableHead>{t("members.joinedAt")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((row) => (
+                  <TableRow
+                    key={row.member_id}
+                    className="cursor-pointer"
+                    onClick={() => router.push(`/members/${row.member_id}`)}
+                  >
+                    <TableCell className="font-medium">{row.full_name}</TableCell>
+                    <TableCell>{row.member_number ?? "—"}</TableCell>
+                    <TableCell>
+                      <Badge variant={MEMBER_STATUS_VARIANTS[row.status] ?? "outline"}>
+                        {t(`status.${row.status}`)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{row.membership_type_name}</TableCell>
+                    <TableCell className="text-right">
+                      {formatCurrency(row.base_price)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {row.unpaid_receipts}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatCurrency(row.unpaid_amount)}
+                    </TableCell>
+                    <TableCell>{formatDate(row.joined_at)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="space-y-3 md:hidden">
+            {items.map((row) => (
+              <Link
+                key={row.member_id}
+                href={`/members/${row.member_id}`}
+                className="block rounded-md border p-3"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium">{row.full_name}</span>
+                  <Badge variant={MEMBER_STATUS_VARIANTS[row.status] ?? "outline"}>
+                    {t(`status.${row.status}`)}
+                  </Badge>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {row.membership_type_name} · {formatCurrency(row.base_price)}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {t("reports.paidTierWithoutPurchase.unpaidAmount")}:{" "}
+                  {formatCurrency(row.unpaid_amount)} ({row.unpaid_receipts})
+                </p>
+              </Link>
+            ))}
+          </div>
+
+          {data && (
+            <Pagination
+              page={page}
+              totalPages={data.meta.total_pages}
+              total={data.meta.total}
+              perPage={data.meta.per_page}
+              onPageChange={setPage}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/features/reports/hooks/use-paid-tier-without-purchase.ts
+++ b/frontend/features/reports/hooks/use-paid-tier-without-purchase.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPaidTierWithoutPurchase } from "../services/reports-api";
+
+export function usePaidTierWithoutPurchase(page: number) {
+  return useQuery({
+    queryKey: ["paid-tier-without-purchase", page],
+    queryFn: () => getPaidTierWithoutPurchase(page),
+  });
+}

--- a/frontend/features/reports/services/reports-api.ts
+++ b/frontend/features/reports/services/reports-api.ts
@@ -22,3 +22,31 @@ export function getAnnualSummary(year?: number): Promise<AnnualSummary> {
   const qs = year ? `?year=${year}` : "";
   return apiClient<AnnualSummary>(`/reports/annual-summary${qs}`);
 }
+
+export interface PaidTierMember {
+  member_id: number;
+  member_number: string | null;
+  full_name: string;
+  email: string | null;
+  status: string;
+  joined_at: string;
+  membership_type_id: number;
+  membership_type_name: string;
+  base_price: number;
+  billing_frequency: string;
+  unpaid_receipts: number;
+  unpaid_amount: number;
+}
+
+export interface PaidTierWithoutPurchase {
+  meta: { page: number; per_page: number; total: number; total_pages: number };
+  items: PaidTierMember[];
+}
+
+export function getPaidTierWithoutPurchase(
+  page = 1
+): Promise<PaidTierWithoutPurchase> {
+  return apiClient<PaidTierWithoutPurchase>(
+    `/reports/paid-tier-without-purchase?page=${page}`
+  );
+}

--- a/frontend/features/settings/components/membership-types-settings.tsx
+++ b/frontend/features/settings/components/membership-types-settings.tsx
@@ -264,9 +264,16 @@ export function MembershipTypesSettings() {
                 <TableCell>{type.base_price.toFixed(2)} EUR</TableCell>
                 <TableCell>{type.group_name || t("members.noGroup")}</TableCell>
                 <TableCell>
-                  <Badge variant={type.is_active ? "default" : "outline"}>
-                    {type.is_active ? t("status.active") : t("members.inactive")}
-                  </Badge>
+                  <div className="flex flex-wrap gap-1">
+                    <Badge variant={type.is_active ? "default" : "outline"}>
+                      {type.is_active ? t("status.active") : t("members.inactive")}
+                    </Badge>
+                    {/* Which row new sign-ups land on is decided in the
+                        Registration panel; here it is only stated. */}
+                    {type.is_default && (
+                      <Badge variant="secondary">{t("members.defaultType")}</Badge>
+                    )}
+                  </div>
                 </TableCell>
                 <TableCell>
                   <div className="flex gap-2">

--- a/frontend/features/settings/components/registration-settings.tsx
+++ b/frontend/features/settings/components/registration-settings.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { FormSkeleton } from "@/components/ui/skeletons";
+import {
+  useMembershipTypes,
+  useUpdateMembershipType,
+} from "@/features/members/hooks/use-members";
+import { useSettings, useUpdateSettings } from "../hooks/use-settings";
+
+/**
+ * Public sign-up as the single decision it is: whether strangers may join at
+ * all, whether an admin reviews them, and which free tier they land on. The two
+ * switches and the tier are separate stores — `organization_settings.features`
+ * and `membership_types.is_default` — but an admin reads them as one rule, so
+ * the panel states the resulting behaviour in words above the controls.
+ */
+export function RegistrationSettings() {
+  const t = useTranslations();
+  const { data: settings, isLoading } = useSettings();
+  const { data: types, isLoading: typesLoading } = useMembershipTypes();
+  const updateSettings = useUpdateSettings();
+  const updateType = useUpdateMembershipType();
+
+  const features = settings?.features ?? {};
+  // Both keys are absent on a fresh install and both default to on there —
+  // `get_registration_settings` reads them the same way.
+  const publicRegistration = features.public_registration !== false;
+  const requiresApproval = features.registration_requires_approval !== false;
+
+  const defaultType = types?.find((type) => type.is_default) ?? null;
+  // Only a free tier may be the default, and the database enforces it. An
+  // inactive default still belongs in the list: it is what sign-ups land on
+  // until the admin moves the flag.
+  const freeTypes =
+    types?.filter((type) => type.base_price === 0 && (type.is_active || type.is_default)) ?? [];
+
+  const flow = !publicRegistration
+    ? "flowClosed"
+    : requiresApproval
+      ? "flowApproval"
+      : "flowImmediate";
+
+  if (isLoading || typesLoading) return <FormSkeleton fields={3} />;
+
+  async function saveFeature(partial: Record<string, unknown>) {
+    try {
+      await updateSettings.mutateAsync({
+        features: { ...(settings?.features ?? {}), ...partial },
+      });
+      toast.success(t("toast.success.saved"));
+    } catch {
+      /* global handler shows the error toast */
+    }
+  }
+
+  async function chooseDefault(value: string) {
+    try {
+      await updateType.mutateAsync({
+        id: Number(value),
+        data: { is_default: true },
+      });
+      toast.success(t("toast.success.saved"));
+    } catch {
+      /* global handler shows the error toast */
+    }
+  }
+
+  return (
+    <div className="space-y-3 max-w-4xl">
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="text-base">
+            {t("settings.registration.title")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-4 pb-3 pt-0 space-y-3">
+          <p className="rounded-lg border bg-muted/50 p-2.5 text-xs text-muted-foreground">
+            {t(`settings.registration.${flow}`)}
+          </p>
+
+          <div className="flex items-center justify-between gap-2 rounded-lg border p-2.5">
+            <div>
+              <p className="text-xs font-medium">
+                {t("settings.registration.publicEnabled")}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {t("settings.registration.publicEnabledDesc")}
+              </p>
+            </div>
+            <Switch
+              checked={publicRegistration}
+              onCheckedChange={(checked) =>
+                saveFeature({ public_registration: checked })
+              }
+              disabled={updateSettings.isPending}
+            />
+          </div>
+
+          {publicRegistration && (
+            <div className="flex items-center justify-between gap-2 rounded-lg border p-2.5">
+              <div>
+                <p className="text-xs font-medium">
+                  {t("settings.registration.requiresApproval")}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {t("settings.registration.requiresApprovalDesc")}
+                </p>
+              </div>
+              <Switch
+                checked={requiresApproval}
+                onCheckedChange={(checked) =>
+                  saveFeature({ registration_requires_approval: checked })
+                }
+                disabled={updateSettings.isPending}
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="text-base">
+            {t("settings.registration.defaultTier")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-4 pb-3 pt-0 space-y-1">
+          <Label className="text-xs">
+            {t("settings.registration.defaultTierLabel")}
+          </Label>
+          <Select
+            value={defaultType ? String(defaultType.id) : ""}
+            onValueChange={chooseDefault}
+            disabled={updateType.isPending || freeTypes.length === 0}
+          >
+            <SelectTrigger className="h-8 w-full sm:w-72">
+              <SelectValue
+                placeholder={t("settings.registration.noDefaultTier")}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {freeTypes.map((type) => (
+                <SelectItem key={type.id} value={String(type.id)}>
+                  {type.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {freeTypes.length === 0
+              ? t("settings.registration.noFreeTiers")
+              : t("settings.registration.defaultTierDesc")}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/lib/i18n/request.ts
+++ b/frontend/lib/i18n/request.ts
@@ -24,6 +24,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
   const memberCard = (await import(`@/locales/${locale}/member-card.json`)).default;
   const exportNs = (await import(`@/locales/${locale}/export.json`)).default;
   const annualSummary = (await import(`@/locales/${locale}/annual-summary.json`)).default;
+  const reports = (await import(`@/locales/${locale}/reports.json`)).default;
   const notes = (await import(`@/locales/${locale}/notes.json`)).default;
   const profileFields = (await import(`@/locales/${locale}/profile-fields.json`)).default;
   const roles = (await import(`@/locales/${locale}/roles.json`)).default;
@@ -31,6 +32,6 @@ export default getRequestConfig(async ({ requestLocale }) => {
 
   return {
     locale,
-    messages: { ...common, ...auth, ...members, ...dashboard, ...settings, ...activities, ...receipts, ...mandates, ...remittances, ...paymentMethod, ...billingRuns, ...reminders, ...communications, ...memberCard, ...exportNs, ...annualSummary, ...notes, ...profileFields, ...bookings, ...roles },
+    messages: { ...common, ...auth, ...members, ...dashboard, ...settings, ...activities, ...receipts, ...mandates, ...remittances, ...paymentMethod, ...billingRuns, ...reminders, ...communications, ...memberCard, ...exportNs, ...annualSummary, ...reports, ...notes, ...profileFields, ...bookings, ...roles },
   };
 });

--- a/frontend/lib/route-permissions.ts
+++ b/frontend/lib/route-permissions.ts
@@ -26,6 +26,7 @@ export const ROUTE_PERMISSIONS: ReadonlyArray<readonly [string, readonly string[
   ["/remittances", ["billing.read"]],
   ["/billing-runs", ["billing.read"]],
   ["/annual-summary", ["reports.read"]],
+  ["/paid-tier-without-purchase", ["members.read"]],
   ["/communications", ["communications.read"]],
   // Settings is a bag of tabs with their own gates — membership types is
   // reachable on `membership.write` alone, so any one of these opens the page.

--- a/frontend/locales/ca/members.json
+++ b/frontend/locales/ca/members.json
@@ -72,6 +72,7 @@
       "queueTitle": "Altes pendents",
       "queueDescription": "Sol·licituds d'alta pendents de decisió.",
       "queueEmpty": "No hi ha altes pendents de revisar."
-    }
+    },
+    "defaultType": "Per defecte"
   }
 }

--- a/frontend/locales/ca/reports.json
+++ b/frontend/locales/ca/reports.json
@@ -1,0 +1,13 @@
+{
+  "reports": {
+    "paidTierWithoutPurchase": {
+      "nav": "Revisió de quotes",
+      "title": "Quotes de pagament sense cap compra al darrere",
+      "description": "Socis amb un tipus de afiliació que costa diners i sense cap quota pagada. L'alta aterrava abans al tipus creat primer, així que alguns d'aquests no els va triar ningú.",
+      "info": "Un soci hi apareix mentre el seu tipus de afiliació costi més de zero i cap dels seus rebuts de quota hagi arribat a pagat. Les quotes ja emeses i encara sense pagar es compten aquí en comptes de treure el soci de la llista: són el que el club està reclamant ara mateix. Els socis cancel·lats, caducats i desactivats en queden fora. Aquí no es modifica res: obre la fitxa i decideix.",
+      "empty": "Cap soci està en una quota de pagament sense una compra al darrere.",
+      "unpaidReceipts": "Quotes sense pagar",
+      "unpaidAmount": "Import sense pagar"
+    }
+  }
+}

--- a/frontend/locales/ca/settings.json
+++ b/frontend/locales/ca/settings.json
@@ -302,6 +302,22 @@
           "description": "Difusió dels anuncis que envien els administradors."
         }
       }
+    },
+    "registration": {
+      "tab": "Registre",
+      "title": "Registre públic",
+      "flowClosed": "El registre està tancat. Només hi ha socis si els crea un administrador.",
+      "flowApproval": "Qualsevol es pot registrar i cada alta queda pendent fins que un administrador la revisa. No es cobra res abans d'aquesta decisió.",
+      "flowImmediate": "Qualsevol es pot registrar i passa a ser soci a l'instant, amb el tipus gratuït de sota. Només un administrador mou algú a un tipus de pagament.",
+      "publicEnabled": "Permetre el registre públic",
+      "publicEnabledDesc": "Mostra el formulari d'alta i accepta registres de qui hi arribi",
+      "requiresApproval": "Revisar cada alta",
+      "requiresApprovalDesc": "Les altes noves queden pendents fins que un administrador les aprova; el número de soci s'assigna llavors, així que una alta abandonada no en gasta cap",
+      "defaultTier": "Tipus de afiliació per defecte",
+      "defaultTierLabel": "On aterren les altes noves",
+      "defaultTierDesc": "Només un tipus de afiliació gratuït pot ser el predeterminat, així que registrar-se mai no inicia una quota per si sol",
+      "noDefaultTier": "Cap seleccionat",
+      "noFreeTiers": "Encara no hi ha cap tipus de afiliació gratuït. Crea'n un a Tipus de afiliació i podrà ser el predeterminat."
     }
   }
 }

--- a/frontend/locales/en/members.json
+++ b/frontend/locales/en/members.json
@@ -72,6 +72,7 @@
       "queueTitle": "Pending registrations",
       "queueDescription": "Sign-ups waiting for a decision.",
       "queueEmpty": "No registrations are waiting for review."
-    }
+    },
+    "defaultType": "Default"
   }
 }

--- a/frontend/locales/en/reports.json
+++ b/frontend/locales/en/reports.json
@@ -1,0 +1,13 @@
+{
+  "reports": {
+    "paidTierWithoutPurchase": {
+      "nav": "Paid tier check",
+      "title": "Paid tiers with no purchase behind them",
+      "description": "Members sitting on a membership type that costs money, where no membership fee has ever been paid. Sign-up used to land on whichever type was created first, so some of these were chosen by nobody.",
+      "info": "A member is listed while their membership type costs more than zero and none of their membership receipts has reached paid. Fees already issued and still unpaid are counted here rather than clearing the member — that is what the club is currently asking for. Cancelled, expired and deactivated members are left out. Nothing here changes a member: open the record and decide.",
+      "empty": "No member is on a paid tier without a purchase behind it.",
+      "unpaidReceipts": "Unpaid fees",
+      "unpaidAmount": "Unpaid amount"
+    }
+  }
+}

--- a/frontend/locales/en/settings.json
+++ b/frontend/locales/en/settings.json
@@ -302,6 +302,22 @@
           "description": "Delivery of the announcements admins broadcast."
         }
       }
+    },
+    "registration": {
+      "tab": "Registration",
+      "title": "Public registration",
+      "flowClosed": "Sign-up is closed. Members exist only when an administrator creates them.",
+      "flowApproval": "Anyone can sign up, and every sign-up waits in the pending queue for an administrator. Nothing is billed before that decision.",
+      "flowImmediate": "Anyone can sign up and becomes a member straight away, on the free tier below. Only an administrator ever moves someone to a paid tier.",
+      "publicEnabled": "Allow public sign-up",
+      "publicEnabledDesc": "Show the sign-up form and accept registrations from anyone who reaches it",
+      "requiresApproval": "Review every sign-up",
+      "requiresApprovalDesc": "New sign-ups wait as pending until an administrator approves them; the member number is issued then, so an abandoned sign-up burns none",
+      "defaultTier": "Default membership type",
+      "defaultTierLabel": "Where new sign-ups land",
+      "defaultTierDesc": "Only a free membership type can be the default, so signing up never starts a fee on its own",
+      "noDefaultTier": "None selected",
+      "noFreeTiers": "There is no free membership type yet. Create one under Membership Types and it can become the default."
     }
   }
 }

--- a/frontend/locales/es/members.json
+++ b/frontend/locales/es/members.json
@@ -72,6 +72,7 @@
       "queueTitle": "Altas pendientes",
       "queueDescription": "Solicitudes de alta pendientes de decisión.",
       "queueEmpty": "No hay altas pendientes de revisar."
-    }
+    },
+    "defaultType": "Por defecto"
   }
 }

--- a/frontend/locales/es/reports.json
+++ b/frontend/locales/es/reports.json
@@ -1,0 +1,13 @@
+{
+  "reports": {
+    "paidTierWithoutPurchase": {
+      "nav": "Revisión de cuotas",
+      "title": "Cuotas de pago sin ninguna compra detrás",
+      "description": "Socios con un tipo de membresía que cuesta dinero y sin ninguna cuota pagada. El alta aterrizaba antes en el tipo creado primero, así que a algunos de estos no los eligió nadie.",
+      "info": "Un socio aparece mientras su tipo de membresía cueste más de cero y ninguno de sus recibos de cuota haya llegado a pagado. Las cuotas ya emitidas y aún sin pagar se cuentan aquí en lugar de sacar al socio de la lista: son lo que el club está reclamando ahora mismo. Los socios cancelados, caducados y desactivados quedan fuera. Aquí no se modifica nada: abre la ficha y decide.",
+      "empty": "Ningún socio está en una cuota de pago sin una compra detrás.",
+      "unpaidReceipts": "Cuotas sin pagar",
+      "unpaidAmount": "Importe sin pagar"
+    }
+  }
+}

--- a/frontend/locales/es/settings.json
+++ b/frontend/locales/es/settings.json
@@ -302,6 +302,22 @@
           "description": "Difusión de los anuncios que envían los administradores."
         }
       }
+    },
+    "registration": {
+      "tab": "Registro",
+      "title": "Registro público",
+      "flowClosed": "El registro está cerrado. Solo hay socios si los crea un administrador.",
+      "flowApproval": "Cualquiera puede registrarse y cada alta queda pendiente hasta que un administrador la revisa. No se cobra nada antes de esa decisión.",
+      "flowImmediate": "Cualquiera puede registrarse y pasa a ser socio al momento, en el tipo gratuito de abajo. Solo un administrador mueve a alguien a un tipo de pago.",
+      "publicEnabled": "Permitir el registro público",
+      "publicEnabledDesc": "Muestra el formulario de alta y acepta registros de quien llegue a él",
+      "requiresApproval": "Revisar cada alta",
+      "requiresApprovalDesc": "Las altas nuevas quedan pendientes hasta que un administrador las aprueba; el número de socio se asigna entonces, así que un alta abandonada no gasta ninguno",
+      "defaultTier": "Tipo de membresía por defecto",
+      "defaultTierLabel": "Dónde aterrizan las altas nuevas",
+      "defaultTierDesc": "Solo un tipo de membresía gratuito puede ser el predeterminado, así que registrarse nunca inicia una cuota por sí solo",
+      "noDefaultTier": "Ninguno seleccionado",
+      "noFreeTiers": "Todavía no hay ningún tipo de membresía gratuito. Crea uno en Tipos de membresía y podrá ser el predeterminado."
     }
   }
 }


### PR DESCRIPTION
**Phases 4 and 5 of #143** — the last two. Merging this completes the issue.

Two commits, independent of each other; split them if a reviewer prefers.

## `347ea58` — phase 4: registration settings panel

`get_registration_settings` (`auth/service.py:20`) has always read two keys from `OrganizationSettings.features` — `public_registration` and `registration_requires_approval`, both defaulting to `true` — and **neither had any UI**. They were changeable only by writing the JSON blob through the API, while nine other feature areas each have a settings panel editing their own slice.

The new panel presents all three registration choices as one decision rather than unrelated toggles: sign-up closed; open and auto-activated at the default tier; or open and held for admin approval. It states the resulting behaviour in a sentence so an admin can see what the combination actually does.

It also exposes **which membership type is the default**, which needed a write path: `PUT /membership-types/{id}` now accepts `is_default`, clearing the previous default first.

**Clearing the default is refused with a 400.** The issue asked for a write path without saying what happens when the flag is removed, and a club with no default sends the next sign-up to a `NULL` membership type — the exact regression phase 1's migration went out of its way to avoid. The way to change it is to mark another tier.

A "Default" badge marks the row on the membership-types list.

## `bd57d3b` — phase 5: the clean-up report

Lists the members the old `order_by(id).first()` behaviour left on a paid tier they never chose. A member appears when **all** of:

1. their tier has `base_price > 0`;
2. **no** active receipt of theirs with `origin = 'membership'` has ever reached `paid`;
3. they are active and not `cancelled`/`expired`.

Ordered dearest tier first. Each row carries the count and total of that member's *unpaid* membership receipts.

The rule matters, so the reasoning is worth stating. There is no membership-purchase record yet (#146), so **a settled membership receipt is the closest the schema comes to "somebody bought this"** — money moved against a membership fee, which needs a human on both sides. The tempting alternative, "has no membership receipts at all", clears exactly the wrong people: a member the recurring run has already billed *does* have receipts, they are simply unpaid, and those are the damage rather than evidence against it. So unpaid fees are counted on the row instead — that total is what the club is currently asking for and may want to withdraw.

Closed members are excluded because the recurring biller only touches active ones. It deliberately does **not** narrow to self-registered members: an admin-created member can later gain an account, so `user_id` is not a reliable provenance marker and filtering on it would silently drop real cases.

The report is read-only; bulk reassignment is not in scope. It is gated on `members.read` rather than `reports.read` — the rows are named member records and the follow-up action is on the member's own page.

## Testing

Verified **after rebasing onto `main` with #153 merged**, not against the older base:

- Backend: **1456 passed**, 0 failed
- Frontend: `✓ Compiled successfully`, `✓ Generating static pages (68/68)`, `✔ No ESLint warnings or errors`

Cypress was not run; no spec touches these screens.

## Known gap, pre-existing

`PUT /membership-types/{id}` with an explicit `{"is_default": null}` would set a NOT NULL column to `None` and surface as a 500. The same is already true of `{"name": null}` on that endpoint, so this matches existing repo behaviour rather than hardening one field in isolation. The frontend never sends null.
