### PR TITLE
Let a member buy a plan, and grant it when the money arrives

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -25,6 +25,7 @@ from app.api.v1.endpoints import (
     member_card,
     member_photo,
     members,
+    membership_purchase,
     payment_providers,
     remittances,
     roles,
@@ -62,6 +63,7 @@ api_router.include_router(members.router)
 api_router.include_router(member_card.router, dependencies=_approved_only)
 api_router.include_router(member_photo.router, dependencies=_approved_only)
 api_router.include_router(membership_types.router, dependencies=_approved_only)
+api_router.include_router(membership_purchase.router, dependencies=_approved_only)
 api_router.include_router(persons.router, dependencies=_approved_only)
 api_router.include_router(registrations.router, dependencies=_approved_only)
 api_router.include_router(reminders.router, dependencies=_approved_only)

--- a/backend/app/api/v1/endpoints/membership_purchase.py
+++ b/backend/app/api/v1/endpoints/membership_purchase.py
@@ -1,0 +1,133 @@
+"""A member buying their own membership plan.
+
+Separate from ``PUT /members/me`` on purpose. ``MemberSelfUpdate`` excludes
+``membership_type_id`` because the tier sets the recurring fee and unlocks
+restricted activities, and that guard stays: buying a plan has its own rules —
+a price, a prorated first period, and a payment that has to arrive before
+anything changes — none of which a profile update could enforce.
+
+Nothing here takes a payment. The purchase raises an emitted receipt and hands
+its id back; the portal then posts it to the Stripe or Redsys checkout that
+already exists, restricts a member to their own receipts, and already has
+working webhooks and return paths.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.authorization import require_permission
+from app.db.session import get_db
+from app.domains.auth.models import User
+from app.domains.billing.membership_purchase_service import (
+    MembershipQuote,
+    purchase_membership,
+    quote_membership_purchase,
+)
+from app.domains.billing.schemas import (
+    MembershipPurchaseQuote,
+    MembershipPurchaseRequest,
+    MembershipPurchaseResponse,
+)
+from app.domains.members.models import Member, MembershipType
+
+router = APIRouter(prefix="/members/me/membership", tags=["members"])
+
+
+def _own_member(db: Session, user: User) -> Member:
+    """The caller's own member record, resolved through the foreign key.
+
+    Never through ``Person.email``: that column is non-unique and a minor
+    routinely shares a guardian's address, so an email match can return somebody
+    else's member row — and this endpoint would then bill them.
+    """
+    member = (
+        db.query(Member)
+        .filter(Member.user_id == user.id, Member.is_active.is_(True))
+        .first()
+    )
+    if not member:
+        raise HTTPException(status_code=404, detail="Member not found")
+    return member
+
+
+def _membership_type(db: Session, membership_type_id: int) -> MembershipType:
+    mtype = (
+        db.query(MembershipType)
+        .filter(MembershipType.id == membership_type_id)
+        .first()
+    )
+    if not mtype:
+        raise HTTPException(status_code=404, detail="Membership type not found")
+    return mtype
+
+
+def _quote_fields(quote: MembershipQuote) -> dict:
+    mtype = quote.membership_type
+    return {
+        "membership_type_id": mtype.id,
+        "membership_type_name": mtype.name,
+        "billing_frequency": mtype.billing_frequency,
+        "full_price": mtype.base_price,
+        "base_amount": quote.base_amount,
+        "vat_rate": quote.vat_rate,
+        "vat_amount": quote.vat_amount,
+        "total_amount": quote.total_amount,
+        "is_prorated": quote.is_prorated,
+        "period_start": quote.period_start,
+        "period_end": quote.period_end,
+        "months_charged": quote.months_charged,
+        "months_in_period": quote.months_in_period,
+    }
+
+
+@router.get("/quote/{membership_type_id}", response_model=MembershipPurchaseQuote)
+def quote_membership(
+    membership_type_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_permission("self.billing.read")),
+):
+    """Price a plan for the caller without raising anything.
+
+    Refuses exactly what the purchase refuses, so a plan that cannot be bought
+    cannot be quoted either and the portal never offers a price it would then
+    reject.
+    """
+    member = _own_member(db, current_user)
+    mtype = _membership_type(db, membership_type_id)
+    quote = quote_membership_purchase(db, member, mtype)
+    return MembershipPurchaseQuote(**_quote_fields(quote))
+
+
+@router.post(
+    "/purchase",
+    response_model=MembershipPurchaseResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def purchase_membership_endpoint(
+    data: MembershipPurchaseRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_permission("self.billing.write")),
+):
+    """Buy a plan: raise the receipt, and leave the member on their current tier.
+
+    The plan is granted when the receipt is paid, wherever the money comes from
+    — card, cash recorded by an admin, or a SEPA collection reconciled days
+    later. Any purchase still awaiting payment is voided by this one, so a
+    member who picked the wrong plan can simply pick again.
+    """
+    member = _own_member(db, current_user)
+    mtype = _membership_type(db, data.membership_type_id)
+
+    receipt, quote = purchase_membership(
+        db, member, mtype, created_by_id=current_user.id
+    )
+    db.commit()
+    db.refresh(receipt)
+
+    return MembershipPurchaseResponse(
+        **_quote_fields(quote),
+        receipt_id=receipt.id,
+        receipt_number=receipt.receipt_number,
+        receipt_status=receipt.status,
+        due_date=receipt.due_date,
+    )

--- a/backend/app/domains/billing/membership_purchase_service.py
+++ b/backend/app/domains/billing/membership_purchase_service.py
@@ -1,0 +1,334 @@
+"""Buying a membership plan — quoting it, billing it, and granting it once paid.
+
+A member cannot write their own ``membership_type_id``: ``MemberSelfUpdate``
+excludes it because the tier sets the recurring fee and unlocks restricted
+activities. Buying a plan is therefore not a relaxed profile update but its own
+flow, and it splits in two.
+
+**Buying raises a receipt and changes nothing else.** The member keeps the tier
+they already hold — the free default, in the ordinary case — and every access
+that tier gives, until the money actually arrives. Buying is not having.
+
+**Paying is what grants the plan**, through ``mark_receipt_paid``: the single
+place a receipt becomes paid, shared by an admin recording cash, both card
+webhooks and the reconciliation of a SEPA remittance. Hanging activation there
+is what makes a member who pays their treasurer in cash get their plan on
+exactly the same terms as one who pays by card.
+
+The first charge is prorated against the calendar period the purchase falls in
+(see ``proration``) and the receipt is stamped with that period, because
+``generate_membership_fees`` skips a member who already holds a receipt for it.
+Stamped correctly the next scheduled run leaves the buyer alone; stamped wrongly
+it bills them a second time for months they have already paid for.
+
+An unpaid purchase does not become a debt. It is voided at its due date, and
+starting another purchase voids whichever one is still open, so a member who
+picked the wrong plan or closed the checkout tab is neither chased by the
+dunning pipeline nor stuck waiting for an admin to unpick it.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.domains.billing.models import Concept, Receipt
+from app.domains.billing.proration import prorate_membership_price
+from app.domains.billing.recurring_billing_service import due_days
+from app.domains.billing.service import (
+    calculate_vat,
+    cancel_receipt,
+    generate_receipt_number,
+    membership_concept,
+)
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+
+logger = logging.getLogger(__name__)
+
+# The statuses in which a purchase receipt still owes money and has therefore
+# granted nothing. ``paid`` is settled, ``cancelled`` is already gone, and
+# ``returned`` reaches here too: a paid receipt is terminal, so a returned one
+# was never paid and never activated anything.
+OPEN_PURCHASE_STATUSES = ("new", "pending", "emitted", "overdue", "returned")
+
+
+@dataclass(frozen=True)
+class MembershipQuote:
+    """What a plan costs this member today — including the tax on it.
+
+    ``base_amount`` is the prorated price before tax and ``total_amount`` is what
+    the member actually pays. Both are here on purpose: the stored plan price is
+    a base amount and VAT is only added when the receipt is raised, so anything
+    quoting the plan price alone shows a figure the receipt then contradicts.
+    The arithmetic is done once, here, rather than guessed at by the caller.
+    """
+
+    membership_type: MembershipType
+    base_amount: Decimal
+    vat_rate: Decimal
+    vat_amount: Decimal
+    total_amount: Decimal
+    period_start: date | None
+    period_end: date | None
+    months_charged: int | None
+    months_in_period: int | None
+
+    @property
+    def is_prorated(self) -> bool:
+        """Whether this charge covers less than a whole period."""
+        return (
+            self.months_charged is not None
+            and self.months_in_period is not None
+            and self.months_charged < self.months_in_period
+        )
+
+
+def _assert_purchasable(member: Member, mtype: MembershipType) -> None:
+    """Reject the purchases that should never reach a receipt.
+
+    Approval is checked here as well as on the router: the router's
+    ``require_approved_member`` is what a request meets first, but the service
+    is also reachable from a script or a future admin-assisted flow, and "the
+    sign-up is not approved yet" must not depend on which door was used.
+    """
+    if member.status == "pending":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="A membership plan cannot be bought until the sign-up is approved",
+        )
+    if not mtype.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This membership plan is not available",
+        )
+    if mtype.base_price is None or Decimal(str(mtype.base_price)) <= 0:
+        # A free tier is granted, not sold. Selling one would raise a zero
+        # receipt that can never be paid, so the plan would never activate.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This membership plan is free and cannot be bought",
+        )
+    if member.membership_type_id == mtype.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This is already the current membership plan",
+        )
+
+
+def _quote(
+    db: Session, mtype: MembershipType, vat_rate: Decimal, today: date
+) -> MembershipQuote:
+    try:
+        charge = prorate_membership_price(mtype.base_price, mtype.billing_frequency, today)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+
+    vat_amount, total_amount = calculate_vat(charge.amount, vat_rate)
+    return MembershipQuote(
+        membership_type=mtype,
+        base_amount=charge.amount,
+        vat_rate=vat_rate,
+        vat_amount=vat_amount,
+        total_amount=total_amount,
+        period_start=charge.period_start,
+        period_end=charge.period_end,
+        months_charged=charge.months_charged,
+        months_in_period=charge.months_in_period,
+    )
+
+
+def _default_vat_rate(db: Session) -> Decimal:
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    return Decimal(str((org.default_vat_rate if org else None) or 21))
+
+
+def quote_membership_purchase(
+    db: Session, member: Member, mtype: MembershipType, today: date | None = None
+) -> MembershipQuote:
+    """Price ``mtype`` for ``member`` without raising anything.
+
+    Reads the concept's VAT rate where one already exists and falls back to the
+    organization default, which is the rate a concept created by the purchase
+    would be given — so the quote and the receipt that follows it agree.
+    """
+    today = today or date.today()
+    _assert_purchasable(member, mtype)
+
+    concept = (
+        db.query(Concept)
+        .filter(
+            Concept.code == f"membership-{mtype.slug}",
+            Concept.is_active.is_(True),
+        )
+        .first()
+    )
+    vat_rate = (
+        Decimal(str(concept.vat_rate)) if concept is not None else _default_vat_rate(db)
+    )
+    return _quote(db, mtype, vat_rate, today)
+
+
+def void_open_purchases(db: Session, member_id: int) -> list[Receipt]:
+    """Cancel every purchase receipt this member still owes money on.
+
+    Called when a new purchase starts. A member who picked the wrong plan can
+    then change their mind on their own; without this they would hold two live
+    invoices for two plans and need an admin to take one away.
+
+    Receipts already handed to the bank are left alone — see
+    ``expire_unpaid_purchases``.
+    """
+    db.flush()
+    open_purchases = (
+        db.query(Receipt)
+        .filter(
+            Receipt.member_id == member_id,
+            Receipt.purchased_membership_type_id.isnot(None),
+            Receipt.is_active.is_(True),
+            Receipt.remittance_id.is_(None),
+            Receipt.status.in_(OPEN_PURCHASE_STATUSES),
+        )
+        .all()
+    )
+    for receipt in open_purchases:
+        cancel_receipt(db, receipt)
+    return open_purchases
+
+
+def purchase_membership(
+    db: Session,
+    member: Member,
+    mtype: MembershipType,
+    today: date | None = None,
+    created_by_id: int | None = None,
+) -> tuple[Receipt, MembershipQuote]:
+    """Raise the receipt for ``member`` buying ``mtype``, and change nothing else.
+
+    The member stays on the tier they hold. The receipt is born ``emitted``,
+    which is what the Stripe and Redsys checkout endpoints require and what
+    makes it collectable in a SEPA remittance; the plan is granted only when it
+    is paid.
+
+    Does not commit — the caller owns the transaction.
+    """
+    today = today or date.today()
+    _assert_purchasable(member, mtype)
+
+    void_open_purchases(db, member.id)
+
+    concept = membership_concept(db, mtype, _default_vat_rate(db))
+    quote = _quote(db, mtype, Decimal(str(concept.vat_rate)), today)
+
+    # "10 of 12 months" is an invoice line a treasurer can check by hand, so it
+    # is on the receipt rather than only implied by an amount that does not match
+    # the plan's advertised price.
+    description = mtype.name
+    if quote.is_prorated:
+        description = f"{mtype.name} — {quote.months_charged}/{quote.months_in_period}"
+
+    receipt = Receipt(
+        receipt_number=generate_receipt_number(db, today),
+        member_id=member.id,
+        concept_id=concept.id,
+        purchased_membership_type_id=mtype.id,
+        # ``membership``, not a new origin: it is what the fee generator's
+        # skip-if-exists check filters on, and a purchase covering the period
+        # only stops the next run duplicating it if the two agree.
+        origin="membership",
+        description=description,
+        base_amount=quote.base_amount,
+        vat_rate=quote.vat_rate,
+        vat_amount=quote.vat_amount,
+        total_amount=quote.total_amount,
+        status="emitted",
+        emission_date=today,
+        due_date=today + timedelta(days=due_days(db)),
+        billing_period_start=quote.period_start,
+        billing_period_end=quote.period_end,
+        is_batchable=True,
+        created_by=created_by_id,
+    )
+    db.add(receipt)
+    db.flush()
+    return receipt, quote
+
+
+def activate_purchased_membership(db: Session, receipt: Receipt) -> bool:
+    """Move the member onto the plan their receipt was raised for.
+
+    Called inline by ``mark_receipt_paid``, inside the transaction that records
+    the payment: the tier is a database effect, and a member whose payment
+    committed while their plan did not would hold a paid invoice for something
+    they never received.
+
+    Returns whether a tier was actually changed. A receipt with no plan on it —
+    every ordinary fee, activity and booking receipt — is not a purchase and is
+    left alone, and neither is one whose plan row has since been deleted, which
+    the ``ON DELETE SET NULL`` foreign key turns into exactly that case.
+    """
+    if receipt.purchased_membership_type_id is None:
+        return False
+
+    mtype = (
+        db.query(MembershipType)
+        .filter(MembershipType.id == receipt.purchased_membership_type_id)
+        .first()
+    )
+    member = db.query(Member).filter(Member.id == receipt.member_id).first()
+    if mtype is None or member is None:
+        logger.error(
+            "Paid purchase receipt %s has no plan or member to activate", receipt.id
+        )
+        return False
+
+    if member.membership_type_id == mtype.id:
+        return False
+
+    # Deliberately not gated on ``mtype.is_active``. A club retiring a plan
+    # between purchase and payment does not undo the payment, and the member
+    # bought what they bought.
+    member.membership_type_id = mtype.id
+    db.flush()
+    return True
+
+
+def expire_unpaid_purchases(db: Session, today: date | None = None) -> int:
+    """Void purchase receipts nobody paid by their due date.
+
+    An abandoned checkout is not a debt. Left open, the receipt would be marked
+    overdue and then chased by the dunning pipeline for a plan the member never
+    received — the wrong message, sent about money that is not owed.
+
+    Runs before ``mark_overdue`` on the same schedule, and on the same
+    ``due_date < today`` boundary, so an expiring purchase is voided rather than
+    ever reaching ``overdue``.
+
+    A receipt already in a remittance is left alone: it has been handed to the
+    bank and its collection is out of our hands, so voiding it here would only
+    make our records disagree with the money that is still on its way.
+
+    Returns how many were voided. Does not commit.
+    """
+    today = today or date.today()
+    expired = (
+        db.query(Receipt)
+        .filter(
+            Receipt.purchased_membership_type_id.isnot(None),
+            Receipt.is_active.is_(True),
+            Receipt.remittance_id.is_(None),
+            Receipt.status.in_(OPEN_PURCHASE_STATUSES),
+            Receipt.payment_date.is_(None),
+            Receipt.due_date.isnot(None),
+            Receipt.due_date < today,
+        )
+        .all()
+    )
+    for receipt in expired:
+        cancel_receipt(db, receipt)
+    return len(expired)

--- a/backend/app/domains/billing/recurring_billing_service.py
+++ b/backend/app/domains/billing/recurring_billing_service.py
@@ -40,7 +40,13 @@ def _last_day_of_month(year: int, month: int) -> int:
     return calendar.monthrange(year, month)[1]
 
 
-def _due_days(db: Session) -> int:
+def due_days(db: Session) -> int:
+    """How many days after emission an automatically raised fee falls due.
+
+    Shared with the plan-purchase flow, which gives a member the same window to
+    pay as the scheduled run gives everybody else — one configured answer to
+    "how long does an unpaid receipt stay open", not two that drift.
+    """
     org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
     features = (org.features if org else None) or {}
     try:
@@ -126,7 +132,7 @@ def run_billing(
     """
     today = today or date.today()
     period_start, period_end = compute_period(frequency, today)
-    due_date = today + timedelta(days=_due_days(db))
+    due_date = today + timedelta(days=due_days(db))
 
     existing = (
         db.query(BillingRun)

--- a/backend/app/domains/billing/schemas.py
+++ b/backend/app/domains/billing/schemas.py
@@ -108,6 +108,7 @@ class ReceiptResponse(BaseModel):
     concept_id: int | None
     registration_id: int | None
     remittance_id: int | None
+    purchased_membership_type_id: int | None = None
     origin: str
     description: str
     base_amount: Decimal
@@ -325,3 +326,54 @@ class ReceiptReminderResponse(BaseModel):
     error: str | None = None
     sent_at: datetime | None = None
     created_at: datetime | None = None
+
+
+# --- Membership plan purchase schemas ---
+
+
+class MembershipPurchaseRequest(BaseModel):
+    membership_type_id: int
+
+
+class MembershipPurchaseQuote(BaseModel):
+    """What buying a plan costs today, before and after tax.
+
+    ``total_amount`` is the figure to show a member. The stored plan price is a
+    base amount and VAT is only added when the receipt is raised, so a portal
+    quoting ``base_amount`` alone would show a number the receipt contradicts —
+    the tax is computed here, by the same code that raises the receipt, rather
+    than reconstructed in the browser from a rate it has no reliable way to read.
+
+    ``months_charged`` / ``months_in_period`` are the prorated fraction of the
+    calendar period being paid for, and are null for a ``one_time`` plan, which
+    has no period. They are what lets the portal warn that an annual plan bought
+    in December is a month of cover, not a year.
+    """
+
+    membership_type_id: int
+    membership_type_name: str
+    billing_frequency: str
+    full_price: Decimal
+    base_amount: Decimal
+    vat_rate: Decimal
+    vat_amount: Decimal
+    total_amount: Decimal
+    is_prorated: bool
+    period_start: date | None = None
+    period_end: date | None = None
+    months_charged: int | None = None
+    months_in_period: int | None = None
+
+
+class MembershipPurchaseResponse(MembershipPurchaseQuote):
+    """The quote that was charged, plus the receipt now waiting to be paid.
+
+    ``receipt_id`` is what the portal hands to the existing Stripe or Redsys
+    checkout endpoint. The member's plan does not change until that receipt is
+    paid.
+    """
+
+    receipt_id: int
+    receipt_number: str
+    receipt_status: str
+    due_date: date | None = None

--- a/backend/app/domains/billing/service.py
+++ b/backend/app/domains/billing/service.py
@@ -295,8 +295,9 @@ def mark_receipt_paid(
     attached here**, so it fires for all of them and for whatever payment method
     is added next.
 
-    Effects that must be atomic with the payment — activating something the
-    member has just bought — belong inline, in the caller's transaction. Emails
+    Effects that must be atomic with the payment — moving a member onto the
+    membership plan they have just bought — belong inline, in the caller's
+    transaction. Emails
     and other outbound notifications must not fire until that transaction has
     committed, so they are not sent here: the ids of the receipts needing one
     are returned, and the caller passes them to
@@ -324,6 +325,18 @@ def mark_receipt_paid(
         receipt.redsys_auth_code = redsys_auth_code
 
     db.flush()
+
+    # Granting a bought membership plan is a database effect, so it happens here
+    # rather than in the notification the caller sends after committing: the
+    # member's tier and the payment that bought it have to land together or not
+    # at all. Imported inside the function because the purchase service builds on
+    # this module. A no-op for every receipt that is not a purchase.
+    from app.domains.billing.membership_purchase_service import (
+        activate_purchased_membership,
+    )
+
+    activate_purchased_membership(db, receipt)
+
     return [receipt.id]
 
 
@@ -414,6 +427,40 @@ def reemit_receipt(db: Session, receipt: Receipt) -> Receipt:
 # --- Fee Generation ---
 
 
+def membership_concept(
+    db: Session, mtype: MembershipType, default_vat: Decimal
+) -> Concept:
+    """The billing concept a membership type's fees are raised against.
+
+    One concept per membership type, keyed on its slug and created on first use.
+    Both the scheduled fee run and a member buying the plan themselves come
+    here, so a purchase is invoiced at the same VAT rate the next scheduled run
+    will apply — quoting one rate at checkout and billing another in January is
+    a discrepancy nobody would be able to explain afterwards.
+    """
+    concept = (
+        db.query(Concept)
+        .filter(
+            Concept.code == f"membership-{mtype.slug}",
+            Concept.is_active.is_(True),
+        )
+        .first()
+    )
+    if concept:
+        return concept
+
+    concept = Concept(
+        name=f"{mtype.name}",
+        code=f"membership-{mtype.slug}",
+        concept_type="membership",
+        default_amount=mtype.base_price,
+        vat_rate=default_vat,
+    )
+    db.add(concept)
+    db.flush()
+    return concept
+
+
 def generate_membership_fees(
     db: Session,
     data: GenerateMembershipFeesRequest,
@@ -488,25 +535,7 @@ def generate_membership_fees(
 
         # Get or create concept for this membership type
         if mtype.id not in concept_cache:
-            concept = (
-                db.query(Concept)
-                .filter(
-                    Concept.code == f"membership-{mtype.slug}",
-                    Concept.is_active.is_(True),
-                )
-                .first()
-            )
-            if not concept:
-                concept = Concept(
-                    name=f"{mtype.name}",
-                    code=f"membership-{mtype.slug}",
-                    concept_type="membership",
-                    default_amount=mtype.base_price,
-                    vat_rate=default_vat,
-                )
-                db.add(concept)
-                db.flush()
-            concept_cache[mtype.id] = concept
+            concept_cache[mtype.id] = membership_concept(db, mtype, default_vat)
 
         concept = concept_cache[mtype.id]
         base_amount = Decimal(str(mtype.base_price))

--- a/backend/app/tasks/billing_tasks.py
+++ b/backend/app/tasks/billing_tasks.py
@@ -69,17 +69,26 @@ def scheduled_billing_run() -> dict:
 
 @celery.task
 def scheduled_payment_reminders() -> dict:
-    """Daily Beat entry point: mark overdue receipts, then send due reminders.
+    """Daily Beat entry point: void expired purchases, mark overdue, then remind.
 
-    No-op (returns zero counts) unless payment reminders are enabled in org
-    settings. Returns a small summary dict for the Celery result backend / logs.
+    Abandoned plan purchases are voided first and unconditionally. They are not
+    debts — nobody received the plan — so they must never reach ``mark_overdue``
+    and be chased for money that is not owed, and that has to hold whether or
+    not the club has switched payment reminders on. Everything after it is the
+    ordinary dunning pass, which stays a no-op (zero counts) while reminders are
+    disabled in org settings.
+
+    Returns a small summary dict for the Celery result backend / logs.
     """
     from app.db.session import SessionLocal
+    from app.domains.billing.membership_purchase_service import expire_unpaid_purchases
     from app.domains.billing.reminder_service import run_scheduled_reminders
 
     db = SessionLocal()
     try:
-        summary = run_scheduled_reminders(db)
+        purchases_expired = expire_unpaid_purchases(db)
+        summary = {"purchases_expired": purchases_expired}
+        summary.update(run_scheduled_reminders(db))
         db.commit()
         logger.info(f"Scheduled payment reminders complete: {summary}")
         return summary

--- a/backend/tests/integration/api/v1/test_membership_purchase.py
+++ b/backend/tests/integration/api/v1/test_membership_purchase.py
@@ -1,0 +1,320 @@
+"""The member-facing endpoints for buying a membership plan."""
+
+from datetime import date
+from decimal import Decimal
+
+from app.core.security.jwt import create_access_token
+from app.core.security.password import hash_password
+from app.domains.auth.models import User
+from app.domains.billing.models import Receipt
+from app.domains.members.models import Member, MembershipType
+from app.domains.members.schemas import MemberSelfUpdate
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+
+def _org(db):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if org:
+        return org
+    org = OrganizationSettings(
+        id=1,
+        name="Buy API Club",
+        currency="EUR",
+        invoice_prefix="FAC",
+        invoice_annual_reset=True,
+        default_vat_rate=Decimal("21.00"),
+    )
+    db.add(org)
+    db.flush()
+    return org
+
+
+def _tier(db, suffix, price, frequency="annual", is_active=True):
+    mtype = MembershipType(
+        name=f"API Tier {suffix}",
+        slug=f"api-tier-{suffix}",
+        base_price=Decimal(str(price)),
+        billing_frequency=frequency,
+        is_active=is_active,
+    )
+    db.add(mtype)
+    db.flush()
+    return mtype
+
+
+def _member_user(db, suffix, tier, status="active"):
+    email = f"api-buy-{suffix}@example.test"
+    person = Person(first_name="Api", last_name=f"Buyer{suffix}", email=email)
+    db.add(person)
+    db.flush()
+    user = User(
+        person_id=person.id,
+        email=email,
+        password_hash=hash_password("password123"),
+        role="member",
+        is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    member = Member(
+        person_id=person.id,
+        user_id=user.id,
+        membership_type_id=tier.id,
+        member_number=f"API-{suffix}",
+        status=status,
+        is_active=True,
+    )
+    db.add(member)
+    db.flush()
+    return user, member
+
+
+def _setup(db, suffix, *, price=200, frequency="annual", status="active"):
+    _org(db)
+    free = _tier(db, f"free-{suffix}", 0)
+    paid = _tier(db, f"paid-{suffix}", price, frequency)
+    user, member = _member_user(db, suffix, free, status=status)
+    return user, member, free, paid
+
+
+def _auth(user):
+    return {"access_token": create_access_token(user.id)}
+
+
+class TestQuote:
+    def test_returns_the_tax_inclusive_total(self, client, db):
+        user, _, _, paid = _setup(db, "quote", price=200)
+        db.commit()
+
+        r = client.get(
+            f"/api/v1/members/me/membership/quote/{paid.id}", cookies=_auth(user)
+        )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert Decimal(data["full_price"]) == Decimal("200.00")
+        # The portal shows `total_amount`; `base_amount` is the pre-tax figure
+        # the plan advertises, which the receipt would otherwise contradict.
+        assert Decimal(data["total_amount"]) == (
+            Decimal(data["base_amount"]) + Decimal(data["vat_amount"])
+        )
+        assert Decimal(data["vat_rate"]) == Decimal("21.00")
+        assert data["billing_frequency"] == "annual"
+        assert data["months_in_period"] == 12
+
+    def test_quoting_raises_no_receipt(self, client, db):
+        user, member, _, paid = _setup(db, "quotenoreceipt")
+        db.commit()
+
+        client.get(
+            f"/api/v1/members/me/membership/quote/{paid.id}", cookies=_auth(user)
+        )
+
+        assert db.query(Receipt).filter(Receipt.member_id == member.id).count() == 0
+
+    def test_unknown_plan_is_404(self, client, db):
+        user, _, _, _ = _setup(db, "quote404")
+        db.commit()
+
+        r = client.get(
+            "/api/v1/members/me/membership/quote/99999", cookies=_auth(user)
+        )
+
+        assert r.status_code == 404
+
+
+class TestPurchase:
+    def test_raises_a_receipt_and_leaves_the_tier_alone(self, client, db):
+        user, member, free, paid = _setup(db, "purchase")
+        db.commit()
+
+        r = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": paid.id},
+            cookies=_auth(user),
+        )
+
+        assert r.status_code == 201
+        data = r.json()
+        assert data["membership_type_id"] == paid.id
+        assert data["receipt_status"] == "emitted"
+
+        receipt = db.query(Receipt).filter(Receipt.id == data["receipt_id"]).one()
+        assert receipt.member_id == member.id
+        assert receipt.purchased_membership_type_id == paid.id
+        db.refresh(member)
+        assert member.membership_type_id == free.id
+
+    def test_the_receipt_id_is_what_checkout_takes(self, client, db):
+        user, _, _, paid = _setup(db, "checkout")
+        db.commit()
+
+        r = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": paid.id},
+            cookies=_auth(user),
+        )
+        receipt_id = r.json()["receipt_id"]
+
+        # No Stripe provider is configured, so the checkout endpoint stops on
+        # that rather than on ownership or a status it will not accept — which
+        # is the part this asserts: the purchase hands checkout a receipt it
+        # recognises as the caller's and as payable.
+        checkout = client.post(
+            f"/api/v1/receipts/{receipt_id}/stripe/checkout", cookies=_auth(user)
+        )
+        assert checkout.status_code == 400
+        assert "Stripe provider" in checkout.json()["detail"]
+
+    def test_another_members_purchase_is_not_payable(self, client, db):
+        user, _, _, paid = _setup(db, "owner")
+        stranger_user, _ = _member_user(db, "stranger", paid)
+        db.commit()
+
+        r = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": paid.id},
+            cookies=_auth(user),
+        )
+        receipt_id = r.json()["receipt_id"]
+
+        checkout = client.post(
+            f"/api/v1/receipts/{receipt_id}/stripe/checkout",
+            cookies=_auth(stranger_user),
+        )
+        assert checkout.status_code == 403
+
+    def test_buying_twice_leaves_one_live_receipt(self, client, db):
+        user, member, _, paid = _setup(db, "twice")
+        other = _tier(db, "twice-other", 300)
+        db.commit()
+
+        first = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": paid.id},
+            cookies=_auth(user),
+        ).json()
+        second = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": other.id},
+            cookies=_auth(user),
+        ).json()
+
+        live = (
+            db.query(Receipt)
+            .filter(
+                Receipt.member_id == member.id,
+                Receipt.status != "cancelled",
+            )
+            .all()
+        )
+        assert [r.id for r in live] == [second["receipt_id"]]
+        assert first["receipt_id"] != second["receipt_id"]
+
+    def test_the_plan_already_held_is_refused(self, client, db):
+        _org(db)
+        paid = _tier(db, "already", 100)
+        user, _ = _member_user(db, "already", paid)
+        db.commit()
+
+        r = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": paid.id},
+            cookies=_auth(user),
+        )
+
+        assert r.status_code == 400
+
+    def test_a_retired_plan_is_refused(self, client, db):
+        user, _, _, _ = _setup(db, "retired")
+        retired = _tier(db, "retired-plan", 100, is_active=False)
+        db.commit()
+
+        r = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": retired.id},
+            cookies=_auth(user),
+        )
+
+        assert r.status_code == 400
+
+    def test_a_sign_up_awaiting_approval_is_refused(self, client, db):
+        user, _, _, paid = _setup(db, "unapproved", status="pending")
+        db.commit()
+
+        r = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": paid.id},
+            cookies=_auth(user),
+        )
+
+        assert r.status_code == 403
+
+    def test_anonymous_callers_are_rejected(self, client, db):
+        _, _, _, paid = _setup(db, "anon")
+        db.commit()
+
+        r = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": paid.id},
+        )
+
+        assert r.status_code == 401
+
+
+class TestSelfUpdateStillGuarded:
+    def test_a_member_cannot_write_their_own_tier(self, client, db):
+        """The purchase endpoint exists because this stays closed."""
+        assert "membership_type_id" not in MemberSelfUpdate.model_fields
+
+        user, member, free, paid = _setup(db, "selfupdate")
+        db.commit()
+
+        r = client.put(
+            f"/api/v1/members/{member.id}",
+            json={"membership_type_id": paid.id},
+            cookies=_auth(user),
+        )
+
+        assert r.status_code == 403
+        assert "membership_type_id" in r.json()["detail"]
+        db.refresh(member)
+        assert member.membership_type_id == free.id
+
+
+class TestActivationThroughTheAdminPaidRoute:
+    def test_an_admin_recording_cash_grants_the_plan(self, client, db):
+        user, member, free, paid = _setup(db, "cash")
+        admin_person = Person(
+            first_name="Admin", last_name="Cash", email="api-buy-admin@example.test"
+        )
+        db.add(admin_person)
+        db.flush()
+        admin = User(
+            person_id=admin_person.id,
+            email=admin_person.email,
+            password_hash=hash_password("password123"),
+            role="admin",
+            is_active=True,
+        )
+        db.add(admin)
+        db.commit()
+
+        purchase = client.post(
+            "/api/v1/members/me/membership/purchase",
+            json={"membership_type_id": paid.id},
+            cookies=_auth(user),
+        ).json()
+        db.refresh(member)
+        assert member.membership_type_id == free.id
+
+        r = client.post(
+            f"/api/v1/receipts/{purchase['receipt_id']}/pay",
+            json={"payment_method": "cash", "payment_date": date.today().isoformat()},
+            cookies=_auth(admin),
+        )
+
+        assert r.status_code == 200
+        db.refresh(member)
+        assert member.membership_type_id == paid.id

--- a/backend/tests/integration/test_membership_purchase.py
+++ b/backend/tests/integration/test_membership_purchase.py
@@ -1,0 +1,497 @@
+"""Buying a membership plan: the receipt it raises, and the plan payment grants."""
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from fastapi import HTTPException
+
+from app.domains.billing.membership_purchase_service import (
+    expire_unpaid_purchases,
+    purchase_membership,
+    quote_membership_purchase,
+)
+from app.domains.billing.models import Receipt, Remittance
+from app.domains.billing.recurring_billing_service import run_billing
+from app.domains.billing.service import mark_receipt_paid, mark_receipts_paid
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+
+# --- Fixtures ---
+
+
+def _org(db, features=None):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if not org:
+        org = OrganizationSettings(
+            id=1,
+            name="Buy Test Club",
+            currency="EUR",
+            invoice_prefix="FAC",
+            invoice_annual_reset=True,
+            default_vat_rate=Decimal("21.00"),
+        )
+        db.add(org)
+    if features is not None:
+        org.features = features
+    db.flush()
+    return org
+
+
+def _tier(db, suffix, price, frequency="annual", is_active=True, is_default=False):
+    mtype = MembershipType(
+        name=f"Tier {suffix}",
+        slug=f"tier-{suffix}",
+        base_price=Decimal(str(price)),
+        billing_frequency=frequency,
+        is_active=is_active,
+        is_default=is_default,
+    )
+    db.add(mtype)
+    db.flush()
+    return mtype
+
+
+def _member(db, suffix, tier, status="active"):
+    person = Person(
+        first_name="Buyer",
+        last_name=f"{suffix}",
+        email=f"{suffix}@buy-test.example",
+    )
+    db.add(person)
+    db.flush()
+    member = Member(
+        person_id=person.id,
+        membership_type_id=tier.id,
+        member_number=f"BUY-{suffix}",
+        status=status,
+        joined_at=date(2026, 1, 1),
+        is_active=True,
+    )
+    db.add(member)
+    db.flush()
+    return member
+
+
+def _setup(db, suffix, *, price=200, frequency="annual", features=None):
+    _org(db, features)
+    free = _tier(db, f"free-{suffix}", 0, "annual")
+    paid = _tier(db, f"paid-{suffix}", price, frequency)
+    member = _member(db, suffix, free)
+    return member, free, paid
+
+
+def _remittance(db, number, total):
+    remittance = Remittance(
+        remittance_number=number,
+        remittance_type="sepa",
+        status="submitted",
+        emission_date=date(2026, 3, 15),
+        due_date=date(2026, 3, 20),
+        total_amount=total,
+        receipt_count=1,
+        creditor_name="Buy Test Club",
+        creditor_iban="ES9121000418450200051332",
+        creditor_id="ES12ZZZ00000000A",
+    )
+    db.add(remittance)
+    db.flush()
+    return remittance
+
+
+def _membership_receipts(db, member_id):
+    return (
+        db.query(Receipt)
+        .filter(
+            Receipt.member_id == member_id,
+            Receipt.origin == "membership",
+            Receipt.is_active.is_(True),
+            Receipt.status != "cancelled",
+        )
+        .all()
+    )
+
+
+# --- The receipt a purchase raises ---
+
+
+class TestPurchaseReceipt:
+    def test_prorated_and_stamped_with_the_calendar_period(self, db):
+        member, _, paid = _setup(db, "prorate", price=200, frequency="annual")
+
+        receipt, quote = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        # March to December: 10 of 12 months of 200.00.
+        assert quote.months_charged == 10
+        assert quote.months_in_period == 12
+        assert receipt.base_amount == Decimal("166.67")
+        assert receipt.billing_period_start == date(2026, 1, 1)
+        assert receipt.billing_period_end == date(2026, 12, 31)
+        assert receipt.purchased_membership_type_id == paid.id
+        assert receipt.origin == "membership"
+        assert receipt.description == "Tier paid-prorate — 10/12"
+
+    def test_receipt_is_emitted_so_the_existing_checkouts_accept_it(self, db):
+        member, _, paid = _setup(db, "emitted")
+
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        # `stripe/checkout` and `redsys/initiate` both refuse anything that is
+        # not emitted or overdue.
+        assert receipt.status == "emitted"
+        assert receipt.is_batchable is True
+
+    def test_due_date_follows_the_configured_window(self, db):
+        member, _, paid = _setup(
+            db, "due", features={"recurring_billing_due_days": 7}
+        )
+
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        assert receipt.due_date == date(2026, 3, 22)
+
+    def test_total_carries_the_vat_the_member_actually_pays(self, db):
+        member, _, paid = _setup(db, "vat", price=200, frequency="annual")
+
+        receipt, quote = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        assert quote.base_amount == Decimal("166.67")
+        assert quote.vat_rate == Decimal("21.00")
+        assert quote.vat_amount == Decimal("35.00")
+        assert quote.total_amount == Decimal("201.67")
+        assert receipt.total_amount == Decimal("201.67")
+
+    def test_one_time_plan_is_charged_in_full_with_no_period(self, db):
+        member, _, paid = _setup(db, "onetime", price=50, frequency="one_time")
+
+        receipt, quote = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        assert receipt.base_amount == Decimal("50.00")
+        assert receipt.billing_period_start is None
+        assert receipt.billing_period_end is None
+        assert quote.is_prorated is False
+        assert receipt.description == "Tier paid-onetime"
+
+    def test_buying_does_not_move_the_member(self, db):
+        member, free, paid = _setup(db, "notyet")
+
+        purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        assert member.membership_type_id == free.id
+
+
+# --- What a purchase refuses ---
+
+
+class TestPurchaseRefusals:
+    def test_inactive_plan(self, db):
+        _org(db)
+        free = _tier(db, "free-inactive", 0)
+        member = _member(db, "inactive", free)
+        retired = _tier(db, "retired", 100, is_active=False)
+
+        with pytest.raises(HTTPException) as exc:
+            purchase_membership(db, member, retired)
+        assert exc.value.status_code == 400
+
+    def test_the_plan_already_held(self, db):
+        _org(db)
+        paid = _tier(db, "held", 100)
+        member = _member(db, "held", paid)
+
+        with pytest.raises(HTTPException) as exc:
+            purchase_membership(db, member, paid)
+        assert exc.value.status_code == 400
+
+    def test_a_free_plan_is_granted_not_sold(self, db):
+        member, free, _ = _setup(db, "freeplan")
+        other_free = _tier(db, "free-other", 0)
+
+        with pytest.raises(HTTPException) as exc:
+            purchase_membership(db, member, other_free)
+        assert exc.value.status_code == 400
+
+    def test_a_sign_up_still_awaiting_approval(self, db):
+        _org(db)
+        free = _tier(db, "free-pending", 0)
+        member = _member(db, "pending", free, status="pending")
+        paid = _tier(db, "paid-pending", 100)
+
+        with pytest.raises(HTTPException) as exc:
+            purchase_membership(db, member, paid)
+        assert exc.value.status_code == 403
+
+    def test_a_quote_refuses_what_a_purchase_refuses(self, db):
+        _org(db)
+        free = _tier(db, "free-quote", 0)
+        member = _member(db, "quote", free)
+        retired = _tier(db, "quote-retired", 100, is_active=False)
+
+        with pytest.raises(HTTPException):
+            quote_membership_purchase(db, member, retired)
+
+    def test_a_quote_raises_nothing(self, db):
+        member, _, paid = _setup(db, "quoteonly")
+
+        quote = quote_membership_purchase(db, member, paid, today=date(2026, 3, 15))
+
+        assert quote.total_amount == Decimal("201.67")
+        assert _membership_receipts(db, member.id) == []
+
+
+# --- Changing your mind ---
+
+
+class TestSupersedingAPurchase:
+    def test_a_new_purchase_voids_the_pending_one(self, db):
+        member, _, first_plan = _setup(db, "changemind")
+        second_plan = _tier(db, "changemind-2", 300)
+
+        first, _ = purchase_membership(db, member, first_plan, today=date(2026, 3, 15))
+        second, _ = purchase_membership(db, member, second_plan, today=date(2026, 3, 16))
+
+        db.refresh(first)
+        assert first.status == "cancelled"
+        assert second.status == "emitted"
+        assert [r.id for r in _membership_receipts(db, member.id)] == [second.id]
+
+    def test_a_purchase_already_handed_to_the_bank_is_left_alone(self, db):
+        member, _, first_plan = _setup(db, "inremittance")
+        second_plan = _tier(db, "inremittance-2", 300)
+
+        first, _ = purchase_membership(db, member, first_plan, today=date(2026, 3, 15))
+        remittance = _remittance(db, "REM-BUY-1", first.total_amount)
+        first.remittance_id = remittance.id
+        db.flush()
+
+        purchase_membership(db, member, second_plan, today=date(2026, 3, 16))
+
+        db.refresh(first)
+        assert first.status == "emitted"
+
+
+# --- Expiry ---
+
+
+class TestExpiry:
+    def test_an_unpaid_purchase_is_voided_past_its_due_date(self, db):
+        member, _, paid = _setup(
+            db, "expire", features={"recurring_billing_due_days": 7}
+        )
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        assert expire_unpaid_purchases(db, date(2026, 3, 23)) == 1
+        db.refresh(receipt)
+        assert receipt.status == "cancelled"
+
+    def test_it_survives_up_to_and_including_the_due_date(self, db):
+        member, _, paid = _setup(
+            db, "notyetdue", features={"recurring_billing_due_days": 7}
+        )
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        assert expire_unpaid_purchases(db, date(2026, 3, 22)) == 0
+        db.refresh(receipt)
+        assert receipt.status == "emitted"
+
+    def test_a_paid_purchase_is_never_touched(self, db):
+        member, _, paid = _setup(
+            db, "paidnotexpired", features={"recurring_billing_due_days": 7}
+        )
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+        mark_receipt_paid(db, receipt, payment_method="cash")
+
+        assert expire_unpaid_purchases(db, date(2026, 4, 30)) == 0
+        db.refresh(receipt)
+        assert receipt.status == "paid"
+
+    def test_an_ordinary_membership_fee_is_never_expired(self, db):
+        member, _, paid = _setup(db, "ordinaryfee")
+        member.membership_type_id = paid.id
+        db.flush()
+        run = run_billing(db, "annual", "scheduled", today=date(2026, 1, 1))
+        assert run.receipts_generated == 1
+
+        assert expire_unpaid_purchases(db, date(2027, 1, 1)) == 0
+        fee = _membership_receipts(db, member.id)[0]
+        assert fee.status == "emitted"
+
+    def test_expiry_runs_before_the_dunning_pass(self, db):
+        member, _, paid = _setup(
+            db,
+            "beforedunning",
+            features={
+                "recurring_billing_due_days": 7,
+                "payment_reminders_enabled": True,
+            },
+        )
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        from app.domains.billing.reminder_service import run_scheduled_reminders
+
+        expire_unpaid_purchases(db, date(2026, 3, 23))
+        summary = run_scheduled_reminders(db, date(2026, 3, 23))
+
+        db.refresh(receipt)
+        assert receipt.status == "cancelled"
+        assert summary["overdue_marked"] == 0
+        assert summary["reminders_sent"] == 0
+
+
+# --- Activation ---
+
+
+class TestActivation:
+    def test_paying_grants_the_plan(self, db):
+        member, free, paid = _setup(db, "activate")
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+        assert member.membership_type_id == free.id
+
+        mark_receipt_paid(db, receipt, payment_method="cash")
+
+        assert member.membership_type_id == paid.id
+
+    @pytest.mark.parametrize(
+        "payment_method",
+        ["cash", "bank_transfer", "stripe_checkout", "redsys", "direct_debit"],
+    )
+    def test_every_payment_method_grants_it_identically(self, db, payment_method):
+        member, _, paid = _setup(db, f"method-{payment_method.replace('_', '-')}")
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+
+        mark_receipt_paid(db, receipt, payment_method=payment_method)
+
+        assert member.membership_type_id == paid.id
+
+    def test_a_sepa_remittance_grants_it_on_reconciliation(self, db):
+        member, free, paid = _setup(db, "sepa")
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+        remittance = _remittance(db, "REM-BUY-SEPA", receipt.total_amount)
+        receipt.remittance_id = remittance.id
+        db.flush()
+        assert member.membership_type_id == free.id
+
+        # What `close_remittance` does days later, in one batch.
+        mark_receipts_paid(
+            db, [receipt], payment_method="direct_debit", payment_date=date(2026, 3, 25)
+        )
+
+        assert member.membership_type_id == paid.id
+        assert receipt.payment_date == date(2026, 3, 25)
+
+    def test_an_ordinary_receipt_changes_no_tier(self, db):
+        member, free, paid = _setup(db, "notapurchase")
+        member.membership_type_id = paid.id
+        db.flush()
+        run_billing(db, "annual", "scheduled", today=date(2026, 1, 1))
+        fee = _membership_receipts(db, member.id)[0]
+        member.membership_type_id = free.id
+        db.flush()
+
+        mark_receipt_paid(db, fee, payment_method="cash")
+
+        assert member.membership_type_id == free.id
+
+    def test_a_deleted_plan_leaves_the_payment_intact(self, db):
+        member, free, paid = _setup(db, "deletedplan")
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+        # What `ON DELETE SET NULL` leaves behind.
+        receipt.purchased_membership_type_id = None
+        db.flush()
+
+        mark_receipt_paid(db, receipt, payment_method="cash")
+
+        assert receipt.status == "paid"
+        assert member.membership_type_id == free.id
+
+
+# --- The reason the period stamp matters ---
+
+
+class TestNoDoubleBilling:
+    def test_the_next_scheduled_run_skips_the_buyer(self, db):
+        """A buyer who paid mid-period is not billed again for that same period.
+
+        This is the whole point of stamping the purchase receipt with the
+        calendar period: `generate_membership_fees` skips a member who already
+        holds a live `membership` receipt for it. Stamped wrongly, the annual run
+        would charge this member a second time for a year they have paid for.
+        """
+        member, _, paid = _setup(db, "nodouble", price=200, frequency="annual")
+
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+        mark_receipt_paid(db, receipt, payment_method="cash")
+        assert member.membership_type_id == paid.id
+
+        run = run_billing(db, "annual", "scheduled", today=date(2026, 3, 20))
+
+        assert run.status == "success"
+        assert run.receipts_generated == 0
+        assert [r.id for r in _membership_receipts(db, member.id)] == [receipt.id]
+
+    def test_the_run_after_the_period_ends_does_bill_them(self, db):
+        """The buyer joins the ordinary cycle at the next calendar boundary."""
+        member, _, paid = _setup(db, "nextperiod", price=200, frequency="annual")
+
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+        mark_receipt_paid(db, receipt, payment_method="cash")
+
+        run = run_billing(db, "annual", "scheduled", today=date(2027, 1, 1))
+
+        assert run.receipts_generated == 1
+        fees = _membership_receipts(db, member.id)
+        assert len(fees) == 2
+        renewal = next(r for r in fees if r.id != receipt.id)
+        assert renewal.base_amount == Decimal("200.00")
+        assert renewal.billing_period_start == date(2027, 1, 1)
+
+    def test_an_unpaid_purchase_still_stops_the_run(self, db):
+        """The dedup key is the period, not the payment.
+
+        An unpaid purchase leaves the member on the free tier, which the fee
+        generator skips anyway (it only bills tiers with a price) — but if an
+        admin moves them by hand while the purchase is open, the stamp is what
+        stops the run raising a second receipt for months already invoiced.
+        """
+        member, _, paid = _setup(db, "unpaiddedup", price=200, frequency="annual")
+        receipt, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+        member.membership_type_id = paid.id
+        db.flush()
+
+        run = run_billing(db, "annual", "scheduled", today=date(2026, 3, 20))
+
+        assert run.receipts_generated == 0
+        assert [r.id for r in _membership_receipts(db, member.id)] == [receipt.id]
+
+    def test_a_monthly_purchase_covers_the_month_it_was_bought_in(self, db):
+        member, _, paid = _setup(db, "monthly", price=30, frequency="monthly")
+
+        receipt, quote = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+        mark_receipt_paid(db, receipt, payment_method="cash")
+
+        assert quote.is_prorated is False
+        assert receipt.base_amount == Decimal("30.00")
+        assert receipt.billing_period_start == date(2026, 3, 1)
+
+        march = run_billing(db, "monthly", "scheduled", today=date(2026, 3, 20))
+        april = run_billing(db, "monthly", "scheduled", today=date(2026, 4, 1))
+        assert march.receipts_generated == 0
+        assert april.receipts_generated == 1
+
+
+# --- The window an abandoned purchase leaves open ---
+
+
+def test_an_expired_purchase_frees_the_period_again(db):
+    """Voiding does not lock the member out of buying the same period later."""
+    member, _, paid = _setup(db, "rebuy", features={"recurring_billing_due_days": 7})
+    first, _ = purchase_membership(db, member, paid, today=date(2026, 3, 15))
+    expire_unpaid_purchases(db, date(2026, 3, 23))
+
+    second, _ = purchase_membership(db, member, paid, today=date(2026, 4, 1))
+
+    assert second.billing_period_start == date(2026, 1, 1)
+    assert second.base_amount == Decimal("150.00")  # April to December, 9/12
+    assert second.due_date == date(2026, 4, 1) + timedelta(days=7)

--- a/backend/tests/unit/test_redsys_provider.py
+++ b/backend/tests/unit/test_redsys_provider.py
@@ -85,6 +85,9 @@ def fake_receipt(receipt_id: int = 42, amount: str = "50.00", description: str =
         description=description,
         status="emitted",
         payment_method=None,
+        # Every real receipt carries this, and `mark_receipt_paid` reads it to
+        # decide whether a membership plan was bought and has to be activated.
+        purchased_membership_type_id=None,
     )
 
 


### PR DESCRIPTION
**Phase 2 of #146** — the purchase flow and activation. Backend only; phase 3 (the portal UI) is separate, so #146 stays open.

`POST /members/me/membership/purchase` raises a prorated receipt for the plan a member chose. `GET /members/me/membership/quote/{id}` is its side-effect-free companion.

`MemberSelfUpdate` still excludes `membership_type_id` — the guard is why this needed its own route rather than a relaxed `PUT`.

## Buying is not having

The purchase raises a receipt and changes nothing else. The member keeps their current tier, and their access with it, until the money arrives. **Activation hangs off `mark_receipt_paid`** — the single place a receipt becomes paid since #144 — so cash handed to an admin activates a plan exactly as a card payment does, and a SEPA collection activates it when the remittance is reconciled.

Changing the tier is a database effect, so it runs inline in the same transaction that records the payment. Closing a remittance weeks after a purchase moves every buyer's tier as part of that one commit; a batch cannot end up half-settled.

## The receipt is stamped with the calendar period, and that is the whole point

`generate_membership_fees` skips a member who already has a receipt for the same period (`billing/service.py:381`). Stamping the purchase receipt with `billing_period_start`/`billing_period_end` therefore makes the next scheduled run skip the buyer for free — and getting it wrong would bill them twice for the same months.

`TestNoDoubleBilling::test_the_next_scheduled_run_skips_the_buyer` buys a 200 €/yr plan on 2026-03-15, pays it, then runs the real annual billing on 2026-03-20 and asserts `receipts_generated == 0` with exactly one membership receipt on the member. Companions cover the 2027 run billing the full 200.00, an unpaid purchase plus a hand-moved tier still blocking the run, and a monthly purchase blocking March but not April.

## The endpoint returns a tax-inclusive total

`MembershipPurchaseQuote` carries `full_price`, `base_amount` (prorated, pre-tax), `vat_rate`, `vat_amount` and `total_amount`, plus `months_charged` / `months_in_period` / `is_prorated`.

#148 phase 3 had to say "before tax" because the VAT rate is not in the payload a member may read, so the browser genuinely could not compute it. Here the endpoint is ours — and there is a sharper reason to answer server-side: the rate is not the org default in general, it is `Concept.vat_rate` on the `membership-{slug}` concept, which an admin can edit. A browser assuming 21 % would be wrong for exactly the clubs that changed it. `membership_concept()` is now shared by quote, purchase and the scheduled fee run, so a plan cannot be quoted at one rate and renewed at another.

## Unpaid purchases expire, with one exception

A purchase receipt is voided the day after its due date, so nobody is chased by dunning for a plan they never received, and a new purchase voids any pending one so a member can change their mind without an admin.

**Both skip a receipt that has a `remittance_id`.** A SEPA collection is routinely presented after the due date; voiding a receipt already handed to the bank would make the books disagree with money still in flight.

The sweep runs at the top of the `scheduled_payment_reminders` Beat task, **outside** the `payment_reminders_enabled` gate — an abandoned purchase must be voided whether or not the club runs dunning, or it becomes permanent phantom debt.

## Things the issue did not anticipate

- **The checkout endpoints dictate the receipt's birth status.** `stripe/checkout` and `redsys/initiate` refuse anything not `emitted`/`overdue`, so the purchase receipt is created `emitted`, not `pending` — which is also what makes it batchable into a SEPA remittance.
- **A free tier cannot be sold.** A zero receipt can never be paid, so the plan would never activate and the member would be stuck. Refused with a 400.
- **The double-billing window is narrower than stated.** `generate_membership_fees` only bills `active` members on tiers with `base_price > 0`, so an *unpaid* buyer sitting on the free tier was never at risk; exposure begins at activation. The stamp is still load-bearing, for a shorter window.

## Testing

**1619 passed**, 0 failed. 30 service tests, 16 endpoint tests.

One pre-existing test needed fixing rather than the code: `test_redsys_provider.py::TestAmountVerification` fed `mark_receipt_paid` a `SimpleNamespace` fake receipt lacking `purchased_membership_type_id`. The field was added to the fake rather than adding a `getattr` guard to production code — a real `Receipt` always has the column.

No migration; phase 1 added the column. Frontend untouched.

## Known gaps

- The Celery task **body** is untested — `expire_unpaid_purchases` is tested directly and the ordering asserted by calling both in sequence, but nothing exercises `scheduled_payment_reminders()` itself. Matches the existing codebase, where `scheduled_billing_run`'s body is equally uncovered.
- No audit-log row for a purchase; the surrounding self-service endpoints do not write them either.
- **Upgrade-mid-period crediting stays undecided**, as #146's open question leaves it. Today a second purchase is simply another purchase, prorated from its own month, with no credit — and it voids the first if that one is unpaid.
