### PR TITLE
Restrict a space to certain membership types

### DIFF
--- a/backend/alembic/versions/b6c7d8e9f0a1_add_space_allowed_membership_types.py
+++ b/backend/alembic/versions/b6c7d8e9f0a1_add_space_allowed_membership_types.py
@@ -1,0 +1,40 @@
+"""add_space_allowed_membership_types
+
+Lets a club keep a space for particular membership types, the way an activity
+already restricts registration. The column is the same shape as
+``activities.allowed_membership_types``: an integer array of membership type
+ids, NULL or empty meaning the space is open to every member.
+
+Every existing space keeps NULL, so nothing that is bookable today stops being
+bookable.
+
+Revision ID: b6c7d8e9f0a1
+Revises: a5b6c7d8e9f0
+Create Date: 2026-09-07 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'b6c7d8e9f0a1'
+down_revision: Union[str, None] = 'a5b6c7d8e9f0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'spaces',
+        sa.Column(
+            'allowed_membership_types',
+            postgresql.ARRAY(sa.Integer()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('spaces', 'allowed_membership_types')

--- a/backend/app/api/v1/endpoints/bookings.py
+++ b/backend/app/api/v1/endpoints/bookings.py
@@ -17,6 +17,7 @@ from app.core.security.dependencies import get_current_user
 from app.db.session import get_db
 from app.domains.auth.models import User
 from app.domains.bookings import service
+from app.domains.bookings.eligibility import check_space_eligibility
 from app.domains.bookings.notifications import EmailBookingNotifier
 from app.domains.bookings.schemas import (
     AdminBookingPage,
@@ -316,7 +317,14 @@ def get_availability(
         raise HTTPException(status_code=404, detail="Space not found")
     member = _current_member(db, current_user)
     cells = service.space_week_availability(db, space, week_start, member.id)
-    return WeekAvailability(space_id=space_id, week_start=week_start, cells=cells)
+    eligibility = check_space_eligibility(space, member)
+    return WeekAvailability(
+        space_id=space_id,
+        week_start=week_start,
+        eligible=eligibility.eligible,
+        ineligible_reason=eligibility.reason,
+        cells=cells,
+    )
 
 
 @member_router.post(
@@ -338,6 +346,13 @@ def create_booking(
         )
     except service.SlotNotFound:
         raise HTTPException(status_code=404, detail="Slot not found")
+    except service.NotEligible as exc:
+        # A member who is not eligible never sees a book button — the week
+        # availability already told the UI so. This is the race: the tier
+        # changed after the calendar loaded.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        )
     except (service.SlotFull, service.DuplicateBooking) as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
     except (

--- a/backend/app/domains/bookings/eligibility.py
+++ b/backend/app/domains/bookings/eligibility.py
@@ -1,0 +1,55 @@
+"""Who may book a space.
+
+``Space.allowed_membership_types`` mirrors ``Activity.allowed_membership_types``:
+a list of membership type ids, and an empty or NULL list means the space is open
+to every member. The check itself is the one in ``activities/eligibility.py``.
+
+Where this parts company with activities is the answer it gives back. Activities
+collapse both failures into one sentence, but a member reads them very
+differently: "the tier you hold is not one of the tiers this space is for" is a
+reason to upgrade, while "you hold no tier at all" is an administrative gap the
+club has to close. The two carry separate reason codes so the UI can say the
+right thing, and the message text follows the code.
+"""
+
+from dataclasses import dataclass
+
+from app.domains.bookings.models import Space
+from app.domains.members.models import Member
+
+#: The member holds a tier, but it is not on the space's allow-list.
+MEMBERSHIP_TYPE_NOT_ALLOWED = "membership_type_not_allowed"
+#: The member holds no tier at all, so no allow-list can ever match.
+NO_MEMBERSHIP_TYPE = "no_membership_type"
+
+_MESSAGES = {
+    MEMBERSHIP_TYPE_NOT_ALLOWED: "Your membership type does not include this space",
+    NO_MEMBERSHIP_TYPE: "You have no membership type assigned",
+}
+
+
+@dataclass(frozen=True)
+class SpaceEligibility:
+    eligible: bool
+    reason: str | None = None
+
+    @property
+    def message(self) -> str | None:
+        return _MESSAGES.get(self.reason) if self.reason else None
+
+
+ELIGIBLE = SpaceEligibility(eligible=True)
+
+
+def check_space_eligibility(space: Space, member: Member) -> SpaceEligibility:
+    """Whether ``member`` may hold a booking in ``space``."""
+    allowed = space.allowed_membership_types
+    if not allowed:
+        return ELIGIBLE
+    if not member.membership_type_id:
+        return SpaceEligibility(eligible=False, reason=NO_MEMBERSHIP_TYPE)
+    if member.membership_type_id not in allowed:
+        return SpaceEligibility(
+            eligible=False, reason=MEMBERSHIP_TYPE_NOT_ALLOWED
+        )
+    return ELIGIBLE

--- a/backend/app/domains/bookings/models.py
+++ b/backend/app/domains/bookings/models.py
@@ -28,7 +28,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import relationship
 
 from app.db.base import Base
@@ -47,6 +47,9 @@ class Space(Base):
     description = Column(Text)
     open_time = Column(Time, nullable=False)
     close_time = Column(Time, nullable=False)
+    # Membership type ids allowed to book. Empty or NULL = open to every member,
+    # the same reading as Activity.allowed_membership_types.
+    allowed_membership_types = Column(ARRAY(Integer))
     is_active = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(

--- a/backend/app/domains/bookings/schemas.py
+++ b/backend/app/domains/bookings/schemas.py
@@ -17,6 +17,8 @@ class SpaceCreate(BaseModel):
     description: str | None = None
     open_time: time
     close_time: time
+    # Empty or omitted means the space is open to every member.
+    allowed_membership_types: list[int] | None = None
     is_active: bool = True
 
     @model_validator(mode="after")
@@ -32,6 +34,7 @@ class SpaceUpdate(BaseModel):
     description: str | None = None
     open_time: time | None = None
     close_time: time | None = None
+    allowed_membership_types: list[int] | None = None
     is_active: bool | None = None
 
 
@@ -44,6 +47,7 @@ class SpaceRead(BaseModel):
     description: str | None
     open_time: time
     close_time: time
+    allowed_membership_types: list[int] | None
     is_active: bool
     created_at: datetime | None
     updated_at: datetime | None
@@ -181,4 +185,10 @@ class AvailabilityCell(BaseModel):
 class WeekAvailability(BaseModel):
     space_id: int
     week_start: date
+    # False when the space is restricted to membership types the member does not
+    # hold. The cells are still returned so the week reads normally, but nothing
+    # in it can be booked — the reason code says which of the two failures it is:
+    # membership_type_not_allowed | no_membership_type
+    eligible: bool = True
+    ineligible_reason: str | None = None
     cells: list[AvailabilityCell]

--- a/backend/app/domains/bookings/service.py
+++ b/backend/app/domains/bookings/service.py
@@ -20,6 +20,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy import func
 from sqlalchemy.orm import Query, Session, joinedload
 
+from app.domains.bookings.eligibility import check_space_eligibility
 from app.domains.bookings.models import Booking, Space, SpaceSlot
 from app.domains.bookings.notifications import (
     BookingNotification,
@@ -82,6 +83,18 @@ class BookingWindowExceeded(BookingError):
 
 class DuplicateBooking(BookingError):
     pass
+
+
+class NotEligible(BookingError):
+    """The member's membership type does not allow booking this space.
+
+    Carries the reason code from ``eligibility`` so the caller can tell
+    "your tier is not on the list" apart from "you have no tier".
+    """
+
+    def __init__(self, reason: str, message: str):
+        super().__init__(message)
+        self.reason = reason
 
 
 class CancellationTooLate(BookingError):
@@ -159,6 +172,7 @@ def create_space(db: Session, data: SpaceCreate) -> Space:
         description=data.description,
         open_time=data.open_time,
         close_time=data.close_time,
+        allowed_membership_types=data.allowed_membership_types or None,
         is_active=data.is_active,
     )
     db.add(space)
@@ -167,6 +181,12 @@ def create_space(db: Session, data: SpaceCreate) -> Space:
 
 def update_space(db: Session, space: Space, data: SpaceUpdate) -> Space:
     payload = data.model_dump(exclude_unset=True)
+    if "allowed_membership_types" in payload:
+        # An empty list and NULL both mean "open to everyone"; store one of them
+        # so the column has a single reading.
+        payload["allowed_membership_types"] = (
+            payload["allowed_membership_types"] or None
+        )
     for key, value in payload.items():
         setattr(space, key, value)
     if space.close_time <= space.open_time:
@@ -591,6 +611,10 @@ def create_booking(
     if space is None or not space.is_active:
         raise SlotNotFound(str(space_slot_id))
 
+    eligibility = check_space_eligibility(space, member)
+    if not eligibility.eligible:
+        raise NotEligible(eligibility.reason, eligibility.message)
+
     tz = _tz(db)
     now_local = datetime.now(tz)
     slot_start = datetime.combine(slot.slot_date, slot.start_time, tzinfo=tz)
@@ -693,31 +717,53 @@ def cancel_booking(
     if was_booked:
         booked = _count(db, slot.id, BookingStatus.BOOKED)
         if booked < slot.capacity:
-            promoted = (
-                db.query(Booking)
-                .filter(
-                    Booking.space_slot_id == slot.id,
-                    Booking.status == BookingStatus.WAITLISTED,
-                )
-                .order_by(Booking.waitlisted_at.asc(), Booking.id.asc())
-                .first()
-            )
-            if promoted is not None:
-                promoted.status = BookingStatus.BOOKED
-                promoted.waitlisted_at = None
-                db.flush()
-                space = get_space(db, slot.space_id)
-                member = (
-                    db.query(Member)
-                    .options(joinedload(Member.person))
-                    .filter(Member.id == promoted.member_id)
-                    .first()
-                )
-                if member is not None and space is not None:
-                    notifier.send_promoted(
-                        _notification(db, promoted, slot, space, member)
-                    )
+            _promote_next(db, slot, notifier)
     return booking
+
+
+def _promote_next(
+    db: Session, slot: SpaceSlot, notifier: BookingNotifier
+) -> Booking | None:
+    """Promote the earliest waitlisted member who may still hold the slot.
+
+    Promotion is a confirmation path, so it re-checks eligibility rather than
+    trusting the check that ran when the member joined the waitlist: a tier can
+    be changed or cleared while a member waits, and promoting them would hand
+    them a seat in a space they are no longer allowed to use. An ineligible
+    member is skipped and keeps their place on the waitlist — the seat goes to
+    the next eligible one, and nobody is silently cancelled for an
+    administrative change they did not make.
+    """
+    space = get_space(db, slot.space_id)
+    candidates = (
+        db.query(Booking)
+        .filter(
+            Booking.space_slot_id == slot.id,
+            Booking.status == BookingStatus.WAITLISTED,
+        )
+        .order_by(Booking.waitlisted_at.asc(), Booking.id.asc())
+        .all()
+    )
+    for candidate in candidates:
+        member = (
+            db.query(Member)
+            .options(joinedload(Member.person))
+            .filter(Member.id == candidate.member_id)
+            .first()
+        )
+        if member is None:
+            continue
+        if space is not None and not check_space_eligibility(space, member).eligible:
+            continue
+        candidate.status = BookingStatus.BOOKED
+        candidate.waitlisted_at = None
+        db.flush()
+        if space is not None:
+            notifier.send_promoted(
+                _notification(db, candidate, slot, space, member)
+            )
+        return candidate
+    return None
 
 
 # --- Reads ----------------------------------------------------------------

--- a/backend/tests/integration/api/v1/test_bookings.py
+++ b/backend/tests/integration/api/v1/test_bookings.py
@@ -6,7 +6,7 @@ import pytest
 
 from app.core.security.password import hash_password
 from app.domains.auth.models import User
-from app.domains.members.models import Member
+from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
 
@@ -54,7 +54,7 @@ def _user(db, role="admin", email=None):
     return user
 
 
-def _member_user(db, email):
+def _member_user(db, email, membership_type=None):
     person = Person(first_name="Mem", last_name="Ber", email=email)
     db.add(person)
     db.flush()
@@ -65,30 +65,37 @@ def _member_user(db, email):
     db.add(user)
     db.flush()
     member = Member(
-        person_id=person.id, user_id=user.id, status="active", is_active=True
+        person_id=person.id, user_id=user.id, status="active", is_active=True,
+        membership_type_id=membership_type.id if membership_type else None,
     )
     db.add(member)
     db.flush()
     return user, member
 
 
+def _membership_type(db, slug):
+    mt = MembershipType(name=slug.title(), slug=slug, is_active=True)
+    db.add(mt)
+    db.flush()
+    return mt
+
+
 def _future(days=3):
     return date.today() + timedelta(days=days)
 
 
-def _make_space(client, admin, *, open_="08:00:00", close="22:00:00"):
-    sp = client.post(
-        "/api/v1/spaces",
-        json={"name": "Court 1", "open_time": open_, "close_time": close},
-        cookies=_auth(admin),
-    )
+def _make_space(client, admin, *, open_="08:00:00", close="22:00:00", allowed=None):
+    body = {"name": "Court 1", "open_time": open_, "close_time": close}
+    if allowed is not None:
+        body["allowed_membership_types"] = allowed
+    sp = client.post("/api/v1/spaces", json=body, cookies=_auth(admin))
     assert sp.status_code == 201, sp.text
     return sp.json()["id"]
 
 
-def _make_space_and_slot(client, admin, *, capacity=1, on=None):
+def _make_space_and_slot(client, admin, *, capacity=1, on=None, allowed=None):
     on = on or _future(3)
-    space_id = _make_space(client, admin)
+    space_id = _make_space(client, admin, allowed=allowed)
     sl = client.post(
         f"/api/v1/spaces/{space_id}/slots",
         json={
@@ -440,3 +447,128 @@ class TestAdminBookingsView:
         assert body["meta"]["total"] == 1
         assert body["items"][0]["member_name"]
         assert body["items"][0]["slot_date"] == _future(3).isoformat()
+
+
+class TestMembershipGating:
+    """A space restricted to membership types refuses the wrong tier, and says
+    which of the two things went wrong."""
+
+    def test_admin_sets_and_clears_the_allow_list(self, client, db):
+        _org(db)
+        admin = _user(db, "admin")
+        premium = _membership_type(db, "premium-gate")
+        space_id = _make_space(client, admin, allowed=[premium.id])
+
+        r = client.get(f"/api/v1/spaces/{space_id}", cookies=_auth(admin))
+        assert r.json()["allowed_membership_types"] == [premium.id]
+
+        r = client.put(
+            f"/api/v1/spaces/{space_id}",
+            json={"allowed_membership_types": []},
+            cookies=_auth(admin),
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["allowed_membership_types"] is None
+
+    def test_allowed_member_books(self, client, db):
+        _org(db)
+        admin = _user(db, "admin")
+        premium = _membership_type(db, "premium-books")
+        _space_id, slot_id = _make_space_and_slot(
+            client, admin, allowed=[premium.id]
+        )
+        user, _ = _member_user(db, "ok@examplee6e3b1.com", membership_type=premium)
+
+        r = client.post(
+            "/api/v1/bookings",
+            json={"space_slot_id": slot_id},
+            cookies=_auth(user),
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["status"] == "booked"
+
+    def test_member_on_another_tier_is_forbidden(self, client, db):
+        _org(db)
+        admin = _user(db, "admin")
+        premium = _membership_type(db, "premium-blocks")
+        basic = _membership_type(db, "basic-blocked")
+        _space_id, slot_id = _make_space_and_slot(
+            client, admin, allowed=[premium.id]
+        )
+        user, _ = _member_user(db, "no@examplee6e3b1.com", membership_type=basic)
+
+        r = client.post(
+            "/api/v1/bookings",
+            json={"space_slot_id": slot_id},
+            cookies=_auth(user),
+        )
+        assert r.status_code == 403
+        assert "membership type does not include" in r.json()["detail"]
+
+    def test_member_with_no_tier_is_told_something_else(self, client, db):
+        _org(db)
+        admin = _user(db, "admin")
+        premium = _membership_type(db, "premium-untyped")
+        _space_id, slot_id = _make_space_and_slot(
+            client, admin, allowed=[premium.id]
+        )
+        user, _ = _member_user(db, "none@examplee6e3b1.com")
+
+        r = client.post(
+            "/api/v1/bookings",
+            json={"space_slot_id": slot_id},
+            cookies=_auth(user),
+        )
+        assert r.status_code == 403
+        assert "no membership type assigned" in r.json()["detail"]
+
+    def test_availability_reports_the_restriction(self, client, db):
+        _org(db)
+        admin = _user(db, "admin")
+        premium = _membership_type(db, "premium-avail")
+        basic = _membership_type(db, "basic-avail")
+        space_id, _slot_id = _make_space_and_slot(
+            client, admin, allowed=[premium.id]
+        )
+        blocked, _ = _member_user(
+            db, "blocked@examplee6e3b1.com", membership_type=basic
+        )
+        untyped, _ = _member_user(db, "untyped@examplee6e3b1.com")
+        allowed_user, _ = _member_user(
+            db, "allowed@examplee6e3b1.com", membership_type=premium
+        )
+        week = (_future(3) - timedelta(days=_future(3).weekday())).isoformat()
+        url = f"/api/v1/spaces/{space_id}/availability?week_start={week}"
+
+        body = client.get(url, cookies=_auth(blocked)).json()
+        assert body["eligible"] is False
+        assert body["ineligible_reason"] == "membership_type_not_allowed"
+        # The week still comes back, so the member sees what they are missing.
+        assert body["cells"]
+
+        body = client.get(url, cookies=_auth(untyped)).json()
+        assert body["ineligible_reason"] == "no_membership_type"
+
+        body = client.get(url, cookies=_auth(allowed_user)).json()
+        assert body["eligible"] is True
+        assert body["ineligible_reason"] is None
+
+    def test_unrestricted_space_stays_open(self, client, db):
+        _org(db)
+        admin = _user(db, "admin")
+        space_id, slot_id = _make_space_and_slot(client, admin)
+        user, _ = _member_user(db, "open@examplee6e3b1.com")
+        week = (_future(3) - timedelta(days=_future(3).weekday())).isoformat()
+
+        body = client.get(
+            f"/api/v1/spaces/{space_id}/availability?week_start={week}",
+            cookies=_auth(user),
+        ).json()
+        assert body["eligible"] is True
+
+        r = client.post(
+            "/api/v1/bookings",
+            json={"space_slot_id": slot_id},
+            cookies=_auth(user),
+        )
+        assert r.status_code == 201

--- a/backend/tests/integration/test_bookings_service.py
+++ b/backend/tests/integration/test_bookings_service.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 
 from app.core.security.password import hash_password
 from app.domains.auth.models import User
-from app.domains.bookings import service
+from app.domains.bookings import eligibility, service
 from app.domains.bookings.models import Space, SpaceSlot
 from app.domains.bookings.schemas import (
     SlotRepeat,
@@ -21,7 +21,7 @@ from app.domains.bookings.schemas import (
     SpaceSlotUpdate,
     SpaceUpdate,
 )
-from app.domains.members.models import Member
+from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
 
@@ -55,14 +55,26 @@ def _org(db, **features):
     return org
 
 
-def _member(db, i=0):
+def _member(db, i=0, membership_type=None):
     person = Person(first_name=f"M{i}", last_name="T", email=f"m{i}@t.com")
     db.add(person)
     db.flush()
-    m = Member(person_id=person.id, status="active", is_active=True)
+    m = Member(
+        person_id=person.id,
+        status="active",
+        is_active=True,
+        membership_type_id=membership_type.id if membership_type else None,
+    )
     db.add(m)
     db.flush()
     return m
+
+
+def _membership_type(db, slug):
+    mt = MembershipType(name=slug.title(), slug=slug, is_active=True)
+    db.add(mt)
+    db.flush()
+    return mt
 
 
 def _user(db, i=0):
@@ -78,8 +90,14 @@ def _user(db, i=0):
     return user
 
 
-def _space(db):
-    s = Space(name="Court 1", open_time=time(8, 0), close_time=time(22, 0), is_active=True)
+def _space(db, allowed_membership_types=None):
+    s = Space(
+        name="Court 1",
+        open_time=time(8, 0),
+        close_time=time(22, 0),
+        allowed_membership_types=allowed_membership_types,
+        is_active=True,
+    )
     db.add(s)
     db.flush()
     return s
@@ -719,3 +737,172 @@ def test_my_bookings_reports_occupancy(db):
     assert mine[0]["slot_date"] == slot.slot_date
     assert mine[0]["capacity"] == 3
     assert mine[0]["booked_count"] == 2
+
+
+# --- Membership-type gating ------------------------------------------------
+#
+# `Space.allowed_membership_types` reads exactly like the activity column of the
+# same name: a list of ids, empty or NULL meaning open to everybody. What the
+# bookings side adds is telling the two failures apart — the member on a tier
+# that is not on the list and the member on no tier at all get different reason
+# codes, because they are different problems with different fixes.
+
+
+def test_member_on_an_allowed_type_books(db):
+    _org(db)
+    allowed = _membership_type(db, "premium")
+    space = _space(db, allowed_membership_types=[allowed.id])
+    slot = _slot(db, space, _future(3), capacity=1)
+    member = _member(db, 1, membership_type=allowed)
+
+    booking = service.create_booking(db, member, slot.id)
+
+    assert booking.status == "booked"
+
+
+def test_member_on_another_type_refused(db):
+    _org(db)
+    allowed = _membership_type(db, "premium")
+    other = _membership_type(db, "basic")
+    space = _space(db, allowed_membership_types=[allowed.id])
+    slot = _slot(db, space, _future(3), capacity=1)
+    member = _member(db, 1, membership_type=other)
+
+    with pytest.raises(service.NotEligible) as exc:
+        service.create_booking(db, member, slot.id)
+
+    assert exc.value.reason == eligibility.MEMBERSHIP_TYPE_NOT_ALLOWED
+
+
+def test_member_without_a_membership_type_refused_for_its_own_reason(db):
+    _org(db)
+    allowed = _membership_type(db, "premium")
+    space = _space(db, allowed_membership_types=[allowed.id])
+    slot = _slot(db, space, _future(3), capacity=1)
+    member = _member(db, 1, membership_type=None)
+
+    with pytest.raises(service.NotEligible) as exc:
+        service.create_booking(db, member, slot.id)
+
+    assert exc.value.reason == eligibility.NO_MEMBERSHIP_TYPE
+    assert str(exc.value) != eligibility.SpaceEligibility(
+        eligible=False, reason=eligibility.MEMBERSHIP_TYPE_NOT_ALLOWED
+    ).message
+
+
+@pytest.mark.parametrize("allowed", [None, []])
+def test_unrestricted_space_is_open_to_everyone(db, allowed):
+    _org(db)
+    space = _space(db, allowed_membership_types=allowed)
+    slot = _slot(db, space, _future(3), capacity=2)
+    typed = _member(db, 1, membership_type=_membership_type(db, "basic"))
+    untyped = _member(db, 2, membership_type=None)
+
+    assert service.create_booking(db, typed, slot.id).status == "booked"
+    assert service.create_booking(db, untyped, slot.id).status == "booked"
+
+
+def test_gating_a_space_does_not_touch_its_other_slots_rules(db):
+    """The gate is the only new refusal — a full slot still waitlists."""
+    _org(db)
+    allowed = _membership_type(db, "premium")
+    space = _space(db, allowed_membership_types=[allowed.id])
+    slot = _slot(db, space, _future(3), capacity=1)
+    m1 = _member(db, 1, membership_type=allowed)
+    m2 = _member(db, 2, membership_type=allowed)
+
+    service.create_booking(db, m1, slot.id)
+
+    assert service.create_booking(db, m2, slot.id).status == "waitlisted"
+
+
+def test_promotion_skips_a_member_who_lost_their_tier(db):
+    """Promotion is a confirmation path, so it re-checks the gate.
+
+    The first waitlisted member's tier is cleared while they wait. Promoting
+    them would hand them a seat in a space they may no longer use, so the seat
+    goes to the next eligible member and they keep their waitlist row.
+    """
+    _org(db, booking_cancellation_deadline_hours=0)
+    allowed = _membership_type(db, "premium")
+    space = _space(db, allowed_membership_types=[allowed.id])
+    slot = _slot(db, space, _future(3), capacity=1)
+    holder = _member(db, 1, membership_type=allowed)
+    lapsed = _member(db, 2, membership_type=allowed)
+    still_allowed = _member(db, 3, membership_type=allowed)
+    notifier = RecordingNotifier()
+
+    held = service.create_booking(db, holder, slot.id, notifier=notifier)
+    first = service.create_booking(db, lapsed, slot.id, notifier=notifier)
+    second = service.create_booking(db, still_allowed, slot.id, notifier=notifier)
+    assert (first.status, second.status) == ("waitlisted", "waitlisted")
+
+    lapsed.membership_type_id = None
+    db.flush()
+
+    canceller = _user(db, 9)
+    service.cancel_booking(
+        db, held, cancelled_by_user_id=canceller.id, is_admin=False, notifier=notifier
+    )
+    db.refresh(first)
+    db.refresh(second)
+
+    assert first.status == "waitlisted"
+    assert second.status == "booked"
+    assert notifier.calls[-1][0] == "promoted"
+
+
+def test_promotion_leaves_the_seat_open_when_nobody_waiting_is_eligible(db):
+    _org(db, booking_cancellation_deadline_hours=0)
+    allowed = _membership_type(db, "premium")
+    space = _space(db, allowed_membership_types=[allowed.id])
+    slot = _slot(db, space, _future(3), capacity=1)
+    holder = _member(db, 1, membership_type=allowed)
+    lapsed = _member(db, 2, membership_type=allowed)
+    notifier = RecordingNotifier()
+
+    held = service.create_booking(db, holder, slot.id, notifier=notifier)
+    waiting = service.create_booking(db, lapsed, slot.id, notifier=notifier)
+
+    lapsed.membership_type_id = None
+    db.flush()
+
+    canceller = _user(db, 9)
+    service.cancel_booking(
+        db, held, cancelled_by_user_id=canceller.id, is_admin=False, notifier=notifier
+    )
+    db.refresh(waiting)
+
+    assert waiting.status == "waitlisted"
+    assert [c[0] for c in notifier.calls].count("promoted") == 0
+
+
+def test_unrestricted_space_still_promotes_the_earliest_waitlisted(db):
+    _org(db, booking_cancellation_deadline_hours=0)
+    space = _space(db)
+    slot = _slot(db, space, _future(3), capacity=1)
+    m1, m2 = _member(db, 1), _member(db, 2)
+    notifier = RecordingNotifier()
+
+    b1 = service.create_booking(db, m1, slot.id, notifier=notifier)
+    b2 = service.create_booking(db, m2, slot.id, notifier=notifier)
+
+    canceller = _user(db, 9)
+    service.cancel_booking(
+        db, b1, cancelled_by_user_id=canceller.id, is_admin=False, notifier=notifier
+    )
+    db.refresh(b2)
+
+    assert b2.status == "booked"
+
+
+def test_update_space_stores_an_empty_allow_list_as_open(db):
+    """Empty and NULL must not be two different states in the column."""
+    _org(db)
+    allowed = _membership_type(db, "premium")
+    space = _space(db, allowed_membership_types=[allowed.id])
+
+    service.update_space(db, space, SpaceUpdate(allowed_membership_types=[]))
+    db.flush()
+
+    assert space.allowed_membership_types is None

--- a/frontend/features/bookings/components/space-detail-section.tsx
+++ b/frontend/features/bookings/components/space-detail-section.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { DetailSection } from "@/components/entity/detail-section";
+import { useMembershipTypes } from "@/features/members/hooks/use-members";
 import type { Space } from "../services/bookings-api";
 
 interface SpaceDetailSectionProps {
@@ -10,6 +11,15 @@ interface SpaceDetailSectionProps {
 
 export function SpaceDetailSection({ space }: SpaceDetailSectionProps) {
   const t = useTranslations();
+  const { data: membershipTypes } = useMembershipTypes();
+
+  const allowed = space.allowed_membership_types ?? [];
+  const allowedNames = allowed
+    .map(
+      (id) =>
+        membershipTypes?.find((mt) => mt.id === id)?.name ?? String(id)
+    )
+    .join(", ");
 
   const fields = [
     { label: t("bookings.spaces.name"), value: space.name, inline: true },
@@ -24,6 +34,13 @@ export function SpaceDetailSection({ space }: SpaceDetailSectionProps) {
       value: space.is_active
         ? t("bookings.spaces.active")
         : t("bookings.spaces.inactive"),
+      inline: true,
+    },
+    {
+      label: t("bookings.spaces.allowedTypes"),
+      value: allowed.length
+        ? allowedNames
+        : t("bookings.spaces.allowedTypesOpen"),
       inline: true,
     },
     { label: t("bookings.spaces.description"), value: space.description },

--- a/frontend/features/bookings/components/space-form.tsx
+++ b/frontend/features/bookings/components/space-form.tsx
@@ -11,12 +11,14 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
 import { mapApiErrorsToForm } from "@/lib/errors";
+import { useMembershipTypes } from "@/features/members/hooks/use-members";
 import { useCreateSpace, useUpdateSpace } from "../hooks/use-bookings";
 import type { Space } from "../services/bookings-api";
 
@@ -29,6 +31,9 @@ const spaceSchema = z
     description: z.string().max(2000),
     open_time: z.string().regex(/^\d{2}:\d{2}$/, "validation.invalidTime"),
     close_time: z.string().regex(/^\d{2}:\d{2}$/, "validation.invalidTime"),
+    // No selection means no restriction, the same reading the backend gives an
+    // empty array — so there is no "nobody may book this" state to fall into.
+    allowed_membership_types: z.array(z.number()),
     is_active: z.boolean(),
   })
   .superRefine((data, ctx) => {
@@ -60,6 +65,8 @@ export function SpaceForm({
   const t = useTranslations();
   const createMutation = useCreateSpace();
   const updateMutation = useUpdateSpace();
+  const { data: membershipTypes } = useMembershipTypes();
+  const activeTypes = (membershipTypes ?? []).filter((mt) => mt.is_active);
 
   const form = useForm<SpaceFormValues>({
     resolver: useZodResolver(spaceSchema),
@@ -69,6 +76,7 @@ export function SpaceForm({
       description: space?.description ?? "",
       open_time: toTimeInput(space?.open_time) || "08:00",
       close_time: toTimeInput(space?.close_time) || "22:00",
+      allowed_membership_types: space?.allowed_membership_types ?? [],
       is_active: space?.is_active ?? true,
     },
   });
@@ -80,6 +88,7 @@ export function SpaceForm({
       description: data.description || null,
       open_time: data.open_time,
       close_time: data.close_time,
+      allowed_membership_types: data.allowed_membership_types,
       is_active: data.is_active,
     };
     try {
@@ -167,6 +176,45 @@ export function SpaceForm({
             )}
           />
         </div>
+        <FormField
+          control={form.control}
+          name="allowed_membership_types"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("bookings.spaces.allowedTypes")}</FormLabel>
+              <FormDescription>
+                {t("bookings.spaces.allowedTypesHint")}
+              </FormDescription>
+              {activeTypes.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {t("bookings.spaces.allowedTypesNone")}
+                </p>
+              ) : (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {activeTypes.map((mt) => (
+                    <label
+                      key={mt.id}
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <Checkbox
+                        checked={field.value.includes(mt.id)}
+                        onCheckedChange={(checked) =>
+                          field.onChange(
+                            checked
+                              ? [...field.value, mt.id]
+                              : field.value.filter((id) => id !== mt.id)
+                          )
+                        }
+                      />
+                      {mt.name}
+                    </label>
+                  ))}
+                </div>
+              )}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
         <FormField
           control={form.control}
           name="is_active"

--- a/frontend/features/bookings/components/week-calendar.tsx
+++ b/frontend/features/bookings/components/week-calendar.tsx
@@ -20,7 +20,7 @@ import {
   useAvailableSpaces,
   useCreateBooking,
 } from "../hooks/use-bookings";
-import type { AvailabilityCell } from "../services/bookings-api";
+import type { AvailabilityCell, IneligibleReason } from "../services/bookings-api";
 
 const WEEKDAYS = [0, 1, 2, 3, 4, 5, 6];
 
@@ -64,6 +64,14 @@ export function WeekCalendar() {
     weekStart,
     spaceId !== null
   );
+
+  // The space itself is off limits to this member's membership type. The week
+  // still renders — hiding it would leave the member guessing why a space they
+  // can see in the picker has nothing in it — but nothing in it can be booked.
+  const ineligibleReason: IneligibleReason | null =
+    availability && !availability.eligible
+      ? availability.ineligible_reason
+      : null;
 
   const cellsByWeekday = useMemo(() => {
     const map = new Map<number, AvailabilityCell[]>();
@@ -164,6 +172,14 @@ export function WeekCalendar() {
         </div>
       </div>
 
+      {ineligibleReason ? (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+          {ineligibleReason === "no_membership_type"
+            ? t("bookings.book.noMembershipType")
+            : t("bookings.book.membershipTypeNotAllowed")}
+        </div>
+      ) : null}
+
       {loadingAvailability ? (
         <TabContentSkeleton />
       ) : (
@@ -190,6 +206,7 @@ export function WeekCalendar() {
                         cell={cell}
                         onBook={() => book(cell)}
                         pending={createBooking.isPending}
+                        bookable={ineligibleReason === null}
                       />
                     ))
                   )}
@@ -207,13 +224,19 @@ function SlotCell({
   cell,
   onBook,
   pending,
+  bookable,
 }: {
   cell: AvailabilityCell;
   onBook: () => void;
   pending: boolean;
+  /** False when the member's membership type does not include this space. */
+  bookable: boolean;
 }) {
   const t = useTranslations();
-  const muted = cell.cell_state === "past" || cell.cell_state === "out_of_window";
+  const muted =
+    !bookable ||
+    cell.cell_state === "past" ||
+    cell.cell_state === "out_of_window";
 
   return (
     <div

--- a/frontend/features/bookings/services/bookings-api.ts
+++ b/frontend/features/bookings/services/bookings-api.ts
@@ -7,6 +7,8 @@ export interface Space {
   description: string | null;
   open_time: string; // "HH:MM:SS"
   close_time: string;
+  // Membership type ids allowed to book. null or empty = open to every member.
+  allowed_membership_types: number[] | null;
   is_active: boolean;
   created_at: string | null;
   updated_at: string | null;
@@ -18,6 +20,7 @@ export interface SpaceInput {
   description: string | null;
   open_time: string;
   close_time: string;
+  allowed_membership_types: number[];
   is_active?: boolean;
 }
 
@@ -193,9 +196,18 @@ export interface AvailabilityCell {
   cell_state: CellState;
 }
 
+// Why the member may not book this space at all. The two are separate because
+// they need separate answers: one is an upgrade, the other is a missing tier
+// only the club can assign.
+export type IneligibleReason =
+  | "membership_type_not_allowed"
+  | "no_membership_type";
+
 export interface WeekAvailability {
   space_id: number;
   week_start: string;
+  eligible: boolean;
+  ineligible_reason: IneligibleReason | null;
   cells: AvailabilityCell[];
 }
 

--- a/frontend/locales/ca/bookings.json
+++ b/frontend/locales/ca/bookings.json
@@ -15,7 +15,9 @@
       "confirmWaitlist": "Aquesta franja és plena. Vols unir-te a la llista d'espera?",
       "confirmWaitlistAction": "Uneix-m'hi",
       "bookedToast": "Reserva confirmada",
-      "waitlistedToast": "Afegit a la llista d'espera"
+      "waitlistedToast": "Afegit a la llista d'espera",
+      "membershipTypeNotAllowed": "Aquest espai està reservat a altres tipus de soci. El teu tipus de soci no l'inclou; consulta amb el club si el vols canviar.",
+      "noMembershipType": "Aquest espai està reservat a determinats tipus de soci i la teva fitxa no en té cap d'assignat. Escriu al club perquè te n'assigni un."
     },
     "my": {
       "title": "Les meves reserves",
@@ -45,7 +47,11 @@
       "noSpaces": "Encara no hi ha espais. Crea'n un per començar a acceptar reserves.",
       "notFound": "Espai no trobat.",
       "confirmDelete": "Vols eliminar aquest espai? Se n'eliminaran les franges i les reserves. Per deixar d'acceptar reserves sense esborrar res, desactiva'l des d'Edita.",
-      "deleteAffected": "{count, plural, one {# soci té reserves actives que es cancel·laran i se l'avisarà per correu.} other {# socis tenen reserves actives que es cancel·laran i se'ls avisarà per correu.}}"
+      "deleteAffected": "{count, plural, one {# soci té reserves actives que es cancel·laran i se l'avisarà per correu.} other {# socis tenen reserves actives que es cancel·laran i se'ls avisarà per correu.}}",
+      "allowedTypes": "Tipus de soci amb accés",
+      "allowedTypesHint": "Sense cap marcat, l'espai queda obert a tots els socis. En marcar tipus, només aquests socis el podran reservar.",
+      "allowedTypesNone": "Encara no hi ha tipus de soci actius.",
+      "allowedTypesOpen": "Tots els socis"
     },
     "slots": {
       "tab": "Franges",

--- a/frontend/locales/en/bookings.json
+++ b/frontend/locales/en/bookings.json
@@ -15,7 +15,9 @@
       "confirmWaitlist": "This slot is full. Join the waitlist?",
       "confirmWaitlistAction": "Join",
       "bookedToast": "Booked",
-      "waitlistedToast": "Added to the waitlist"
+      "waitlistedToast": "Added to the waitlist",
+      "membershipTypeNotAllowed": "This space is reserved for other membership types. Yours does not include it — ask the club if you want to change it.",
+      "noMembershipType": "This space is reserved for certain membership types and your record has none assigned. Ask the club to assign you one."
     },
     "my": {
       "title": "My bookings",
@@ -45,7 +47,11 @@
       "noSpaces": "No spaces yet. Create one to start taking bookings.",
       "notFound": "Space not found.",
       "confirmDelete": "Delete this space? Its slots and bookings will be removed. To stop taking bookings without deleting anything, deactivate it from Edit.",
-      "deleteAffected": "{count, plural, one {# member has active bookings that will be cancelled and notified by email.} other {# members have active bookings that will be cancelled and notified by email.}}"
+      "deleteAffected": "{count, plural, one {# member has active bookings that will be cancelled and notified by email.} other {# members have active bookings that will be cancelled and notified by email.}}",
+      "allowedTypes": "Membership types with access",
+      "allowedTypesHint": "With none ticked the space is open to every member. Tick types and only those members can book it.",
+      "allowedTypesNone": "No active membership types yet.",
+      "allowedTypesOpen": "All members"
     },
     "slots": {
       "tab": "Slots",

--- a/frontend/locales/es/bookings.json
+++ b/frontend/locales/es/bookings.json
@@ -15,7 +15,9 @@
       "confirmWaitlist": "Esta franja está completa. ¿Unirse a la lista de espera?",
       "confirmWaitlistAction": "Unirse",
       "bookedToast": "Reserva confirmada",
-      "waitlistedToast": "Añadido a la lista de espera"
+      "waitlistedToast": "Añadido a la lista de espera",
+      "membershipTypeNotAllowed": "Este espacio está reservado a otros tipos de socio. Tu tipo de socio no lo incluye; consulta con el club si quieres cambiarlo.",
+      "noMembershipType": "Este espacio está reservado a determinados tipos de socio y tu ficha no tiene ninguno asignado. Escribe al club para que te asigne uno."
     },
     "my": {
       "title": "Mis reservas",
@@ -45,7 +47,11 @@
       "noSpaces": "Aún no hay espacios. Crea uno para empezar a aceptar reservas.",
       "notFound": "Espacio no encontrado.",
       "confirmDelete": "¿Eliminar este espacio? Se eliminarán sus franjas y reservas. Para dejar de aceptar reservas sin borrar nada, desactívalo desde Editar.",
-      "deleteAffected": "{count, plural, one {# socio tiene reservas activas que se cancelarán y se le avisará por correo.} other {# socios tienen reservas activas que se cancelarán y se les avisará por correo.}}"
+      "deleteAffected": "{count, plural, one {# socio tiene reservas activas que se cancelarán y se le avisará por correo.} other {# socios tienen reservas activas que se cancelarán y se les avisará por correo.}}",
+      "allowedTypes": "Tipos de socio con acceso",
+      "allowedTypesHint": "Sin ninguno marcado, el espacio queda abierto a todos los socios. Al marcar tipos, solo esos socios podrán reservarlo.",
+      "allowedTypesNone": "Aún no hay tipos de socio activos.",
+      "allowedTypesOpen": "Todos los socios"
     },
     "slots": {
       "tab": "Franjas",


### PR DESCRIPTION
**Phase 1 of #148** — gating only. Phases 2 (pricing, receipts, `booking_id`, the `'booking'` origin) and 3 (pricing UI) are separate, so #148 stays open. No file under `app/domains/billing/` is touched.

`Space.allowed_membership_types` mirrors `Activity.allowed_membership_types`: an `ARRAY(Integer)`, empty or NULL meaning open to everyone, enforced before a booking is created.

## Waitlist promotion re-checks eligibility

The issue did not raise this; it matters. A member can join a waitlist, lose their tier while queued, and be promoted into a space they can no longer use — and nothing downstream ever re-validates.

Promotion is a confirmation path, and the same argument the issue makes for billing on every confirmation path applies to gating: a check that runs only in `create_booking` has a hole exactly where nobody is watching.

`_promote_next` therefore walks the waitlist in order and promotes the **first eligible** member, **skipping rather than cancelling** anyone whose tier no longer qualifies. Cancelling would silently destroy someone's place over an administrative change they did not make; skipping leaves them queued, so the moment their tier is restored they are back in line where they were.

Cost is `.first()` becoming `.all()` plus one member load per skipped candidate — bounded by waitlist length, and the common case is one extra load. The `order_by(waitlisted_at.asc(), id.asc())` ordering is untouched, so **#110 is neither fixed nor made worse**.

## Two refusal reasons, deliberately

A `NULL` membership type fails the same check as a wrong one, but they are different problems for the member:

- `membership_type_not_allowed` — "your type does not include this space", pointing at an upgrade they can ask the club for
- `no_membership_type` — "your record has no type assigned", pointing at an administrative gap only the club can close

Telling someone with no plan that "your plan does not include this" sends them chasing an upgrade they cannot buy.

**This diverges from the activity reference on purpose.** `activities/eligibility.py:39` collapses both failures into one string. The *condition* is mirrored exactly; the *result shape* is not, because bookings surface the reason to the member and activities do not. Activities were left alone.

## Where the restriction surfaces

The restriction lives on the space, not the slot, so `eligible` and `ineligible_reason` ride on the `WeekAvailability` envelope rather than a per-cell state. The calendar shows an amber banner and greys the slots with no book button, so the 403 is reachable only as a race.

`[]` is normalised to NULL on write — both mean "open to all", and the column should not have two spellings for one state.

## Testing

- Backend: **1490 passed**, 0 failed
- Migration applied against a scratch database from zero and downgraded cleanly
- Frontend: `✓ Compiled successfully`, `✔ No ESLint warnings or errors`

Cypress not run. `bookings-flow.cy.ts` creates its space via API without the new field and books an unrestricted space, so it should be unaffected — unverified.

## Two notes for whoever picks up phase 2

**The test database needs restarting when a column is added.** `conftest.py` uses `Base.metadata.create_all`, which never alters an existing table, so a long-running `memship-db-test` fails with `column ... does not exist`. Restart the container (tmpfs, so it wipes).

**`create_booking` has never checked `member.status == "active"`**, and still does not. Out of scope here, but the membership-type gate is now the only membership condition on the booking path.
