### PR TITLE
Charge for a space, and show the member what it costs

### DIFF
--- a/backend/alembic/versions/c6d7e8f9a0b1_add_booking_pricing_and_receipts.py
+++ b/backend/alembic/versions/c6d7e8f9a0b1_add_booking_pricing_and_receipts.py
@@ -1,0 +1,102 @@
+"""add_booking_pricing_and_receipts
+
+Makes a space chargeable. ``spaces.price`` is the default a booking costs and
+``space_slots.price`` overrides it for one slot, so a club sets one number for
+"the court costs 10 EUR" and only reaches for the override when prime time costs
+more. Both are nullable and every existing row stays NULL, which reads as free —
+so this migration changes no behaviour until an admin types a price.
+
+The receipt side needs three things. ``'booking'`` joins the allowed values of
+``concepts.concept_type`` and ``receipts.origin``: the unused ``'service'`` value
+would have saved a migration and cost every future report a footnote explaining
+that ``'service'`` secretly means a booking, so it is left alone.
+
+``receipts.booking_id`` is ``ON DELETE SET NULL``, unlike ``registration_id``,
+which carries no rule at all. That is safe for registrations because nothing
+hard-deletes one; bookings are the opposite — ``bookings.space_slot_id`` cascades
+and ``delete_slot(force=True)`` deletes slot rows outright, so an admin tidying a
+calendar would hit a foreign key violation the moment an affected booking had a
+receipt. The receipt outlives the booking and keeps its description, which is
+what the member was actually invoiced for.
+
+Revision ID: c6d7e8f9a0b1
+Revises: b6c7d8e9f0a1
+Create Date: 2026-09-07 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c6d7e8f9a0b1'
+down_revision: Union[str, None] = 'b6c7d8e9f0a1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+OLD_TYPES = "('membership', 'activity', 'manual', 'service')"
+NEW_TYPES = "('membership', 'activity', 'booking', 'manual', 'service')"
+
+
+def upgrade() -> None:
+    op.add_column('spaces', sa.Column('price', sa.Numeric(10, 2), nullable=True))
+    op.create_check_constraint(
+        'space_price_non_negative', 'spaces', 'price IS NULL OR price >= 0'
+    )
+    op.add_column(
+        'space_slots', sa.Column('price', sa.Numeric(10, 2), nullable=True)
+    )
+    op.create_check_constraint(
+        'space_slot_price_non_negative',
+        'space_slots',
+        'price IS NULL OR price >= 0',
+    )
+
+    # A CHECK constraint cannot be widened in place — drop and recreate.
+    op.drop_constraint('valid_concept_type', 'concepts', type_='check')
+    op.create_check_constraint(
+        'valid_concept_type', 'concepts', f'concept_type IN {NEW_TYPES}'
+    )
+    op.drop_constraint('valid_receipt_origin', 'receipts', type_='check')
+    op.create_check_constraint(
+        'valid_receipt_origin', 'receipts', f'origin IN {NEW_TYPES}'
+    )
+
+    op.add_column('receipts', sa.Column('booking_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        'fk_receipts_booking_id',
+        'receipts',
+        'bookings',
+        ['booking_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+    op.create_index('ix_receipts_booking_id', 'receipts', ['booking_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_receipts_booking_id', table_name='receipts')
+    op.drop_constraint('fk_receipts_booking_id', 'receipts', type_='foreignkey')
+    op.drop_column('receipts', 'booking_id')
+
+    # Narrowing the constraints again means any receipt or concept raised for a
+    # booking would violate it, so those rows go first — a downgrade past the
+    # feature cannot keep records the schema can no longer describe.
+    op.execute("DELETE FROM receipts WHERE origin = 'booking'")
+    op.execute("DELETE FROM concepts WHERE concept_type = 'booking'")
+
+    op.drop_constraint('valid_receipt_origin', 'receipts', type_='check')
+    op.create_check_constraint(
+        'valid_receipt_origin', 'receipts', f'origin IN {OLD_TYPES}'
+    )
+    op.drop_constraint('valid_concept_type', 'concepts', type_='check')
+    op.create_check_constraint(
+        'valid_concept_type', 'concepts', f'concept_type IN {OLD_TYPES}'
+    )
+
+    op.drop_constraint(
+        'space_slot_price_non_negative', 'space_slots', type_='check'
+    )
+    op.drop_column('space_slots', 'price')
+    op.drop_constraint('space_price_non_negative', 'spaces', type_='check')
+    op.drop_column('spaces', 'price')

--- a/backend/app/domains/billing/models.py
+++ b/backend/app/domains/billing/models.py
@@ -27,7 +27,7 @@ class Concept(Base):
     __tablename__ = "concepts"
     __table_args__ = (
         CheckConstraint(
-            "concept_type IN ('membership', 'activity', 'manual', 'service')",
+            "concept_type IN ('membership', 'activity', 'booking', 'manual', 'service')",
             name="valid_concept_type",
         ),
         CheckConstraint("default_amount >= 0", name="concept_amount_non_negative"),
@@ -69,7 +69,7 @@ class Receipt(Base):
             name="valid_receipt_status",
         ),
         CheckConstraint(
-            "origin IN ('membership', 'activity', 'manual', 'service')",
+            "origin IN ('membership', 'activity', 'booking', 'manual', 'service')",
             name="valid_receipt_origin",
         ),
         CheckConstraint(
@@ -87,6 +87,7 @@ class Receipt(Base):
         Index("ix_receipts_status", "status"),
         Index("ix_receipts_emission_date", "emission_date"),
         Index("ix_receipts_origin", "origin"),
+        Index("ix_receipts_booking_id", "booking_id"),
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -96,6 +97,12 @@ class Receipt(Base):
     member_id = Column(Integer, ForeignKey("members.id"), nullable=False)
     concept_id = Column(Integer, ForeignKey("concepts.id"))
     registration_id = Column(Integer, ForeignKey("registrations.id"))
+    # SET NULL, unlike registration_id: a booking is a row an admin can destroy
+    # (deleting a slot cascades its bookings away), and a receipt must outlive
+    # that. It keeps its description, which is what the member is invoiced for.
+    booking_id = Column(
+        Integer, ForeignKey("bookings.id", ondelete="SET NULL")
+    )
     remittance_id = Column(Integer, ForeignKey("remittances.id"))
     created_by = Column(Integer, ForeignKey("users.id"))
 
@@ -157,6 +164,7 @@ class Receipt(Base):
     member = relationship("Member", backref="receipts")
     concept = relationship("Concept", back_populates="receipts")
     registration = relationship("Registration", backref="receipts")
+    booking = relationship("Booking", backref="receipts")
     remittance = relationship("Remittance", back_populates="receipts")
     creator = relationship("User", foreign_keys=[created_by])
 

--- a/backend/app/domains/billing/service.py
+++ b/backend/app/domains/billing/service.py
@@ -604,3 +604,72 @@ def generate_activity_receipt(
     db.add(receipt)
     db.flush()
     return receipt
+
+
+def generate_booking_receipt(
+    db: Session,
+    booking_id: int,
+    member_id: int,
+    description: str,
+    amount: Decimal,
+    created_by_id: int | None = None,
+) -> Receipt | None:
+    """Create a receipt for a space booking.
+
+    Called whenever a booking is confirmed — booking a free seat, or being
+    promoted off the waitlist.
+
+    Returns ``None`` for a free booking, which is the normal case: a space with
+    no price never reaches a receipt at all. The return type says so, unlike
+    ``generate_activity_receipt`` (see #106).
+
+    ``description`` carries the space name and the slot's date and time because
+    the link back to the booking is deliberately breakable — ``booking_id`` is
+    ``ON DELETE SET NULL``, so an admin deleting a slot leaves this text as the
+    only record of what was billed.
+    """
+    if amount <= 0:
+        return None
+
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    vat_rate = Decimal(str((org.default_vat_rate if org else None) or 21))
+
+    concept = (
+        db.query(Concept)
+        .filter(Concept.code == "space-booking", Concept.is_active.is_(True))
+        .first()
+    )
+    if not concept:
+        concept = Concept(
+            name="Space Booking",
+            code="space-booking",
+            concept_type="booking",
+            default_amount=Decimal("0"),
+            vat_rate=vat_rate,
+        )
+        db.add(concept)
+        db.flush()
+
+    base_amount = Decimal(str(amount))
+    vat_amount, total_amount = calculate_vat(base_amount, vat_rate)
+    today = date.today()
+
+    receipt = Receipt(
+        receipt_number=generate_receipt_number(db, today),
+        member_id=member_id,
+        concept_id=concept.id,
+        booking_id=booking_id,
+        origin="booking",
+        description=description,
+        base_amount=base_amount,
+        vat_rate=vat_rate,
+        vat_amount=vat_amount,
+        total_amount=total_amount,
+        status="emitted",
+        emission_date=today,
+        is_batchable=True,
+        created_by=created_by_id,
+    )
+    db.add(receipt)
+    db.flush()
+    return receipt

--- a/backend/app/domains/bookings/billing.py
+++ b/backend/app/domains/bookings/billing.py
@@ -1,0 +1,139 @@
+"""Billing a space booking — what it costs, and the receipt that follows.
+
+The rule is the one activities already follow: *bill once, bill on every
+confirmation path, void on cancel.* A confirmed booking in a paid space is money
+owed whichever path produced it, so both ``create_booking`` and waitlist
+promotion come through :func:`ensure_booking_receipt`.
+
+Price lives on the ``Space`` as the default and on the ``SpaceSlot`` as an
+optional override, so a club sets one number for "the court costs 10 €" and only
+reaches for the override when prime time costs more. A slot's own ``0`` is an
+explicit free slot in a paid space, which is why the override is read by
+``is not None`` and not by truthiness.
+
+Nothing here is a refund path. There is none: a member who cancels a paid
+booking keeps the invoice unless it was still unpaid, and one whose slot an
+admin deletes is in exactly the same position. Cancelling voids what has not
+been paid and leaves a paid receipt standing, to be settled offline.
+"""
+
+import logging
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from app.domains.bookings.models import Booking, Space, SpaceSlot
+
+logger = logging.getLogger(__name__)
+
+#: Receipt statuses a cancellation may void — everything short of paid.
+VOIDABLE_STATUSES = ("new", "pending", "emitted", "overdue")
+
+
+def booking_price(space: Space, slot: SpaceSlot) -> Decimal:
+    """What this slot costs: its own price, or the space's, or nothing."""
+    amount = slot.price if slot.price is not None else space.price
+    return Decimal(str(amount)) if amount is not None else Decimal("0")
+
+
+def booking_description(space: Space, slot: SpaceSlot) -> str:
+    """The line the member is invoiced for.
+
+    Self-contained on purpose. ``Receipt.booking_id`` is ``ON DELETE SET NULL``,
+    so this text is all that survives an admin deleting the slot.
+    """
+    times = (
+        f"{slot.start_time.strftime('%H:%M')}–{slot.end_time.strftime('%H:%M')}"
+    )
+    return f"{space.name} — {slot.slot_date.strftime('%d/%m/%Y')} {times}"
+
+
+def ensure_booking_receipt(
+    db: Session, booking: Booking, slot: SpaceSlot, space: Space
+) -> None:
+    """Bill a confirmed booking, once.
+
+    Idempotent: a booking that already has a live receipt keeps it, so a member
+    promoted after re-joining a waitlist is not billed twice. A receipt voided by
+    an earlier cancellation deliberately does not count as live — re-booking owes
+    money again.
+
+    Free stays free with no special-casing: a space with no price, or a slot
+    overriding it to zero, produces no receipt at all.
+
+    Receipt generation never fails the booking. The seat has already been given,
+    and rolling it back here would be worse than an invoice an admin has to raise
+    by hand — so the error is logged and the booking stands.
+    """
+    amount = booking_price(space, slot)
+    if amount <= 0:
+        return
+
+    from app.domains.billing.models import Receipt
+
+    # The receipt a cancellation just voided may still be pending in the session
+    # (the app's sessions do not autoflush), and it must not read as a live one.
+    db.flush()
+    existing = (
+        db.query(Receipt)
+        .filter(
+            Receipt.booking_id == booking.id,
+            Receipt.is_active.is_(True),
+            Receipt.status != "cancelled",
+        )
+        .first()
+    )
+    if existing:
+        return
+
+    try:
+        from app.domains.billing.service import generate_booking_receipt
+
+        # Best-effort, inside a SAVEPOINT so a failure rolls back only the
+        # receipt and leaves the booking's transaction usable.
+        with db.begin_nested():
+            generate_booking_receipt(
+                db=db,
+                booking_id=booking.id,
+                member_id=booking.member_id,
+                description=booking_description(space, slot),
+                amount=amount,
+            )
+    except Exception as exc:
+        logger.error(
+            "Failed to generate receipt for booking %s: %s", booking.id, exc
+        )
+
+
+def void_booking_receipts(db: Session, booking: Booking) -> None:
+    """Void the unpaid receipts of a cancelled booking; leave a paid one alone.
+
+    A paid receipt stays paid because the system has no way to represent a
+    refund — there are no credit notes and no refund API — so the club settles
+    it offline. Voiding it here would silently erase money that changed hands.
+    """
+    from app.domains.billing.models import Receipt
+    from app.domains.billing.service import cancel_receipt
+
+    try:
+        receipts = (
+            db.query(Receipt)
+            .filter(
+                Receipt.booking_id == booking.id,
+                Receipt.is_active.is_(True),
+                Receipt.status.in_(VOIDABLE_STATUSES),
+            )
+            .all()
+        )
+        for receipt in receipts:
+            cancel_receipt(db, receipt)
+    except Exception:
+        # The seat is already released, so failing the cancellation here would
+        # be worse than an invoice left open — but it must not be invisible. A
+        # receipt still standing against a cancelled booking is money the member
+        # is asked for and does not owe.
+        logger.exception(
+            "Failed to void receipts for booking %s; a receipt may still stand "
+            "against a cancelled booking",
+            booking.id,
+        )

--- a/backend/app/domains/bookings/models.py
+++ b/backend/app/domains/bookings/models.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    Numeric,
     SmallInteger,
     String,
     Text,
@@ -38,6 +39,9 @@ class Space(Base):
     __tablename__ = "spaces"
     __table_args__ = (
         CheckConstraint("close_time > open_time", name="space_hours_valid"),
+        CheckConstraint(
+            "price IS NULL OR price >= 0", name="space_price_non_negative"
+        ),
         Index("ix_spaces_active", "is_active"),
     )
 
@@ -45,6 +49,9 @@ class Space(Base):
     name = Column(String(200), nullable=False)
     space_type = Column(String(50))
     description = Column(Text)
+    # What one booking of this space costs, before VAT. NULL or 0 = free, and a
+    # free space raises no receipt at all. A slot may override it.
+    price = Column(Numeric(10, 2))
     open_time = Column(Time, nullable=False)
     close_time = Column(Time, nullable=False)
     # Membership type ids allowed to book. Empty or NULL = open to every member,
@@ -66,6 +73,9 @@ class SpaceSlot(Base):
     __table_args__ = (
         CheckConstraint("end_time > start_time", name="space_slot_time_valid"),
         CheckConstraint("capacity >= 1", name="space_slot_capacity_valid"),
+        CheckConstraint(
+            "price IS NULL OR price >= 0", name="space_slot_price_non_negative"
+        ),
         Index("ix_space_slots_space_date", "space_id", "slot_date"),
         Index("ix_space_slots_series", "series_id"),
     )
@@ -78,6 +88,9 @@ class SpaceSlot(Base):
     start_time = Column(Time, nullable=False)
     end_time = Column(Time, nullable=False)
     capacity = Column(SmallInteger, nullable=False, default=1)
+    # Overrides the space's price for this one slot — prime time costs more.
+    # NULL falls back to the space; 0 is an explicit free slot in a paid space.
+    price = Column(Numeric(10, 2))
     # Slots generated together by one repeat rule share a series_id; NULL = one-off.
     series_id = Column(UUID(as_uuid=True))
     is_active = Column(Boolean, nullable=False, default=True)

--- a/backend/app/domains/bookings/schemas.py
+++ b/backend/app/domains/bookings/schemas.py
@@ -15,6 +15,9 @@ class SpaceCreate(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     space_type: str | None = Field(default=None, max_length=50)
     description: str | None = None
+    # Price per booking, before VAT. None or 0 means the space is free and no
+    # receipt is ever raised for it. Typed like ActivityPrice.amount.
+    price: float | None = Field(default=None, ge=0)
     open_time: time
     close_time: time
     # Empty or omitted means the space is open to every member.
@@ -32,6 +35,7 @@ class SpaceUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=200)
     space_type: str | None = Field(default=None, max_length=50)
     description: str | None = None
+    price: float | None = Field(default=None, ge=0)
     open_time: time | None = None
     close_time: time | None = None
     allowed_membership_types: list[int] | None = None
@@ -45,6 +49,7 @@ class SpaceRead(BaseModel):
     name: str
     space_type: str | None
     description: str | None
+    price: float | None
     open_time: time
     close_time: time
     allowed_membership_types: list[int] | None
@@ -77,6 +82,8 @@ class SpaceSlotCreate(BaseModel):
     # all_day expands to the space's opening hours in the service.
     all_day: bool = False
     capacity: int = Field(default=1, ge=1)
+    # Overrides the space's price for this slot; None falls back to the space.
+    price: float | None = Field(default=None, ge=0)
     is_active: bool = True
     repeat: SlotRepeat | None = None
 
@@ -96,6 +103,7 @@ class SpaceSlotUpdate(BaseModel):
     end_time: time | None = None
     all_day: bool = False
     capacity: int | None = Field(default=None, ge=1)
+    price: float | None = Field(default=None, ge=0)
     is_active: bool | None = None
 
 
@@ -108,6 +116,7 @@ class SpaceSlotRead(BaseModel):
     start_time: time
     end_time: time
     capacity: int
+    price: float | None
     series_id: UUID | None
     is_active: bool
     # Slots in this slot's series dated today-or-later than it (itself included);
@@ -174,6 +183,9 @@ class AvailabilityCell(BaseModel):
     start_time: time
     end_time: time
     capacity: int
+    # What this slot costs the member: the slot's own price, or the space's,
+    # or 0 when neither is set. Shown before the booking is confirmed.
+    price: float
     booked_count: int
     waitlist_count: int
     # none | booked | waitlisted

--- a/backend/app/domains/bookings/service.py
+++ b/backend/app/domains/bookings/service.py
@@ -20,6 +20,11 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy import func
 from sqlalchemy.orm import Query, Session, joinedload
 
+from app.domains.bookings.billing import (
+    booking_price,
+    ensure_booking_receipt,
+    void_booking_receipts,
+)
 from app.domains.bookings.eligibility import check_space_eligibility
 from app.domains.bookings.models import Booking, Space, SpaceSlot
 from app.domains.bookings.notifications import (
@@ -170,6 +175,7 @@ def create_space(db: Session, data: SpaceCreate) -> Space:
         name=data.name,
         space_type=data.space_type,
         description=data.description,
+        price=data.price,
         open_time=data.open_time,
         close_time=data.close_time,
         allowed_membership_types=data.allowed_membership_types or None,
@@ -382,6 +388,7 @@ def create_slot(db: Session, space: Space, data: SpaceSlotCreate) -> list[SpaceS
             start_time=start_time,
             end_time=end_time,
             capacity=data.capacity,
+            price=data.price,
             series_id=series_id,
             is_active=data.is_active,
         )
@@ -558,6 +565,7 @@ def space_week_availability(
                 "start_time": slot.start_time,
                 "end_time": slot.end_time,
                 "capacity": slot.capacity,
+                "price": booking_price(space, slot),
                 "booked_count": booked,
                 "waitlist_count": waitlisted,
                 "my_status": my_status,
@@ -646,6 +654,7 @@ def create_booking(
     db.flush()
 
     if status == BookingStatus.BOOKED:
+        ensure_booking_receipt(db, booking, slot, space)
         notifier.send_confirmation(
             _notification(
                 db,
@@ -699,6 +708,10 @@ def cancel_booking(
     booking.cancelled_at = now_local
     booking.cancelled_by_user_id = cancelled_by_user_id
     db.flush()
+
+    # Money follows the seat: whatever is still unpaid is voided here, and a
+    # paid receipt is left standing — the club settles that one offline.
+    void_booking_receipts(db, booking)
 
     if is_admin:
         # The member didn't cancel this themselves — tell them.
@@ -759,6 +772,9 @@ def _promote_next(
         candidate.waitlisted_at = None
         db.flush()
         if space is not None:
+            # Promotion confirms a seat, so it bills like any other confirmation
+            # path — the one that is easiest to forget.
+            ensure_booking_receipt(db, candidate, slot, space)
             notifier.send_promoted(
                 _notification(db, candidate, slot, space, member)
             )

--- a/backend/tests/integration/test_booking_billing.py
+++ b/backend/tests/integration/test_booking_billing.py
@@ -1,0 +1,324 @@
+"""Every path that confirms a booking must invoice it, and no admin action may
+destroy the invoice.
+
+Two failures are covered here that nothing else would catch. The first is the
+waitlist: a member promoted into a paid slot holds exactly what a member who
+booked it directly holds, and billing only the direct path leaks money silently,
+because nothing reconciles bookings against receipts. The second is deletion —
+``bookings.space_slot_id`` cascades and ``delete_slot(force=True)`` deletes the
+slot row, so a receipt pointing at a booking has to survive its subject.
+"""
+
+from datetime import date, time, timedelta
+from decimal import Decimal
+
+from sqlalchemy import text
+
+from app.domains.billing.models import Concept, Receipt
+from app.domains.billing.service import mark_receipt_paid
+from app.domains.bookings import service
+from app.domains.bookings.billing import ensure_booking_receipt
+from app.domains.bookings.models import Booking, Space, SpaceSlot
+from app.domains.members.models import Member
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+PRICE = Decimal("10.00")
+#: 10.00 plus the org's default 21% VAT.
+TOTAL = Decimal("12.10")
+
+
+def _org(db, **features):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if not org:
+        org = OrganizationSettings(
+            id=1,
+            name="Club",
+            locale="es",
+            timezone="Europe/Madrid",
+            currency="EUR",
+        )
+        db.add(org)
+    org.default_vat_rate = 21
+    org.features = {"bookings": True, **features}
+    db.flush()
+    return org
+
+
+def _member(db, i=0):
+    person = Person(first_name=f"B{i}", last_name="Payer", email=f"b{i}@bill.com")
+    db.add(person)
+    db.flush()
+    member = Member(person_id=person.id, status="active", is_active=True)
+    db.add(member)
+    db.flush()
+    return member
+
+
+def _space(db, price=None):
+    space = Space(
+        name="Court 1",
+        open_time=time(8, 0),
+        close_time=time(22, 0),
+        is_active=True,
+        price=price,
+    )
+    db.add(space)
+    db.flush()
+    return space
+
+
+def _slot(db, space, on=None, capacity=1, price=None):
+    slot = SpaceSlot(
+        space_id=space.id,
+        slot_date=on or (date.today() + timedelta(days=3)),
+        start_time=time(10, 0),
+        end_time=time(11, 0),
+        capacity=capacity,
+        price=price,
+        is_active=True,
+    )
+    db.add(slot)
+    db.flush()
+    return slot
+
+
+def _user(db):
+    from app.core.security.password import hash_password
+    from app.domains.auth.models import User
+
+    person = Person(first_name="U", last_name="ser", email="canceller@bill.com")
+    db.add(person)
+    db.flush()
+    user = User(
+        person_id=person.id,
+        email="canceller@bill.com",
+        password_hash=hash_password("x"),
+        role="admin",
+        is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _receipts(db, booking_id):
+    return (
+        db.query(Receipt)
+        .filter(Receipt.booking_id == booking_id)
+        .order_by(Receipt.id)
+        .all()
+    )
+
+
+# --- A price on the space is what gets billed ------------------------------
+
+
+def test_free_space_raises_no_receipt(db):
+    _org(db)
+    space = _space(db)
+    slot = _slot(db, space)
+
+    booking = service.create_booking(db, _member(db, 1), slot.id)
+
+    assert _receipts(db, booking.id) == []
+
+
+def test_paid_space_bills_the_confirmed_booking(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space)
+    member = _member(db, 1)
+
+    booking = service.create_booking(db, member, slot.id)
+
+    receipt = _receipts(db, booking.id)[0]
+    assert receipt.origin == "booking"
+    assert receipt.member_id == member.id
+    assert receipt.status == "emitted"
+    assert receipt.base_amount == PRICE
+    assert receipt.total_amount == TOTAL
+    # The description has to stand on its own — the link back is breakable.
+    assert space.name in receipt.description
+    assert slot.slot_date.strftime("%d/%m/%Y") in receipt.description
+
+
+def test_booking_concept_is_found_or_created_once(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    member = _member(db, 1)
+    for day in (3, 4):
+        slot = _slot(db, space, on=date.today() + timedelta(days=day))
+        service.create_booking(db, member, slot.id)
+
+    concepts = db.query(Concept).filter(Concept.code == "space-booking").all()
+    assert len(concepts) == 1
+    assert concepts[0].concept_type == "booking"
+
+
+def test_slot_price_overrides_the_space_price(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space, price=Decimal("25.00"))
+
+    booking = service.create_booking(db, _member(db, 1), slot.id)
+
+    assert _receipts(db, booking.id)[0].base_amount == Decimal("25.00")
+
+
+def test_slot_priced_at_zero_is_free_in_a_paid_space(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space, price=Decimal("0"))
+
+    booking = service.create_booking(db, _member(db, 1), slot.id)
+
+    assert _receipts(db, booking.id) == []
+
+
+def test_waitlisted_booking_is_not_billed_until_it_is_confirmed(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space, capacity=1)
+    service.create_booking(db, _member(db, 1), slot.id)
+
+    waiting = service.create_booking(db, _member(db, 2), slot.id)
+
+    assert waiting.status == "waitlisted"
+    assert _receipts(db, waiting.id) == []
+
+
+# --- Promotion is a confirmation path, so it bills too ---------------------
+
+
+def test_waitlist_promotion_bills_the_promoted_member(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space, capacity=1)
+    holder = service.create_booking(db, _member(db, 1), slot.id)
+    promoted = service.create_booking(db, _member(db, 2), slot.id)
+    user = _user(db)
+
+    service.cancel_booking(db, holder, cancelled_by_user_id=user.id, is_admin=True)
+
+    assert promoted.status == "booked"
+    receipt = _receipts(db, promoted.id)[0]
+    assert receipt.status == "emitted"
+    assert receipt.total_amount == TOTAL
+
+
+def test_billing_a_booking_twice_raises_one_receipt(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space)
+    booking = service.create_booking(db, _member(db, 1), slot.id)
+
+    ensure_booking_receipt(db, booking, slot, space)
+    ensure_booking_receipt(db, booking, slot, space)
+
+    assert len(_receipts(db, booking.id)) == 1
+
+
+# --- Cancellation: void what is unpaid, leave what is paid -----------------
+
+
+def test_cancelling_voids_the_unpaid_receipt(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space)
+    booking = service.create_booking(db, _member(db, 1), slot.id)
+    user = _user(db)
+
+    service.cancel_booking(db, booking, cancelled_by_user_id=user.id, is_admin=True)
+
+    assert _receipts(db, booking.id)[0].status == "cancelled"
+
+
+def test_cancelling_leaves_a_paid_receipt_standing(db):
+    """There is no refund path — no credit notes, no refund API. A paid receipt
+    records money that changed hands, and the club settles it offline."""
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space)
+    booking = service.create_booking(db, _member(db, 1), slot.id)
+    mark_receipt_paid(db, _receipts(db, booking.id)[0], payment_method="cash")
+    user = _user(db)
+
+    service.cancel_booking(db, booking, cancelled_by_user_id=user.id, is_admin=True)
+
+    assert _receipts(db, booking.id)[0].status == "paid"
+
+
+def test_rebooking_after_a_cancellation_owes_again(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space)
+    member = _member(db, 1)
+    first = service.create_booking(db, member, slot.id)
+    user = _user(db)
+    service.cancel_booking(db, first, cancelled_by_user_id=user.id, is_admin=True)
+
+    second = service.create_booking(db, member, slot.id)
+
+    assert _receipts(db, first.id)[0].status == "cancelled"
+    assert _receipts(db, second.id)[0].status == "emitted"
+
+
+# --- Deleting a slot must not delete the money ----------------------------
+
+
+def test_receipt_booking_fk_is_set_null_on_delete(db):
+    """The shape the deletion test depends on, asserted directly.
+
+    ``registration_id`` carries no ``ondelete`` and gets away with it only
+    because registrations are never hard-deleted. Copying that shape here would
+    make ``delete_slot(force=True)`` fail with a foreign key violation as soon as
+    an affected booking had a receipt — and the ORM's own nullification would
+    hide the mistake from the test below, which is why the catalog is read.
+    """
+    rule = db.execute(
+        text(
+            "SELECT confdeltype FROM pg_constraint "
+            "WHERE contype = 'f' "
+            "AND conrelid = 'receipts'::regclass "
+            "AND confrelid = 'bookings'::regclass"
+        )
+    ).scalar_one()
+    # 'n' = SET NULL, 'a' = NO ACTION, 'c' = CASCADE.
+    assert rule == "n"
+
+
+def test_forced_slot_delete_succeeds_and_the_receipt_survives(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space)
+    booking = service.create_booking(db, _member(db, 1), slot.id)
+    receipt_id = _receipts(db, booking.id)[0].id
+
+    service.delete_slot(db, slot, force=True)
+    db.flush()
+    db.expire_all()
+
+    assert db.query(Booking).filter(Booking.id == booking.id).first() is None
+    receipt = db.query(Receipt).filter(Receipt.id == receipt_id).one()
+    assert receipt.booking_id is None
+    assert receipt.status == "emitted"
+    assert receipt.total_amount == TOTAL
+    # The invoice line still says what was sold, with nothing left to join to.
+    assert "Court 1" in receipt.description
+
+
+def test_forced_space_delete_succeeds_and_the_receipt_survives(db):
+    _org(db)
+    space = _space(db, price=PRICE)
+    slot = _slot(db, space)
+    booking = service.create_booking(db, _member(db, 1), slot.id)
+    receipt_id = _receipts(db, booking.id)[0].id
+
+    service.delete_space(db, space, force=True)
+    db.flush()
+    db.expire_all()
+
+    receipt = db.query(Receipt).filter(Receipt.id == receipt_id).one()
+    assert receipt.booking_id is None
+    assert receipt.status == "emitted"

--- a/frontend/features/bookings/components/slots-tab.tsx
+++ b/frontend/features/bookings/components/slots-tab.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { Repeat } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { DecimalInput } from "@/components/ui/decimal-input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
@@ -21,6 +22,7 @@ import {
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -81,6 +83,14 @@ const slotSchema = z
     start_time: z.string(),
     end_time: z.string(),
     capacity: z.coerce.number().int().min(1),
+    // Empty means "use the space's price"; "0" means this slot is free. The two
+    // are different answers, so the field stays a string until it is submitted.
+    price: z
+      .string()
+      .refine(
+        (v) => v === "" || (!Number.isNaN(Number(v)) && Number(v) >= 0),
+        "validation.notANumber"
+      ),
     is_active: z.boolean(),
     repeat_enabled: z.boolean(),
     repeat_weekdays: z.array(z.number().int().min(0).max(6)),
@@ -183,6 +193,7 @@ export function SlotsTab({ spaceId }: { spaceId: number }) {
                 <TableHead>{t("bookings.slots.start")}</TableHead>
                 <TableHead>{t("bookings.slots.end")}</TableHead>
                 <TableHead>{t("bookings.slots.capacity")}</TableHead>
+                <TableHead>{t("bookings.slots.price")}</TableHead>
                 <TableHead>{t("common.actions")}</TableHead>
               </TableRow>
             </TableHeader>
@@ -218,7 +229,7 @@ function SlotRow({
   const t = useTranslations();
   const { has } = usePermissions();
   const canWrite = has("bookings.write");
-  const { formatDate } = useFormatters();
+  const { formatCurrency, formatDate } = useFormatters();
   const qc = useQueryClient();
   const updateMutation = useUpdateSlot(spaceId);
   const deleteMutation = useDeleteSlot(spaceId);
@@ -276,6 +287,11 @@ function SlotRow({
       <TableCell>{toTimeInput(slot.start_time)}</TableCell>
       <TableCell>{toTimeInput(slot.end_time)}</TableCell>
       <TableCell>{slot.capacity}</TableCell>
+      <TableCell className="text-muted-foreground">
+        {slot.price != null
+          ? formatCurrency(slot.price)
+          : t("bookings.slots.priceFromSpace")}
+      </TableCell>
       <TableCell>
         <div className="flex gap-2">
           {confirmDialog}
@@ -347,6 +363,7 @@ function SlotForm({
       start_time: slot ? toTimeInput(slot.start_time) : "10:00",
       end_time: slot ? toTimeInput(slot.end_time) : "11:00",
       capacity: slot?.capacity ?? 1,
+      price: slot?.price != null ? String(slot.price) : "",
       is_active: slot?.is_active ?? true,
       repeat_enabled: false,
       repeat_weekdays: [],
@@ -366,6 +383,7 @@ function SlotForm({
         ? {}
         : { start_time: data.start_time, end_time: data.end_time }),
       capacity: data.capacity,
+      price: data.price === "" ? null : Number(data.price),
       is_active: data.is_active,
     };
     try {
@@ -488,6 +506,22 @@ function SlotForm({
               <FormControl>
                 <Input type="number" min={1} {...field} />
               </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="price"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("bookings.slots.price")}</FormLabel>
+              <FormControl>
+                <DecimalInput placeholder="0.00" {...field} />
+              </FormControl>
+              <FormDescription>
+                {t("bookings.slots.priceHint")}
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/frontend/features/bookings/components/space-detail-section.tsx
+++ b/frontend/features/bookings/components/space-detail-section.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { DetailSection } from "@/components/entity/detail-section";
 import { useMembershipTypes } from "@/features/members/hooks/use-members";
+import { useFormatters } from "@/hooks/use-formatters";
 import type { Space } from "../services/bookings-api";
 
 interface SpaceDetailSectionProps {
@@ -12,6 +13,7 @@ interface SpaceDetailSectionProps {
 export function SpaceDetailSection({ space }: SpaceDetailSectionProps) {
   const t = useTranslations();
   const { data: membershipTypes } = useMembershipTypes();
+  const { formatCurrency } = useFormatters();
 
   const allowed = space.allowed_membership_types ?? [];
   const allowedNames = allowed
@@ -27,6 +29,13 @@ export function SpaceDetailSection({ space }: SpaceDetailSectionProps) {
     {
       label: t("bookings.spaces.hours"),
       value: `${space.open_time.slice(0, 5)}–${space.close_time.slice(0, 5)}`,
+      inline: true,
+    },
+    {
+      label: t("bookings.spaces.price"),
+      value: space.price
+        ? formatCurrency(space.price)
+        : t("bookings.spaces.free"),
       inline: true,
     },
     {

--- a/frontend/features/bookings/components/space-form.tsx
+++ b/frontend/features/bookings/components/space-form.tsx
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { DecimalInput } from "@/components/ui/decimal-input";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Form,
@@ -29,6 +30,14 @@ const spaceSchema = z
     name: z.string().min(1).max(200),
     space_type: z.string().max(50),
     description: z.string().max(2000),
+    // Left empty the space is free. Kept as a string so "empty" and "0" stay
+    // distinguishable — 0 is a deliberate free price, not a missing one.
+    price: z
+      .string()
+      .refine(
+        (v) => v === "" || (!Number.isNaN(Number(v)) && Number(v) >= 0),
+        "validation.notANumber"
+      ),
     open_time: z.string().regex(/^\d{2}:\d{2}$/, "validation.invalidTime"),
     close_time: z.string().regex(/^\d{2}:\d{2}$/, "validation.invalidTime"),
     // No selection means no restriction, the same reading the backend gives an
@@ -74,6 +83,7 @@ export function SpaceForm({
       name: space?.name ?? "",
       space_type: space?.space_type ?? "",
       description: space?.description ?? "",
+      price: space?.price != null ? String(space.price) : "",
       open_time: toTimeInput(space?.open_time) || "08:00",
       close_time: toTimeInput(space?.close_time) || "22:00",
       allowed_membership_types: space?.allowed_membership_types ?? [],
@@ -86,6 +96,7 @@ export function SpaceForm({
       name: data.name,
       space_type: data.space_type || null,
       description: data.description || null,
+      price: data.price === "" ? null : Number(data.price),
       open_time: data.open_time,
       close_time: data.close_time,
       allowed_membership_types: data.allowed_membership_types,
@@ -144,6 +155,22 @@ export function SpaceForm({
               <FormControl>
                 <Input {...field} />
               </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="price"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("bookings.spaces.price")}</FormLabel>
+              <FormControl>
+                <DecimalInput placeholder="0.00" {...field} />
+              </FormControl>
+              <FormDescription>
+                {t("bookings.spaces.priceHint")}
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/frontend/features/bookings/components/week-calendar.tsx
+++ b/frontend/features/bookings/components/week-calendar.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select";
 import { useConfirmDialog } from "@/components/ui/confirm-dialog";
 import { TabContentSkeleton } from "@/components/ui/skeletons";
+import { useFormatters } from "@/hooks/use-formatters";
 import {
   useAvailability,
   useAvailableSpaces,
@@ -53,6 +54,7 @@ export function WeekCalendar() {
   );
   const [confirmDialog, confirmAction] = useConfirmDialog();
   const createBooking = useCreateBooking();
+  const { formatCurrency } = useFormatters();
 
   useEffect(() => {
     if (spaceId === null && spaces.length) setSpaceId(spaces[0].id);
@@ -87,10 +89,25 @@ export function WeekCalendar() {
 
   function book(cell: AvailabilityCell) {
     const waitlist = cell.cell_state === "full";
+    // What it costs and what happens to that money afterwards, before the
+    // member commits. Nothing is refunded automatically — neither a
+    // cancellation nor the club removing the slot returns a paid amount — so
+    // the policy is stated here rather than left to be discovered.
+    const price = formatCurrency(cell.price);
+    const description =
+      cell.price > 0
+        ? [
+            waitlist
+              ? t("bookings.book.priceOnPromotion", { price })
+              : t("bookings.book.price", { price }),
+            t("bookings.book.refundPolicy"),
+          ].join(" ")
+        : undefined;
     confirmAction({
       title: waitlist
         ? t("bookings.book.confirmWaitlist")
         : t("bookings.book.confirmBook"),
+      description,
       cancelLabel: t("common.cancel"),
       confirmLabel: waitlist
         ? t("bookings.book.confirmWaitlistAction")
@@ -233,6 +250,7 @@ function SlotCell({
   bookable: boolean;
 }) {
   const t = useTranslations();
+  const { formatCurrency } = useFormatters();
   const muted =
     !bookable ||
     cell.cell_state === "past" ||
@@ -249,6 +267,9 @@ function SlotCell({
         {cell.booked_count}/{cell.capacity}
         {cell.waitlist_count > 0 ? ` · +${cell.waitlist_count}` : ""}
       </div>
+      {cell.price > 0 && (
+        <div className="font-medium">{formatCurrency(cell.price)}</div>
+      )}
       <div className="mt-1">
         {cell.my_status === "booked" ? (
           /* Success green, deliberately not the primary fill — the primary

--- a/frontend/features/bookings/services/bookings-api.ts
+++ b/frontend/features/bookings/services/bookings-api.ts
@@ -5,6 +5,8 @@ export interface Space {
   name: string;
   space_type: string | null;
   description: string | null;
+  // What one booking costs, before tax. null or 0 = free, and nothing is billed.
+  price: number | null;
   open_time: string; // "HH:MM:SS"
   close_time: string;
   // Membership type ids allowed to book. null or empty = open to every member.
@@ -18,6 +20,7 @@ export interface SpaceInput {
   name: string;
   space_type: string | null;
   description: string | null;
+  price: number | null;
   open_time: string;
   close_time: string;
   allowed_membership_types: number[];
@@ -31,6 +34,8 @@ export interface SpaceSlot {
   start_time: string;
   end_time: string;
   capacity: number;
+  // Overrides the space's price for this slot; null falls back to the space.
+  price: number | null;
   series_id: string | null;
   is_active: boolean;
   // Slots of this slot's series dated on/after it (itself included).
@@ -49,6 +54,7 @@ export interface SpaceSlotInput {
   end_time?: string;
   all_day?: boolean;
   capacity: number;
+  price?: number | null;
   is_active?: boolean;
   repeat?: SlotRepeat;
 }
@@ -190,6 +196,8 @@ export interface AvailabilityCell {
   start_time: string;
   end_time: string;
   capacity: number;
+  // The slot's own price, or the space's, or 0 — before tax.
+  price: number;
   booked_count: number;
   waitlist_count: number;
   my_status: MyStatus;

--- a/frontend/locales/ca/bookings.json
+++ b/frontend/locales/ca/bookings.json
@@ -17,7 +17,10 @@
       "bookedToast": "Reserva confirmada",
       "waitlistedToast": "Afegit a la llista d'espera",
       "membershipTypeNotAllowed": "Aquest espai està reservat a altres tipus de soci. El teu tipus de soci no l'inclou; consulta amb el club si el vols canviar.",
-      "noMembershipType": "Aquest espai està reservat a determinats tipus de soci i la teva fitxa no en té cap d'assignat. Escriu al club perquè te n'assigni un."
+      "noMembershipType": "Aquest espai està reservat a determinats tipus de soci i la teva fitxa no en té cap d'assignat. Escriu al club perquè te n'assigni un.",
+      "price": "Aquesta reserva costa {price} abans d'impostos; el rebut mostrarà l'import final.",
+      "priceOnPromotion": "Si queda una plaça lliure, la reserva es confirma automàticament i es cobren {price} abans d'impostos; el rebut mostrarà l'import final.",
+      "refundPolicy": "Si cancel·les abans de pagar, el càrrec s'anul·la amb la reserva. Un cop pagat, l'import no es retorna automàticament: ni si cancel·les, ni si el club elimina la franja. Qualsevol devolució s'acorda directament amb el club."
     },
     "my": {
       "title": "Les meves reserves",
@@ -37,6 +40,9 @@
       "type": "Tipus",
       "typePlaceholder": "pista, sala, camp…",
       "description": "Descripció",
+      "price": "Preu per reserva",
+      "priceHint": "Abans d'impostos. Deixa-ho buit, o a 0, i l'espai és gratuït: no s'emet cap rebut.",
+      "free": "Gratuït",
       "openTime": "Obertura",
       "closeTime": "Tancament",
       "hours": "Horari",
@@ -61,6 +67,9 @@
       "start": "Inici",
       "end": "Fi",
       "capacity": "Aforament",
+      "price": "Preu",
+      "priceHint": "Deixa-ho buit per fer servir el preu de l'espai. Posa 0 perquè aquesta franja sigui gratuïta.",
+      "priceFromSpace": "Preu de l'espai",
       "active": "Activa",
       "inactive": "Inactiva",
       "activate": "Activa",

--- a/frontend/locales/en/bookings.json
+++ b/frontend/locales/en/bookings.json
@@ -17,7 +17,10 @@
       "bookedToast": "Booked",
       "waitlistedToast": "Added to the waitlist",
       "membershipTypeNotAllowed": "This space is reserved for other membership types. Yours does not include it — ask the club if you want to change it.",
-      "noMembershipType": "This space is reserved for certain membership types and your record has none assigned. Ask the club to assign you one."
+      "noMembershipType": "This space is reserved for certain membership types and your record has none assigned. Ask the club to assign you one.",
+      "price": "This booking costs {price} before tax; the receipt will show the final amount.",
+      "priceOnPromotion": "If a place frees up you are booked automatically and charged {price} before tax; the receipt will show the final amount.",
+      "refundPolicy": "If you cancel before paying, the charge is cancelled with it. Once paid, the money is not returned automatically \u2014 not if you cancel, and not if the club removes the slot. Arrange any refund with the club."
     },
     "my": {
       "title": "My bookings",
@@ -37,6 +40,9 @@
       "type": "Type",
       "typePlaceholder": "pitch, court, room…",
       "description": "Description",
+      "price": "Price per booking",
+      "priceHint": "Before tax. Leave it empty, or 0, and the space is free \u2014 no receipt is raised.",
+      "free": "Free",
       "openTime": "Opens",
       "closeTime": "Closes",
       "hours": "Hours",
@@ -61,6 +67,9 @@
       "start": "Start",
       "end": "End",
       "capacity": "Capacity",
+      "price": "Price",
+      "priceHint": "Leave it empty to use the space's price. Enter 0 to make this slot free.",
+      "priceFromSpace": "Space price",
       "active": "Active",
       "inactive": "Inactive",
       "activate": "Activate",

--- a/frontend/locales/es/bookings.json
+++ b/frontend/locales/es/bookings.json
@@ -17,7 +17,10 @@
       "bookedToast": "Reserva confirmada",
       "waitlistedToast": "Añadido a la lista de espera",
       "membershipTypeNotAllowed": "Este espacio está reservado a otros tipos de socio. Tu tipo de socio no lo incluye; consulta con el club si quieres cambiarlo.",
-      "noMembershipType": "Este espacio está reservado a determinados tipos de socio y tu ficha no tiene ninguno asignado. Escribe al club para que te asigne uno."
+      "noMembershipType": "Este espacio está reservado a determinados tipos de socio y tu ficha no tiene ninguno asignado. Escribe al club para que te asigne uno.",
+      "price": "Esta reserva cuesta {price} antes de impuestos; el recibo mostrará el importe final.",
+      "priceOnPromotion": "Si queda una plaza libre, la reserva se confirma automáticamente y se cobran {price} antes de impuestos; el recibo mostrará el importe final.",
+      "refundPolicy": "Si cancelas antes de pagar, el cargo se anula con la reserva. Una vez pagado, el importe no se devuelve automáticamente: ni al cancelar, ni si el club elimina la franja. Cualquier devolución se acuerda directamente con el club."
     },
     "my": {
       "title": "Mis reservas",
@@ -37,6 +40,9 @@
       "type": "Tipo",
       "typePlaceholder": "pista, sala, campo…",
       "description": "Descripción",
+      "price": "Precio por reserva",
+      "priceHint": "Antes de impuestos. Déjalo vacío, o a 0, y el espacio es gratuito: no se emite ningún recibo.",
+      "free": "Gratuito",
       "openTime": "Apertura",
       "closeTime": "Cierre",
       "hours": "Horario",
@@ -61,6 +67,9 @@
       "start": "Inicio",
       "end": "Fin",
       "capacity": "Aforo",
+      "price": "Precio",
+      "priceHint": "Déjalo vacío para usar el precio del espacio. Pon 0 para que esta franja sea gratuita.",
+      "priceFromSpace": "Precio del espacio",
       "active": "Activa",
       "inactive": "Inactiva",
       "activate": "Activar",


### PR DESCRIPTION
**Phases 2 and 3 of #148**, completing the issue. Two commits — phase 2 is mergeable on its own, since without the UI to set a price every space stays free and the receipt paths never fire.

Closes #148.

## `d39d004` — phase 2: charge for a space

Price on `Space`, nullable per-slot override on `SpaceSlot`. A booking raises a receipt on **every** confirmation path — `create_booking` and waitlist promotion — idempotently, following `ensure_registration_receipt`. A zero or absent price raises nothing. Cancelling voids the unpaid receipt and leaves a paid one alone, mirroring `cancel_registration`.

`'booking'` is added to the `origin` and `concept_type` CHECK constraints rather than reusing the unused `'service'` slot: a club sells bookings and activities as different products, and no report should have to know that `'service'` secretly means `'booking'`.

`generate_booking_receipt` is annotated `-> Receipt | None`, unlike its activity sibling (#106).

### `Receipt.booking_id` is `ondelete="SET NULL"`, and that is load-bearing

`Booking.space_slot_id` is `ondelete="CASCADE"` and `delete_slot(force=True)` calls `db.delete(slot)`, so bookings are hard-deleted. `Receipt.registration_id` is a plain FK with no `ondelete` — safe only because registrations are *never* hard-deleted. Copying that shape here would make `delete_slot(force=True)` fail with a foreign key violation the moment an affected booking had a receipt: the admin's force escape hatch breaking precisely when money is involved.

Two tests guard it. `test_forced_slot_delete_succeeds_and_the_receipt_survives` books a paid slot, force-deletes it, and asserts the booking row is gone while the receipt still exists with `booking_id` NULL, status still `emitted`, total still 12.10, description still naming the space. A sibling covers `delete_space(force=True)`.

Because the ORM nullifies loaded children by itself and would mask a wrong constraint, `test_receipt_booking_fk_is_set_null_on_delete` reads `pg_constraint.confdeltype` directly and asserts `'n'`.

## `a3bded1` — phase 3: show the price before they commit

Admin sets the space price and the optional per-slot override. The booking dialog shows the cost and the refund policy.

The refund wording is stated plainly because there is no refund path to imply — no credit notes (#154), and `process_refund` raises `NotImplementedError`:

> "If you cancel before paying, the charge is cancelled with it. Once paid, the money is not returned automatically — not if you cancel, and not if the club removes the slot. Arrange any refund with the club."

Joining a waitlist gets its own sentence, since that commits the member to being charged on promotion.

## Two things the issue under-specified

**The member sees a pre-tax number.** The stored price is a base amount and VAT is added when the receipt is raised, so the dialog says "costs {price} before tax; the receipt will show the final amount" rather than quoting a total the receipt then contradicts. Showing the exact total would need the availability cell to carry it — a small backend change, deliberately not made, since phase 3 was scoped as frontend. Worth doing if a reviewer wants the precise figure on screen.

**Spaces have no VAT rate of their own.** Activities carry `Activity.tax_rate`; a booking is taxed at the organisation's `default_vat_rate`. A club charging a different rate for court hire cannot express it. MVP call, easy to add later.

## Testing

- Backend: **1504 passed**, 0 failed — run after rebasing onto current `main`
- Migration verified on a scratch database: `upgrade head` → `downgrade -1` → `upgrade head`, all clean
- Frontend: `✓ Compiled successfully`, `✔ No ESLint warnings or errors`

Cypress not run; the bookings spec creates spaces without a price, so everything stays free there.

## The conflict that would have broken startup

Phase 1 (#157) merged partway through this work. Both migrations initially declared `down_revision = 'a5b6c7d8e9f0'`, which makes **two Alembic heads** and stops the API container booting — `alembic upgrade head` cannot resolve them. `test_migration_graph.py::test_graph_loads_and_has_a_single_head` catches it; this migration now points at phase 1's `b6c7d8e9f0a1`.

The other conflict worth noting: phase 1 replaced the inline waitlist promotion with `_promote_next`, so the receipt call moved inside it, next to `send_promoted` — where it belongs, and where `test_waitlist_promotion_bills_the_promoted_member` covers it.
