### PR TITLE
Tell a member their payment arrived

### DIFF
--- a/backend/app/core/email.py
+++ b/backend/app/core/email.py
@@ -107,6 +107,11 @@ _SUBJECTS = {
         "ca": "Recordatori de pagament: rebut {receipt_number}",
         "en": "Payment reminder: receipt {receipt_number}",
     },
+    "payment_confirmation": {
+        "es": "Pago recibido: recibo {receipt_number}",
+        "ca": "Pagament confirmat: rebut {receipt_number}",
+        "en": "Payment received: receipt {receipt_number}",
+    },
     "mailing_test": {
         "es": "Correo de prueba de Memship",
         "ca": "Correu de prova de Memship",
@@ -668,6 +673,42 @@ def send_payment_reminder_email(
             "org_name": org_name,
             "pay_now_url": pay_now_url,
             "bank_details": bank_details,
+        },
+        subject_args={"receipt_number": receipt_number},
+    )
+
+
+def send_payment_confirmation_email(
+    to: str,
+    member_name: str,
+    receipt_number: str,
+    description: str,
+    amount: str,
+    currency: str,
+    payment_date: str,
+    org_name: str,
+    payment_method_label: str | None = None,
+    locale: str = "es",
+) -> bool:
+    """Tell a member the payment against one of their receipts has landed.
+
+    ``payment_method_label`` is optional and already localized: a member who
+    paid at a checkout watched it succeed, so the row is only worth showing for
+    the methods that settle out of sight.
+    """
+    return _send_templated(
+        "payment_confirmation",
+        to,
+        locale,
+        {
+            "member_name": member_name,
+            "receipt_number": receipt_number,
+            "description": description,
+            "amount": amount,
+            "currency": currency,
+            "payment_date": payment_date,
+            "org_name": org_name,
+            "payment_method_label": payment_method_label,
         },
         subject_args={"receipt_number": receipt_number},
     )

--- a/backend/app/domains/mailing/policy.py
+++ b/backend/app/domains/mailing/policy.py
@@ -57,6 +57,7 @@ CATALOG: tuple[TemplateSpec, ...] = (
     TemplateSpec("booking_cancelled", "bookings", "operational"),
     TemplateSpec("receipt_delivery", "billing", "operational"),
     TemplateSpec("payment_reminder", "billing", "operational"),
+    TemplateSpec("payment_confirmation", "billing", "operational"),
     TemplateSpec("billing_summary", "billing", "optional"),
     TemplateSpec("announcement", "broadcasts", "optional"),
 )

--- a/backend/app/tasks/billing_tasks.py
+++ b/backend/app/tasks/billing_tasks.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from sqlalchemy.orm import Session
+
 from app.core.celery_app import celery
 
 logger = logging.getLogger(__name__)
@@ -104,15 +106,76 @@ def payment_notifications_fanout(receipt_ids: list[int]) -> int:
     return len(receipt_ids)
 
 
+def _send_payment_confirmation(db: Session, receipt_id: int) -> bool:
+    """Compose and send the confirmation for one receipt that has been paid.
+
+    Only what the receipt itself carries reaches the member: number, concept,
+    amount, payment date and — when the method settles out of sight — how it was
+    paid. Nothing about the mandate or the account it was collected from; a
+    member does not expect their bank details in an inbox.
+    """
+    from app.core.email import send_payment_confirmation_email
+    from app.domains.billing.models import Receipt
+    from app.domains.billing.pdf import PAYMENT_METHOD_LABELS
+    from app.domains.members.models import Member
+    from app.domains.organizations.models import OrganizationSettings
+    from app.domains.persons.models import Person
+
+    receipt = db.query(Receipt).filter(Receipt.id == receipt_id).first()
+    if not receipt:
+        logger.warning(f"Receipt {receipt_id} not found for payment notification")
+        return False
+
+    member = db.query(Member).filter(Member.id == receipt.member_id).first()
+    person = (
+        db.query(Person).filter(Person.id == member.person_id).first() if member else None
+    )
+    if not person or not person.email:
+        logger.warning(f"No email for the payer of receipt {receipt_id}")
+        return False
+
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    locale = (org.locale if org else None) or "es"
+    labels = PAYMENT_METHOD_LABELS.get(locale, PAYMENT_METHOD_LABELS["es"])
+
+    return send_payment_confirmation_email(
+        to=person.email,
+        member_name=" ".join(filter(None, [person.first_name, person.last_name]))
+        or person.email,
+        receipt_number=receipt.receipt_number,
+        description=receipt.description,
+        amount=f"{receipt.total_amount:.2f}",
+        currency=(org.currency if org else None) or "EUR",
+        payment_date=receipt.payment_date.isoformat() if receipt.payment_date else "",
+        org_name=(org.name if org else None) or "Memship",
+        payment_method_label=labels.get(receipt.payment_method),
+        locale=locale,
+    )
+
+
 @celery.task(bind=True, max_retries=3, default_retry_delay=60)
 def send_payment_notification(self, receipt_id: int) -> bool:
     """Send the outbound notifications owed for one paid receipt.
 
     The seam for anything that must be *sent* after a payment, as opposed to
     written: those effects run inline in ``mark_receipt_paid``, inside the
-    transaction that records the payment. Nothing is sent today — the club has
-    no payment-confirmation mail configured — so this is the place to add one
-    rather than a fourth call site to wire up.
+    transaction that records the payment.
+
+    Today that is the payment confirmation, which matters most for the methods
+    that settle out of the member's sight — a SEPA collection reconciled days
+    later, cash or a transfer marked paid by an admin. Off until the club
+    switches it on, like every catalogued template.
     """
-    logger.debug(f"No payment notification configured for receipt {receipt_id}")
-    return False
+    from app.db.session import SessionLocal
+
+    try:
+        db = SessionLocal()
+        try:
+            return _send_payment_confirmation(db, receipt_id)
+        finally:
+            db.close()
+    except Exception as exc:
+        logger.error(
+            f"Payment notification failed: receipt_id={receipt_id}, error={exc}"
+        )
+        raise self.retry(exc=exc)

--- a/backend/app/templates/email/payment_confirmation_ca.html
+++ b/backend/app/templates/email/payment_confirmation_ca.html
@@ -1,0 +1,20 @@
+{% extends "_base.html" %}
+{% import "_components.html" as c with context %}
+
+{% block preheader %}Hem registrat el pagament del rebut {{ receipt_number }}.{% endblock %}
+
+{% block content %}
+<h1 style="{{ s.h1 }}">Pagament confirmat</h1>
+<p style="{{ s.p }}">Hola {{ member_name }},</p>
+<p style="{{ s.p }}">Hem registrat el pagament del rebut següent. No has de fer res més.</p>
+{% call c.panel() %}
+{{ c.data_row("Rebut", receipt_number) }}
+{{ c.data_row("Concepte", description) }}
+{{ c.data_row("Import", amount ~ " " ~ currency) }}
+{{ c.data_row("Data de pagament", payment_date) }}
+{%- if payment_method_label %}
+{{ c.data_row("Forma de pagament", payment_method_label) }}
+{%- endif %}
+{% endcall %}
+<p style="{{ s.note_last }}">Si detectes cap error, posa't en contacte amb nosaltres.</p>
+{% endblock %}

--- a/backend/app/templates/email/payment_confirmation_en.html
+++ b/backend/app/templates/email/payment_confirmation_en.html
@@ -1,0 +1,20 @@
+{% extends "_base.html" %}
+{% import "_components.html" as c with context %}
+
+{% block preheader %}We have recorded the payment of receipt {{ receipt_number }}.{% endblock %}
+
+{% block content %}
+<h1 style="{{ s.h1 }}">Payment received</h1>
+<p style="{{ s.p }}">Hi {{ member_name }},</p>
+<p style="{{ s.p }}">We have recorded the payment of the following receipt. There is nothing else for you to do.</p>
+{% call c.panel() %}
+{{ c.data_row("Receipt", receipt_number) }}
+{{ c.data_row("Description", description) }}
+{{ c.data_row("Amount", amount ~ " " ~ currency) }}
+{{ c.data_row("Payment date", payment_date) }}
+{%- if payment_method_label %}
+{{ c.data_row("Payment method", payment_method_label) }}
+{%- endif %}
+{% endcall %}
+<p style="{{ s.note_last }}">If anything looks wrong, please get in touch with us.</p>
+{% endblock %}

--- a/backend/app/templates/email/payment_confirmation_es.html
+++ b/backend/app/templates/email/payment_confirmation_es.html
@@ -1,0 +1,20 @@
+{% extends "_base.html" %}
+{% import "_components.html" as c with context %}
+
+{% block preheader %}Hemos registrado el pago del recibo {{ receipt_number }}.{% endblock %}
+
+{% block content %}
+<h1 style="{{ s.h1 }}">Pago recibido</h1>
+<p style="{{ s.p }}">Hola {{ member_name }},</p>
+<p style="{{ s.p }}">Hemos registrado el pago del siguiente recibo. No tienes que hacer nada más.</p>
+{% call c.panel() %}
+{{ c.data_row("Recibo", receipt_number) }}
+{{ c.data_row("Concepto", description) }}
+{{ c.data_row("Importe", amount ~ " " ~ currency) }}
+{{ c.data_row("Fecha de pago", payment_date) }}
+{%- if payment_method_label %}
+{{ c.data_row("Forma de pago", payment_method_label) }}
+{%- endif %}
+{% endcall %}
+<p style="{{ s.note_last }}">Si detectas algún error, ponte en contacto con nosotros.</p>
+{% endblock %}

--- a/backend/tests/integration/test_receipt_payment.py
+++ b/backend/tests/integration/test_receipt_payment.py
@@ -282,6 +282,91 @@ class TestDispatchPaymentNotifications:
         assert [call.args[0] for call in delay.call_args_list] == [7, 8]
 
 
+class TestThePaymentConfirmation:
+    """What the fanned-out task actually sends, once a club has switched it on."""
+
+    def _paid(self, db, suffix, method="direct_debit"):
+        member = _create_member(db, suffix)
+        receipt = _create_receipt(db, member, suffix)
+        mark_receipt_paid(
+            db, receipt, payment_method=method, payment_date=date(2026, 4, 15)
+        )
+        return receipt
+
+    def test_it_tells_the_member_the_amount_the_concept_and_the_date(self, db):
+        from app.tasks.billing_tasks import _send_payment_confirmation
+
+        receipt = self._paid(db, "conf-body")
+
+        with patch("app.core.email._template_enabled", return_value=True), patch(
+            "app.core.email.send_email", return_value=True
+        ) as send:
+            assert _send_payment_confirmation(db, receipt.id) is True
+
+        to, subject, html = send.call_args[0]
+        assert to == "conf-body@pay-test.example"
+        assert receipt.receipt_number in subject
+        assert "Membership fee" in html
+        assert "121.00 EUR" in html
+        assert "2026-04-15" in html
+
+    def test_a_direct_debit_says_so(self, db):
+        """The case with no other signal: the label is the reassurance."""
+        from app.tasks.billing_tasks import _send_payment_confirmation
+
+        receipt = self._paid(db, "conf-sepa")
+
+        with patch("app.core.email._template_enabled", return_value=True), patch(
+            "app.core.email.send_email", return_value=True
+        ) as send:
+            _send_payment_confirmation(db, receipt.id)
+
+        assert "Domiciliación bancaria" in send.call_args[0][2]
+
+    def test_a_checkout_payment_leaves_the_method_row_out(self, db):
+        from app.tasks.billing_tasks import _send_payment_confirmation
+
+        receipt = self._paid(db, "conf-stripe", method="stripe_checkout")
+
+        with patch("app.core.email._template_enabled", return_value=True), patch(
+            "app.core.email.send_email", return_value=True
+        ) as send:
+            _send_payment_confirmation(db, receipt.id)
+
+        html = send.call_args[0][2]
+        assert "stripe_checkout" not in html
+        assert "Forma de pago" not in html
+
+    def test_nothing_is_sent_without_an_address(self, db):
+        from app.tasks.billing_tasks import _send_payment_confirmation
+
+        receipt = self._paid(db, "conf-noaddr")
+        member = db.query(Member).filter(Member.id == receipt.member_id).first()
+        db.query(Person).filter(Person.id == member.person_id).first().email = None
+        db.flush()
+
+        with patch("app.core.email.send_email") as send:
+            assert _send_payment_confirmation(db, receipt.id) is False
+        send.assert_not_called()
+
+    def test_an_unknown_receipt_is_not_a_failure(self, db):
+        from app.tasks.billing_tasks import _send_payment_confirmation
+
+        with patch("app.core.email.send_email") as send:
+            assert _send_payment_confirmation(db, 999_999) is False
+        send.assert_not_called()
+
+    def test_an_untouched_install_sends_nothing(self, db):
+        """Default-off: the catalogue entry alone mails nobody."""
+        from app.tasks.billing_tasks import _send_payment_confirmation
+
+        receipt = self._paid(db, "conf-off")
+
+        with patch("app.core.email.send_email") as send:
+            assert _send_payment_confirmation(db, receipt.id) is False
+        send.assert_not_called()
+
+
 # --- The three write sites ---
 
 

--- a/backend/tests/unit/test_email.py
+++ b/backend/tests/unit/test_email.py
@@ -8,6 +8,7 @@ from app.core.email import (
     render_template,
     send_email,
     send_password_reset_email,
+    send_payment_confirmation_email,
     send_registration_cancellation_email,
     send_registration_confirmation_email,
     send_waitlist_promotion_email,
@@ -233,3 +234,100 @@ class TestHighLevelEmails:
         assert result is True
         subject = mock_send.call_args[0][1]
         assert "Chess Club" in subject
+
+
+PAYMENT_CONFIRMATION = {
+    "member_name": "María Puig",
+    "receipt_number": "FAC-2026-0117",
+    "description": "Cuota anual 2026",
+    "amount": "121.00",
+    "currency": "EUR",
+    "payment_date": "2026-04-15",
+    "org_name": "Club Sant Jordi",
+    "payment_method_label": "Domiciliación bancaria",
+}
+
+
+class TestPaymentConfirmationTemplate:
+    """What a member is told when a payment lands, in all three locales."""
+
+    @pytest.mark.parametrize(
+        "locale,heading",
+        [
+            ("es", "Pago recibido"),
+            # "Pagament rebut: rebut X" collides; Catalan says "confirmat".
+            ("ca", "Pagament confirmat"),
+            ("en", "Payment received"),
+        ],
+    )
+    def test_it_leads_with_the_payment_having_arrived(self, locale, heading):
+        html = render_template("payment_confirmation", locale, dict(PAYMENT_CONFIRMATION))
+        assert heading in html
+
+    @pytest.mark.parametrize("locale", ["es", "ca", "en"])
+    def test_it_carries_the_receipt_the_concept_the_amount_and_the_date(self, locale):
+        html = render_template("payment_confirmation", locale, dict(PAYMENT_CONFIRMATION))
+
+        assert "FAC-2026-0117" in html
+        assert "Cuota anual 2026" in html
+        assert "121.00 EUR" in html
+        assert "2026-04-15" in html
+
+    def test_a_labelled_payment_method_is_shown(self):
+        html = render_template("payment_confirmation", "es", dict(PAYMENT_CONFIRMATION))
+        assert "Domiciliación bancaria" in html
+
+    def test_an_unlabelled_method_drops_the_row(self):
+        """A checkout payer already watched it succeed, and a raw provider name
+        is not something to show a member."""
+        context = dict(PAYMENT_CONFIRMATION, payment_method_label=None)
+        html = render_template("payment_confirmation", "es", context)
+
+        assert "Forma de pago" not in html
+        assert "121.00 EUR" in html
+
+
+class TestPaymentConfirmationSend:
+    @pytest.fixture(autouse=True)
+    def _templates_enabled(self):
+        with patch("app.core.email._template_enabled", return_value=True):
+            yield
+
+    @patch("app.core.email.send_email", return_value=True)
+    def test_the_subject_names_the_receipt(self, mock_send):
+        result = send_payment_confirmation_email("m@example.com", **PAYMENT_CONFIRMATION)
+
+        assert result is True
+        subject = mock_send.call_args[0][1]
+        assert "FAC-2026-0117" in subject
+        assert "Pago recibido" in subject
+
+    @patch("app.core.email.send_email", return_value=True)
+    def test_the_subject_is_localized(self, mock_send):
+        send_payment_confirmation_email(
+            "m@example.com", **PAYMENT_CONFIRMATION, locale="en"
+        )
+
+        assert "Payment received" in mock_send.call_args[0][1]
+
+    @patch("app.core.email.send_email", return_value=True)
+    def test_the_body_reaches_the_member(self, mock_send):
+        send_payment_confirmation_email("m@example.com", **PAYMENT_CONFIRMATION)
+
+        to, _, html = mock_send.call_args[0]
+        assert to == "m@example.com"
+        assert "María Puig" in html
+        assert "121.00 EUR" in html
+
+    def test_it_is_off_until_the_club_switches_it_on(self):
+        """Catalogued and default-off: adding it mails nobody by itself."""
+        with (
+            patch("app.core.email._template_enabled", return_value=False),
+            patch("app.core.email.send_email") as mock_send,
+        ):
+            result = send_payment_confirmation_email(
+                "m@example.com", **PAYMENT_CONFIRMATION
+            )
+
+        assert result is False
+        mock_send.assert_not_called()

--- a/frontend/locales/ca/settings.json
+++ b/frontend/locales/ca/settings.json
@@ -293,6 +293,11 @@
           "description": "Reclama els rebuts vençuts segons la pauta configurada.",
           "warning": "Els rebuts vençuts deixaran de reclamar-se per correu."
         },
+        "payment_confirmation": {
+          "name": "Confirmació de pagament",
+          "description": "Avisa el soci que el seu pagament ha quedat registrat.",
+          "warning": "Qui pagui per domiciliació, efectiu o transferència no tindrà cap senyal que el seu pagament ha arribat."
+        },
         "billing_summary": {
           "name": "Resum de facturació",
           "description": "Resum intern de cada remesa, a l'adreça d'administració."

--- a/frontend/locales/en/settings.json
+++ b/frontend/locales/en/settings.json
@@ -293,6 +293,11 @@
           "description": "Chases overdue receipts on the configured schedule.",
           "warning": "Overdue receipts stop being chased by email."
         },
+        "payment_confirmation": {
+          "name": "Payment confirmation",
+          "description": "Tells the member their payment has been recorded.",
+          "warning": "Members paying by direct debit, cash or transfer get no signal that their payment arrived."
+        },
         "billing_summary": {
           "name": "Billing summary",
           "description": "Internal summary of each billing run, to the admin address."

--- a/frontend/locales/es/settings.json
+++ b/frontend/locales/es/settings.json
@@ -293,6 +293,11 @@
           "description": "Reclama los recibos vencidos según la pauta configurada.",
           "warning": "Los recibos vencidos dejarán de reclamarse por correo."
         },
+        "payment_confirmation": {
+          "name": "Confirmación de pago",
+          "description": "Avisa al socio de que su pago ha quedado registrado.",
+          "warning": "Quien pague por domiciliación, efectivo o transferencia no tendrá ninguna señal de que su pago ha llegado."
+        },
         "billing_summary": {
           "name": "Resumen de facturación",
           "description": "Resumen interno de cada remesa, a la dirección de administración."


### PR DESCRIPTION
Closes #150.

#144 built the whole mechanism for telling a member their payment landed — `mark_receipt_paid` returns the receipts needing a notification, the caller dispatches after commit, one fan-out job queues one task per receipt so a bad address cannot strand the rest — and left `send_payment_notification` as a deliberate stub, because no such message existed. This is the message.

It matters most where the money moves out of sight. Since #142, a SEPA payer has their receipt reconciled days after the collection with nothing telling them; the same holds for cash and bank transfer marked paid by an admin. Card payers at least watched a checkout succeed.

## What it says

Subject *"Pago recibido: recibo FAC-2026-0117"*, then a panel: receipt number, concept, amount, payment date, and payment method.

Content decisions worth reviewing:

- **Only what the receipt carries** — `receipt_number`, `description`, `total_amount` with the org currency, `payment_date`. Nothing invented.
- **Payment method appears only when it has a label.** It resolves through the existing `PAYMENT_METHOD_LABELS` in `billing/pdf.py`, which covers `cash`/`bank_transfer`/`card`/`direct_debit` but not `stripe_checkout`/`redsys`/`bizum`. An unknown method drops the row rather than printing a raw enum at a member — and those payers saw the checkout succeed anyway. (The receipt PDF *does* print the raw value for those three; left alone, pre-existing.)
- **Nothing sensitive.** No IBAN, mandate reference, bank name, `transaction_id` or provider ids. `payment_reminder` can print bank details because it is telling you where to *send* money; a confirmation has no such reason, and where money was collected *from* does not belong in an inbox.

## Tier: `operational`

`policy.py` defines `optional` as "confirmations whose state is visible in the portal anyway" and `operational` as "the member gained or lost something and has no other signal". For a SEPA, cash or transfer payer there genuinely is no other signal, so `operational` is the stronger reading — and it means the settings UI shows a confirmation dialog before an admin switches it off.

**Default is off**, like every catalogued template: a key absent from `communications_config` does not send, and a test asserts this mails nobody until a club enables it.

## Catalan wording

`ca` uses "Pagament confirmat" for both subject and heading rather than the literal parallel, because *rebut* is both "received" and "receipt" — "Pagament rebut: rebut FAC-…" collides with itself. `es` and `en` say received. No other divergence; the three are structurally identical.

## Settings UI

Picked up automatically — `email-templates-settings.tsx` renders whatever `/communications` returns over `CATALOG`, and `billing` is already in `GROUP_ORDER`. **The three locale strings were not optional**, though: without them the row renders raw i18n keys. That is the one piece beyond the issue's checklist.

## Testing

**1463 passed**, 0 failed. 12 unit tests covering rendering in all three locales, the conditional method row, subject localisation and the enabled-gate; 6 integration tests against a real paid receipt.

Frontend build and lint were not run — the only frontend change is three JSON string blocks, verified as parseable and key-parallel across locales.

## Note

`frontend/locales/{es,ca,en}/settings.json` is also touched by PR #155, which appends a `settings.registration` block a few lines from this one's insertion inside `emailTemplates.templates`. Verified non-destructively with `git merge-tree`: no conflict. Whichever merges second may still want a rebase.
