### PR TITLE
Settle the rounding rule, then prorate a first membership charge

### DIFF
--- a/backend/alembic/versions/01ea89383f1d_add_receipt_purchased_membership_type.py
+++ b/backend/alembic/versions/01ea89383f1d_add_receipt_purchased_membership_type.py
@@ -1,0 +1,56 @@
+"""add receipt purchased membership type
+
+Records which plan a purchase receipt was raised for, so that activation can
+read it off the receipt it has just marked paid. A member must not move tiers
+until the money arrives, which means the pending purchase has to be remembered
+somewhere, and the receipt is the row that already knows when it is paid.
+
+``ON DELETE SET NULL``, matching ``members.membership_type_id`` — the only other
+foreign key to this table, and the one that settles the question of whether a
+membership type is a row the schema expects to survive losing. The API only ever
+soft-deletes one (``DELETE /membership-types/{id}`` sets ``is_active = false``),
+but a plain restricting key would turn any future hard delete into a foreign key
+violation on a receipt, which is exactly the trap the booking column avoided. A
+receipt outlives the plan and keeps its description and its amount, which is
+what the member was actually invoiced for.
+
+The column is nullable and every existing row stays NULL, so this migration
+changes nothing until the purchase flow exists.
+
+Revision ID: 01ea89383f1d
+Revises: c6d7e8f9a0b1
+Create Date: 2026-09-07 10:35:42.954905
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '01ea89383f1d'
+down_revision: Union[str, None] = 'c6d7e8f9a0b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'receipts',
+        sa.Column('purchased_membership_type_id', sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        'fk_receipts_purchased_membership_type_id',
+        'receipts',
+        'membership_types',
+        ['purchased_membership_type_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'fk_receipts_purchased_membership_type_id', 'receipts', type_='foreignkey'
+    )
+    op.drop_column('receipts', 'purchased_membership_type_id')

--- a/backend/app/core/money.py
+++ b/backend/app/core/money.py
@@ -1,0 +1,31 @@
+"""Money rounding — one quantisation rule for every euro amount the app computes.
+
+Every derived amount (VAT, a percentage discount, a prorated first period) is
+rounded here and nowhere else. Two rules were in use before this module existed:
+billing quantised with an explicit ``ROUND_HALF_UP`` while ``discount_service``
+called a bare ``.quantize(Decimal("0.01"))``, which silently inherits whatever
+rounding the ambient decimal context carries — ``ROUND_HALF_EVEN`` by default.
+The two disagree by a cent on an exact half, so a discounted registration could
+contradict the receipt raised from it, and nothing in the source said so.
+
+``ROUND_HALF_UP`` is the rule that wins: it is the ordinary convention for VAT
+in Spain and it is what the billing paths already applied.
+
+This does not cover the two places that convert a euro amount to minor units for
+a payment provider (``sepa_xml`` and ``stripe_provider``). Those truncate rather
+than round, which is a different defect, tracked separately.
+"""
+
+from decimal import ROUND_HALF_UP, Decimal
+
+# Euro cents: the only precision a stored or transmitted amount ever has.
+CENTS = Decimal("0.01")
+
+
+def round_money(amount: Decimal) -> Decimal:
+    """Round ``amount`` to two decimals, half away from zero.
+
+    Always pass a ``Decimal``. A float has already lost the exact half this
+    function exists to decide.
+    """
+    return amount.quantize(CENTS, rounding=ROUND_HALF_UP)

--- a/backend/app/domains/activities/discount_service.py
+++ b/backend/app/domains/activities/discount_service.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 
 from sqlalchemy.orm import Session
 
+from app.core.money import round_money
 from app.domains.activities.models import DiscountCode
 
 
@@ -52,7 +53,7 @@ def apply_discount(price_amount: Decimal, discount: DiscountCode) -> Decimal:
         result = price_amount - discount.discount_value
 
     # Never go below zero
-    return max(Decimal("0"), result.quantize(Decimal("0.01")))
+    return max(Decimal("0"), round_money(result))
 
 
 def increment_usage(db: Session, discount: DiscountCode) -> None:

--- a/backend/app/domains/billing/models.py
+++ b/backend/app/domains/billing/models.py
@@ -103,6 +103,15 @@ class Receipt(Base):
     booking_id = Column(
         Integer, ForeignKey("bookings.id", ondelete="SET NULL")
     )
+    # The plan an unpaid purchase receipt was raised for, so activation can read
+    # it off the receipt it has just marked paid. SET NULL, like
+    # ``members.membership_type_id`` — the only other foreign key to this table,
+    # and the one that establishes a membership type is a row the schema expects
+    # to be able to lose. A receipt must outlive that: it keeps its description
+    # and its amount, which is what the member was actually invoiced for.
+    purchased_membership_type_id = Column(
+        Integer, ForeignKey("membership_types.id", ondelete="SET NULL")
+    )
     remittance_id = Column(Integer, ForeignKey("remittances.id"))
     created_by = Column(Integer, ForeignKey("users.id"))
 
@@ -165,6 +174,7 @@ class Receipt(Base):
     concept = relationship("Concept", back_populates="receipts")
     registration = relationship("Registration", backref="receipts")
     booking = relationship("Booking", backref="receipts")
+    purchased_membership_type = relationship("MembershipType")
     remittance = relationship("Remittance", back_populates="receipts")
     creator = relationship("User", foreign_keys=[created_by])
 

--- a/backend/app/domains/billing/proration.py
+++ b/backend/app/domains/billing/proration.py
@@ -1,0 +1,96 @@
+"""Proration — what a membership plan costs for the rest of the period it is bought in.
+
+The billing engine is calendar-anchored: ``compute_period`` returns the natural
+month, quarter or year, and a ``BillingRun`` is unique per period. A member who
+buys mid-period therefore pays for the remainder of that period at purchase and
+joins the ordinary cycle with everybody else at the next boundary.
+
+The remainder is counted in **whole months, including the month of purchase**.
+A 200 EUR/year plan bought on 15 March covers March to December — 10 of 12
+months, 166.67 EUR — not the 160.00 EUR an elapsed-days count would give.
+Membership is felt monthly rather than daily, "10 of 12 months" is an invoice
+line a treasurer can check by hand, and nobody joining on the 30th pays almost
+nothing for a month they used. It also makes the arithmetic immune to month
+lengths and leap days: February is a month like any other.
+
+Nothing calls this yet. The purchase endpoint that will is a later phase.
+"""
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from app.core.money import round_money
+from app.domains.billing.recurring_billing_service import compute_period
+
+# Whole months in one calendar period of each recurring frequency.
+MONTHS_IN_PERIOD = {"monthly": 1, "quarterly": 3, "annual": 12}
+
+
+@dataclass(frozen=True)
+class ProratedCharge:
+    """What to charge for a plan bought mid-period, and which period it covers.
+
+    ``period_start`` / ``period_end`` are the calendar period the charge covers,
+    and a receipt raised from this must be stamped with them: fee generation
+    skips a member who already holds a receipt for the same period, so correct
+    stamping is what stops the next scheduled run billing the buyer twice.
+
+    Every field but ``amount`` is ``None`` for a ``one_time`` plan, which has no
+    calendar period and is never billed again.
+    """
+
+    amount: Decimal
+    period_start: date | None
+    period_end: date | None
+    months_charged: int | None
+    months_in_period: int | None
+
+
+def prorate_membership_price(
+    base_price: Decimal | None, frequency: str, purchase_date: date
+) -> ProratedCharge:
+    """The base amount to charge for ``frequency`` bought on ``purchase_date``.
+
+    Pre-tax: VAT is applied to this figure when the receipt is raised, not here.
+
+    ``monthly`` is never prorated — the period is the month of purchase, so the
+    whole of it is charged.
+
+    ``one_time`` is supported deliberately rather than left to raise. A plan the
+    membership-type API already permits means *pay once, hold indefinitely*: the
+    recurring engine excludes it (``is_frequency_due`` is always ``False``), so
+    there is no period to prorate against, nothing to stamp on the receipt to
+    deduplicate against a later run, and no renewal. The full price is charged.
+
+    Raises ``ValueError`` for any other frequency.
+    """
+    price = Decimal("0") if base_price is None else Decimal(str(base_price))
+
+    if frequency == "one_time":
+        return ProratedCharge(
+            amount=round_money(price),
+            period_start=None,
+            period_end=None,
+            months_charged=None,
+            months_in_period=None,
+        )
+
+    months_in_period = MONTHS_IN_PERIOD.get(frequency)
+    if months_in_period is None:
+        raise ValueError(f"Unsupported billing frequency: {frequency!r}")
+
+    period_start, period_end = compute_period(frequency, purchase_date)
+    months_charged = (
+        (period_end.year - purchase_date.year) * 12
+        + (period_end.month - purchase_date.month)
+        + 1
+    )
+
+    return ProratedCharge(
+        amount=round_money(price * months_charged / months_in_period),
+        period_start=period_start,
+        period_end=period_end,
+        months_charged=months_charged,
+        months_in_period=months_in_period,
+    )

--- a/backend/app/domains/billing/service.py
+++ b/backend/app/domains/billing/service.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import Sequence
 from datetime import date, datetime, timezone
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 
 from fastapi import HTTPException, status
 from sqlalchemy import extract, func, or_
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Query, Session, joinedload
 
 from sqlalchemy.exc import IntegrityError
 
+from app.core.money import round_money
 from app.domains.billing.models import Concept, InvoiceSequence, Receipt
 from app.domains.billing.schemas import (
     GenerateMembershipFeesRequest,
@@ -84,9 +85,7 @@ def calculate_vat(base_amount: Decimal, vat_rate: Decimal) -> tuple[Decimal, Dec
 
     Returns (vat_amount, total_amount).
     """
-    vat_amount = (base_amount * vat_rate / Decimal("100")).quantize(
-        Decimal("0.01"), rounding=ROUND_HALF_UP
-    )
+    vat_amount = round_money(base_amount * vat_rate / Decimal("100"))
     total_amount = base_amount + vat_amount
     return vat_amount, total_amount
 
@@ -209,9 +208,7 @@ def create_receipt(
     # Apply discount
     discount_amount = Decimal(str(data.discount_amount or 0))
     if data.discount_type == "percentage" and discount_amount > 0:
-        discount_amount = (base_amount * discount_amount / Decimal("100")).quantize(
-            Decimal("0.01"), rounding=ROUND_HALF_UP
-        )
+        discount_amount = round_money(base_amount * discount_amount / Decimal("100"))
 
     effective_base = base_amount - discount_amount
     if effective_base < 0:

--- a/backend/tests/unit/test_money.py
+++ b/backend/tests/unit/test_money.py
@@ -1,0 +1,106 @@
+"""Unit tests for the shared money rounding rule.
+
+Pure-function tests — no database required.
+
+The point of every exact-half case below is that ``ROUND_HALF_EVEN``, the
+default the decimal context hands to a bare ``.quantize``, would answer
+differently. That divergence was the defect: billing rounded one way and
+discounts the other, so a discounted registration could contradict the receipt
+raised from it.
+"""
+
+import decimal
+from decimal import ROUND_HALF_EVEN, Decimal
+
+import pytest
+
+from app.core.money import round_money
+
+
+class TestRoundMoney:
+    def test_rounds_up_on_an_exact_half(self):
+        assert round_money(Decimal("1.005")) == Decimal("1.01")
+
+    def test_exact_half_does_not_round_to_even(self):
+        """The case where the two rules disagree: half-even would give 1.02."""
+        assert round_money(Decimal("1.025")) == Decimal("1.03")
+        assert Decimal("1.025").quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_EVEN
+        ) == Decimal("1.02")
+
+    def test_rounds_down_below_a_half(self):
+        assert round_money(Decimal("1.004")) == Decimal("1.00")
+
+    def test_rounds_up_above_a_half(self):
+        assert round_money(Decimal("1.006")) == Decimal("1.01")
+
+    def test_negative_exact_half_rounds_away_from_zero(self):
+        assert round_money(Decimal("-1.005")) == Decimal("-1.01")
+
+    def test_already_two_decimals_is_unchanged(self):
+        assert round_money(Decimal("42.42")) == Decimal("42.42")
+
+    def test_result_always_carries_two_decimal_places(self):
+        assert str(round_money(Decimal("5"))) == "5.00"
+        assert str(round_money(Decimal("5.1"))) == "5.10"
+
+    def test_zero(self):
+        assert round_money(Decimal("0")) == Decimal("0.00")
+
+    def test_a_repeating_division_is_truncated_to_cents(self):
+        assert round_money(Decimal("200") * 10 / 12) == Decimal("166.67")
+
+    def test_ignores_the_ambient_decimal_context_rounding(self):
+        """A caller's context must not be able to change the answer.
+
+        This is the whole reason the rule is passed explicitly rather than
+        inherited: the context is process-wide, mutable and invisible at the
+        call site.
+        """
+        with decimal.localcontext() as ctx:
+            ctx.rounding = ROUND_HALF_EVEN
+            assert round_money(Decimal("1.025")) == Decimal("1.03")
+
+
+class TestCallSitesShareTheRule:
+    """The three money paths that were split across two rounding modes."""
+
+    def test_vat_uses_half_up(self):
+        from app.domains.billing.service import calculate_vat
+
+        # 10.05 EUR at 10% VAT is exactly 1.005.
+        vat_amount, total = calculate_vat(Decimal("10.05"), Decimal("10"))
+        assert vat_amount == Decimal("1.01")
+        assert total == Decimal("11.06")
+
+    def test_percentage_discount_uses_half_up(self):
+        from types import SimpleNamespace
+
+        from app.domains.activities.discount_service import apply_discount
+
+        # 10.05 less 10% is 9.045 — an exact half that half-even sends to 9.04.
+        discount = SimpleNamespace(discount_type="percentage", discount_value=Decimal("10"))
+        assert apply_discount(Decimal("10.05"), discount) == Decimal("9.05")
+
+    def test_discount_still_clamps_at_zero(self):
+        from types import SimpleNamespace
+
+        from app.domains.activities.discount_service import apply_discount
+
+        discount = SimpleNamespace(discount_type="fixed", discount_value=Decimal("50"))
+        assert apply_discount(Decimal("10.00"), discount) == Decimal("0")
+
+
+@pytest.mark.parametrize(
+    "amount,expected",
+    [
+        ("0.005", "0.01"),
+        ("0.015", "0.02"),
+        ("0.025", "0.03"),
+        ("0.035", "0.04"),
+        ("0.045", "0.05"),
+    ],
+)
+def test_every_exact_half_rounds_up(amount, expected):
+    """Half-even would alternate down/up across this sequence."""
+    assert round_money(Decimal(amount)) == Decimal(expected)

--- a/backend/tests/unit/test_proration.py
+++ b/backend/tests/unit/test_proration.py
@@ -1,0 +1,254 @@
+"""Unit tests for membership plan proration.
+
+Pure-function tests — no database required.
+
+Proration counts whole months remaining in the calendar period, including the
+month of purchase. These tests are deliberately exhaustive: this is arithmetic
+about money that a treasurer will check by hand, and it is the one part of the
+purchase flow with no user interface to notice a mistake.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.domains.billing.proration import ProratedCharge, prorate_membership_price
+
+
+class TestTheWorkedExamplesFromTheDesign:
+    def test_annual_plan_bought_in_march(self):
+        """200 EUR/year on 15 March covers March-December: 10 of 12 months."""
+        charge = prorate_membership_price(Decimal("200.00"), "annual", date(2026, 3, 15))
+        assert charge.amount == Decimal("166.67")
+        assert charge.months_charged == 10
+        assert charge.months_in_period == 12
+        assert charge.period_start == date(2026, 1, 1)
+        assert charge.period_end == date(2026, 12, 31)
+
+    def test_quarterly_plan_bought_in_february(self):
+        """50 EUR/quarter on 15 February covers February and March: 2 of 3."""
+        charge = prorate_membership_price(Decimal("50.00"), "quarterly", date(2026, 2, 15))
+        assert charge.amount == Decimal("33.33")
+        assert charge.months_charged == 2
+        assert charge.months_in_period == 3
+        assert charge.period_start == date(2026, 1, 1)
+        assert charge.period_end == date(2026, 3, 31)
+
+    def test_whole_months_not_elapsed_days(self):
+        """The day of the month never changes the answer.
+
+        An elapsed-days rule would charge 160.00 for 15 March. Counting whole
+        months is what makes the 1st and the 31st cost the same.
+        """
+        first = prorate_membership_price(Decimal("200.00"), "annual", date(2026, 3, 1))
+        last = prorate_membership_price(Decimal("200.00"), "annual", date(2026, 3, 31))
+        assert first.amount == last.amount == Decimal("166.67")
+
+
+class TestMonthly:
+    def test_is_never_prorated(self):
+        charge = prorate_membership_price(Decimal("25.00"), "monthly", date(2026, 6, 15))
+        assert charge.amount == Decimal("25.00")
+        assert charge.months_charged == 1
+        assert charge.months_in_period == 1
+
+    def test_first_day_of_the_month(self):
+        charge = prorate_membership_price(Decimal("25.00"), "monthly", date(2026, 6, 1))
+        assert charge.amount == Decimal("25.00")
+        assert charge.period_start == date(2026, 6, 1)
+        assert charge.period_end == date(2026, 6, 30)
+
+    def test_last_day_of_the_month(self):
+        charge = prorate_membership_price(Decimal("25.00"), "monthly", date(2026, 6, 30))
+        assert charge.amount == Decimal("25.00")
+        assert charge.period_start == date(2026, 6, 1)
+        assert charge.period_end == date(2026, 6, 30)
+
+    def test_last_day_of_a_leap_february(self):
+        charge = prorate_membership_price(Decimal("25.00"), "monthly", date(2024, 2, 29))
+        assert charge.amount == Decimal("25.00")
+        assert charge.period_start == date(2024, 2, 1)
+        assert charge.period_end == date(2024, 2, 29)
+
+
+class TestQuarterly:
+    @pytest.mark.parametrize(
+        "purchase,expected_months,expected_amount,period",
+        [
+            # Q1
+            (date(2026, 1, 1), 3, "60.00", (date(2026, 1, 1), date(2026, 3, 31))),
+            (date(2026, 2, 14), 2, "40.00", (date(2026, 1, 1), date(2026, 3, 31))),
+            (date(2026, 3, 31), 1, "20.00", (date(2026, 1, 1), date(2026, 3, 31))),
+            # Q2
+            (date(2026, 4, 1), 3, "60.00", (date(2026, 4, 1), date(2026, 6, 30))),
+            (date(2026, 5, 20), 2, "40.00", (date(2026, 4, 1), date(2026, 6, 30))),
+            (date(2026, 6, 30), 1, "20.00", (date(2026, 4, 1), date(2026, 6, 30))),
+            # Q3
+            (date(2026, 7, 1), 3, "60.00", (date(2026, 7, 1), date(2026, 9, 30))),
+            (date(2026, 8, 2), 2, "40.00", (date(2026, 7, 1), date(2026, 9, 30))),
+            (date(2026, 9, 30), 1, "20.00", (date(2026, 7, 1), date(2026, 9, 30))),
+            # Q4
+            (date(2026, 10, 1), 3, "60.00", (date(2026, 10, 1), date(2026, 12, 31))),
+            (date(2026, 11, 11), 2, "40.00", (date(2026, 10, 1), date(2026, 12, 31))),
+            (date(2026, 12, 31), 1, "20.00", (date(2026, 10, 1), date(2026, 12, 31))),
+        ],
+    )
+    def test_every_month_of_every_quarter(
+        self, purchase, expected_months, expected_amount, period
+    ):
+        charge = prorate_membership_price(Decimal("60.00"), "quarterly", purchase)
+        assert charge.months_charged == expected_months
+        assert charge.months_in_period == 3
+        assert charge.amount == Decimal(expected_amount)
+        assert (charge.period_start, charge.period_end) == period
+
+    def test_first_month_of_a_quarter_pays_the_full_price(self):
+        charge = prorate_membership_price(Decimal("50.00"), "quarterly", date(2026, 7, 3))
+        assert charge.amount == Decimal("50.00")
+        assert charge.months_charged == charge.months_in_period == 3
+
+    def test_last_month_of_a_quarter_pays_one_third(self):
+        charge = prorate_membership_price(Decimal("50.00"), "quarterly", date(2026, 9, 3))
+        assert charge.amount == Decimal("16.67")
+        assert charge.months_charged == 1
+
+    def test_leap_day_is_an_ordinary_february(self):
+        charge = prorate_membership_price(Decimal("60.00"), "quarterly", date(2024, 2, 29))
+        assert charge.amount == Decimal("40.00")
+        assert charge.months_charged == 2
+        assert charge.period_end == date(2024, 3, 31)
+
+
+class TestAnnual:
+    @pytest.mark.parametrize(
+        "month,expected_months,expected_amount",
+        [
+            (1, 12, "240.00"),
+            (2, 11, "220.00"),
+            (3, 10, "200.00"),
+            (4, 9, "180.00"),
+            (5, 8, "160.00"),
+            (6, 7, "140.00"),
+            (7, 6, "120.00"),
+            (8, 5, "100.00"),
+            (9, 4, "80.00"),
+            (10, 3, "60.00"),
+            (11, 2, "40.00"),
+            (12, 1, "20.00"),
+        ],
+    )
+    def test_every_month_of_the_year(self, month, expected_months, expected_amount):
+        charge = prorate_membership_price(
+            Decimal("240.00"), "annual", date(2026, month, 10)
+        )
+        assert charge.months_charged == expected_months
+        assert charge.months_in_period == 12
+        assert charge.amount == Decimal(expected_amount)
+        assert charge.period_start == date(2026, 1, 1)
+        assert charge.period_end == date(2026, 12, 31)
+
+    def test_first_day_of_the_year_pays_the_full_price(self):
+        charge = prorate_membership_price(Decimal("240.00"), "annual", date(2026, 1, 1))
+        assert charge.amount == Decimal("240.00")
+
+    def test_last_day_of_the_year_pays_one_month(self):
+        """The December wart, stated as arithmetic.
+
+        Buying an annual plan on 31 December costs one twelfth, and the full
+        year lands the following January. That is the calendar-anchored engine
+        working as designed, and the purchase UI has to say so.
+        """
+        charge = prorate_membership_price(Decimal("240.00"), "annual", date(2026, 12, 31))
+        assert charge.amount == Decimal("20.00")
+        assert charge.months_charged == 1
+
+    def test_leap_day_is_an_ordinary_february(self):
+        charge = prorate_membership_price(Decimal("240.00"), "annual", date(2024, 2, 29))
+        assert charge.amount == Decimal("220.00")
+        assert charge.months_charged == 11
+        assert charge.period_end == date(2024, 12, 31)
+
+    def test_a_leap_year_costs_the_same_as_a_common_one(self):
+        leap = prorate_membership_price(Decimal("240.00"), "annual", date(2024, 3, 1))
+        common = prorate_membership_price(Decimal("240.00"), "annual", date(2026, 3, 1))
+        assert leap.amount == common.amount
+
+
+class TestOneTime:
+    """Pay once, hold indefinitely: no proration, no period, no renewal.
+
+    The recurring engine never bills a ``one_time`` plan — ``is_frequency_due``
+    is always ``False`` for it — so there is no period to prorate against and
+    nothing a later run could double-bill.
+    """
+
+    def test_charges_the_full_price(self):
+        charge = prorate_membership_price(Decimal("300.00"), "one_time", date(2026, 12, 31))
+        assert charge.amount == Decimal("300.00")
+
+    def test_has_no_calendar_period(self):
+        charge = prorate_membership_price(Decimal("300.00"), "one_time", date(2026, 3, 15))
+        assert charge.period_start is None
+        assert charge.period_end is None
+        assert charge.months_charged is None
+        assert charge.months_in_period is None
+
+    def test_does_not_raise_the_way_compute_period_does(self):
+        """``compute_period('one_time', ...)`` raises; this must not."""
+        from app.domains.billing.recurring_billing_service import compute_period
+
+        with pytest.raises(ValueError):
+            compute_period("one_time", date(2026, 3, 15))
+
+        assert prorate_membership_price(
+            Decimal("10.00"), "one_time", date(2026, 3, 15)
+        ).amount == Decimal("10.00")
+
+    @pytest.mark.parametrize("day", [date(2026, 1, 1), date(2026, 6, 15), date(2026, 12, 31)])
+    def test_the_purchase_date_never_changes_the_price(self, day):
+        assert prorate_membership_price(Decimal("300.00"), "one_time", day).amount == (
+            Decimal("300.00")
+        )
+
+
+class TestRounding:
+    def test_uses_the_shared_half_up_rule(self):
+        """An annual plan bought in July is charged exactly half its price.
+
+        100.01 / 2 is 50.005 — the exact half where the old bare ``.quantize``
+        would have answered 50.00.
+        """
+        charge = prorate_membership_price(Decimal("100.01"), "annual", date(2026, 7, 4))
+        assert charge.months_charged == 6
+        assert charge.amount == Decimal("50.01")
+
+    def test_a_repeating_fraction_is_cut_at_cents(self):
+        charge = prorate_membership_price(Decimal("100.00"), "quarterly", date(2026, 2, 1))
+        assert charge.amount == Decimal("66.67")
+
+    def test_the_result_always_carries_two_decimals(self):
+        charge = prorate_membership_price(Decimal("120"), "annual", date(2026, 1, 1))
+        assert str(charge.amount) == "120.00"
+
+
+class TestDegenerateInputs:
+    def test_a_free_plan_costs_nothing(self):
+        charge = prorate_membership_price(Decimal("0.00"), "annual", date(2026, 3, 15))
+        assert charge.amount == Decimal("0.00")
+        assert charge.months_charged == 10
+
+    def test_a_null_price_is_treated_as_free(self):
+        """``membership_types.base_price`` is nullable, so this reaches us."""
+        charge = prorate_membership_price(None, "annual", date(2026, 3, 15))
+        assert charge.amount == Decimal("0.00")
+
+    def test_an_unknown_frequency_is_refused(self):
+        with pytest.raises(ValueError, match="Unsupported billing frequency"):
+            prorate_membership_price(Decimal("100.00"), "weekly", date(2026, 3, 15))
+
+    def test_the_result_is_immutable(self):
+        charge = prorate_membership_price(Decimal("100.00"), "annual", date(2026, 3, 15))
+        assert isinstance(charge, ProratedCharge)
+        with pytest.raises(Exception):
+            charge.amount = Decimal("1.00")


### PR DESCRIPTION
**Phase 1 of #146** — arithmetic and schema, nothing wired up. It ships inert: no endpoint calls the new code until phase 2, so this is safe to merge ahead of the rest. #146 stays open for phases 2 and 3.

Closes #100.

## `6db4c09` — one rounding rule

`billing/service.py` quantized with an explicit `ROUND_HALF_UP`; `activities/discount_service.py:55` called a bare `.quantize(Decimal("0.01"))` and inherited `ROUND_HALF_EVEN` from the decimal context. The two differ by a cent on exact halves, so a discounted receipt could disagree with its own total — #100.

`app/core/money.py` now holds the single rule, and `calculate_vat`, the percentage-discount branch of `create_receipt`, and `apply_discount` all go through it. `ROUND_HALF_UP` is what the billing paths already used and the ordinary convention for VAT in Spain.

Doing this **before** the proration work is the point: adding new money arithmetic beside a second, invisible rounding mode would have entrenched #100 rather than closed it.

**No existing test encoded the old behaviour** — `test_discount_codes.py` only asserts round numbers, and nothing in the suite reached an exact half through `apply_discount`. The new `test_money.py` pins the divergence in both directions, including a case asserting what half-even *would* have answered.

`sepa_xml.py:79` and `stripe_provider.py:34` are deliberately untouched: their truncation to minor units is #112, a different defect. `cli/seed.py` and `cli/demo_data.py` still use bare `.quantize` — fixture data rather than real money, and the remaining holdouts if anyone wants them swept.

## `29cd745` — proration and the receipt column

`prorate_membership_price` charges the whole months remaining in the calendar period, counting the month of purchase. Verified independently against the worked examples:

| Plan | Bought | Charge |
|---|---|---|
| 200 €/year | 15 March | 166.67 € |
| 50 €/quarter | 15 February | 33.33 € |
| 30 €/month | 28 March | 30.00 € (never prorated) |
| 200 €/year | 3 December | 16.67 € |
| 200 €/year | 9 January | 200.00 € |

The December row is the documented wart — buy an annual plan then and you pay about a twelfth before the full year lands in January. Correct, and phase 3 must say so at the point of purchase.

`Receipt.purchased_membership_type_id` records which plan an unpaid purchase receipt is for, so activation can read it off the receipt it just marked paid.

### `one_time` is supported, not refused

The frequency is already permitted by the CHECK constraint, so an admin can create such a plan today, and refusing to sell it would still need a refusal path in phase 2 — so it is not the smaller change.

What makes `one_time` awkward elsewhere is what makes it safe here: `is_frequency_due` is always `False` for it and `generate_membership_fees` never sees it, so there is no later run to double-bill and nothing needing a stamped period. "Pay once, hold indefinitely" falls out with no machinery. A test pins the deliberate divergence — `compute_period("one_time", …)` still raises while `prorate_membership_price` does not.

### The foreign key is `ON DELETE SET NULL`

`DELETE /membership-types/{id}` is a **soft** delete (`membership_types.py:132` sets `is_active = False`), and no `db.delete()` targets `MembershipType` anywhere, so by the letter of the plan a bare FK would have been safe.

The decisive evidence was elsewhere: **`members.membership_type_id` is already `ondelete="SET NULL"`** (`members/models.py:120`). That is the only other foreign key to the table, and it settles the schema's own position — membership types are rows the schema expects to be able to lose, and it has already decided what happens to dependents. A restricting key on `receipts` would contradict that and turn any future hard delete into a foreign key violation on a *receipt*, which is the `delete_slot(force=True)` shape #148 phase 2 had to avoid. A receipt keeps its description and amount either way, which is what the member was invoiced for.

## Testing

- Backend: **1573 passed**, 0 failed. 18 new tests on the rounding rule, 51 on the proration arithmetic.
- Migration verified against a live database: `upgrade head` → `downgrade -1` → `upgrade head`, then the FK confirmed as `ON DELETE SET NULL` in `\d receipts`.
- Frontend untouched.

## Unrelated drift found, not fixed

Autogenerate also emitted `op.drop_index('ix_reminders_id', table_name='reminders')`. That index is created by `a2b3c4d5e6f7_add_reminders_table.py` on the older `reminders` table and no model declares it — pre-existing model/DB drift, removed from this migration rather than shipped as a silent unrelated schema change. Worth its own issue.
