### PR TITLE
Queue registration emails until the transaction commits

### DIFF
--- a/backend/app/db/after_commit.py
+++ b/backend/app/db/after_commit.py
@@ -1,0 +1,52 @@
+"""Defer a side effect until the session's transaction actually commits.
+
+Queueing an email from inside a service function is a race: the Celery worker
+can pick the task up before the row it describes is visible, and if the
+endpoint's ``db.commit()`` then fails the member has already been told about a
+registration that does not exist. ``run_after_commit`` parks the callable on
+the session and runs it from the ``after_commit`` event, so it fires only once
+the data is durable. A rollback drops the queue without running anything.
+
+Callables must not touch the session — by the time they run, ``commit()`` has
+expired every loaded instance, so resolve the payload first and close over
+plain values.
+"""
+
+import logging
+from collections.abc import Callable
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session, SessionTransaction
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_KEY = "after_commit_hooks"
+
+
+def run_after_commit(db: Session, fn: Callable[[], None]) -> None:
+    """Run ``fn`` after the next successful commit on ``db``; drop it on rollback."""
+    queue = db.info.get(_QUEUE_KEY)
+    if queue is None:
+        queue = db.info[_QUEUE_KEY] = []
+        event.listen(db, "after_commit", _run_queued)
+        event.listen(db, "after_soft_rollback", _discard_queued)
+    queue.append(fn)
+
+
+def _run_queued(session: Session) -> None:
+    queue = session.info.get(_QUEUE_KEY) or []
+    session.info[_QUEUE_KEY] = []
+    for fn in queue:
+        try:
+            fn()
+        except Exception:  # noqa: BLE001 — a failed side effect must not undo a commit
+            logger.exception("after-commit hook failed")
+
+
+def _discard_queued(session: Session, previous_transaction: SessionTransaction) -> None:
+    # ``after_soft_rollback`` also fires when a SAVEPOINT from ``begin_nested()``
+    # is rolled back. That undoes only the nested work, so hooks queued by the
+    # enclosing transaction — which may still commit — must survive it.
+    if previous_transaction.nested:
+        return
+    session.info[_QUEUE_KEY] = []

--- a/backend/app/domains/activities/registration_service.py
+++ b/backend/app/domains/activities/registration_service.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 
 from sqlalchemy.orm import Query, Session, joinedload
 
+from app.db.after_commit import run_after_commit
+
 logger = logging.getLogger(__name__)
 
 from app.domains.activities.discount_service import (
@@ -178,8 +180,8 @@ def register_member(
     if status == "confirmed":
         ensure_registration_receipt(db, registration, activity)
 
-    # Dispatch email notification (async via Celery)
-    _dispatch_registration_email(registration, activity, member)
+    # Queued for after the endpoint commits — see _dispatch_registration_email.
+    _dispatch_registration_email(db, registration, activity, member)
 
     return registration
 
@@ -310,8 +312,7 @@ def cancel_registration(
             registration.id,
         )
 
-    # Dispatch cancellation email (async via Celery)
-    _dispatch_cancellation_email(registration, activity)
+    _dispatch_cancellation_email(db, registration, activity)
 
     return registration
 
@@ -537,13 +538,19 @@ def _promote_from_waitlist(
 
     ensure_registration_receipt(db, next_in_line, activity)
 
-    # Dispatch promotion email (async via Celery)
-    _dispatch_promotion_email(next_in_line, activity)
+    _dispatch_promotion_email(db, next_in_line, activity)
 
     return next_in_line
 
 
 # --- Email dispatch helpers ---
+#
+# Each helper resolves the email payload now, while the ORM objects are loaded,
+# and queues the Celery ``.delay()`` on the session with ``run_after_commit``.
+# Sending from inside the service was a race: the worker could read the
+# database before the registration row was committed, and a commit that failed
+# afterwards left the member told about a registration that never existed.
+# The task takes the payload explicitly and never re-reads the row.
 
 def _get_member_email(registration: Registration) -> str | None:
     """Get the member's email address from the registration."""
@@ -562,16 +569,16 @@ def _get_member_name(registration: Registration) -> str:
 
 
 def _dispatch_registration_email(
-    registration: Registration, activity: Activity, member: "Member"
+    db: Session, registration: Registration, activity: Activity, member: "Member"
 ) -> None:
-    """Dispatch registration confirmation email via Celery."""
+    """Queue the registration confirmation email for after commit."""
     try:
         from app.tasks.email_tasks import send_registration_email_task
         email = _get_member_email(registration) or (member.person.email if member.person else None)
         if not email:
             return
         name = _get_member_name(registration) or (member.person.first_name if member.person else "")
-        send_registration_email_task.delay(
+        payload = dict(
             to=email,
             member_name=name,
             activity_name=activity.name,
@@ -579,39 +586,46 @@ def _dispatch_registration_email(
             activity_date=activity.starts_at.strftime("%d/%m/%Y") if activity.starts_at else None,
             location=activity.location,
         )
+        run_after_commit(db, lambda: send_registration_email_task.delay(**payload))
     except Exception as e:
         logger.error(f"Failed to dispatch registration email: {e}")
 
 
-def _dispatch_cancellation_email(registration: Registration, activity: Activity) -> None:
-    """Dispatch cancellation email via Celery."""
+def _dispatch_cancellation_email(
+    db: Session, registration: Registration, activity: Activity
+) -> None:
+    """Queue the cancellation email for after commit."""
     try:
         from app.tasks.email_tasks import send_cancellation_email_task
         email = _get_member_email(registration)
         if not email:
             return
-        send_cancellation_email_task.delay(
+        payload = dict(
             to=email,
             member_name=_get_member_name(registration),
             activity_name=activity.name,
         )
+        run_after_commit(db, lambda: send_cancellation_email_task.delay(**payload))
     except Exception as e:
         logger.error(f"Failed to dispatch cancellation email: {e}")
 
 
-def _dispatch_promotion_email(registration: Registration, activity: Activity) -> None:
-    """Dispatch waitlist promotion email via Celery."""
+def _dispatch_promotion_email(
+    db: Session, registration: Registration, activity: Activity
+) -> None:
+    """Queue the waitlist promotion email for after commit."""
     try:
         from app.tasks.email_tasks import send_promotion_email_task
         email = _get_member_email(registration)
         if not email:
             return
-        send_promotion_email_task.delay(
+        payload = dict(
             to=email,
             member_name=_get_member_name(registration),
             activity_name=activity.name,
             activity_date=activity.starts_at.strftime("%d/%m/%Y") if activity.starts_at else None,
             location=activity.location,
         )
+        run_after_commit(db, lambda: send_promotion_email_task.delay(**payload))
     except Exception as e:
         logger.error(f"Failed to dispatch promotion email: {e}")

--- a/backend/tests/integration/test_registration_emails.py
+++ b/backend/tests/integration/test_registration_emails.py
@@ -1,0 +1,203 @@
+"""Registration emails go out after the commit, never before.
+
+The service functions used to call ``.delay()`` directly, so the Celery worker
+could run before the endpoint's ``db.commit()`` — or after a commit that
+failed. Now they queue the dispatch on the session and it fires from the
+``after_commit`` event, with a rollback discarding it.
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from itertools import count
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+
+from app.db.after_commit import run_after_commit
+from app.domains.activities.models import Activity, ActivityPrice
+from app.domains.activities.registration_service import (
+    cancel_registration,
+    register_member,
+)
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+_seq = count(1)
+
+
+@pytest.fixture
+def org(db):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if not org:
+        org = OrganizationSettings(id=1, name="Email Club", default_vat_rate=21)
+        db.add(org)
+        db.flush()
+    return org
+
+
+@pytest.fixture
+def membership_type(db):
+    mt = MembershipType(name="Emails", slug=f"emails-{next(_seq)}", is_active=True)
+    db.add(mt)
+    db.flush()
+    return mt
+
+
+def _member(db, membership_type, suffix):
+    person = Person(
+        first_name="Mail", last_name=suffix, email=f"mail-{suffix}@example9f2c1.com"
+    )
+    db.add(person)
+    db.flush()
+    member = Member(
+        person_id=person.id,
+        membership_type_id=membership_type.id,
+        member_number=f"MAIL-{suffix}",
+        status="active",
+    )
+    db.add(member)
+    db.flush()
+    return member
+
+
+def _activity(db, *, max_participants=1):
+    now = datetime.now(timezone.utc)
+    activity = Activity(
+        name="Email Activity",
+        slug=f"email-activity-{next(_seq)}",
+        starts_at=now + timedelta(days=10),
+        ends_at=now + timedelta(days=11),
+        registration_starts_at=now - timedelta(days=1),
+        registration_ends_at=now + timedelta(days=9),
+        max_participants=max_participants,
+        status="published",
+        is_active=True,
+        features={"waiting_list": True},
+    )
+    db.add(activity)
+    db.flush()
+    price = ActivityPrice(
+        activity_id=activity.id,
+        name="Standard",
+        amount=Decimal("10.00"),
+        is_default=True,
+        is_active=True,
+    )
+    db.add(price)
+    db.flush()
+    return activity, price
+
+
+class TestRunAfterCommit:
+    def test_runs_only_once_the_session_commits(self, db):
+        calls = []
+        run_after_commit(db, lambda: calls.append("a"))
+        run_after_commit(db, lambda: calls.append("b"))
+        assert calls == []
+
+        db.commit()
+        assert calls == ["a", "b"]
+
+        # The queue is drained: a later commit does not replay it.
+        db.commit()
+        assert calls == ["a", "b"]
+
+    def test_one_failing_hook_does_not_block_the_others(self, db):
+        calls = []
+
+        def boom():
+            raise RuntimeError("smtp down")
+
+        run_after_commit(db, boom)
+        run_after_commit(db, lambda: calls.append("after"))
+        db.commit()
+        assert calls == ["after"]
+
+    def test_rollback_discards_the_queue(self, db):
+        calls = []
+        db.execute(text("SELECT 1"))  # autobegin, as any request would have
+        run_after_commit(db, lambda: calls.append("never"))
+        db.rollback()
+        db.commit()
+        assert calls == []
+
+    def test_nested_savepoint_rollback_keeps_the_queue(self, db):
+        calls = []
+        run_after_commit(db, lambda: calls.append("kept"))
+        try:
+            with db.begin_nested():
+                raise RuntimeError("receipt failed")
+        except RuntimeError:
+            pass
+        db.commit()
+        assert calls == ["kept"]
+
+
+class TestRegistrationEmailsWaitForCommit:
+    def test_confirmation_is_queued_until_commit(self, db, org, membership_type):
+        activity, price = _activity(db)
+        member = _member(db, membership_type, "confirm")
+
+        with patch(
+            "app.tasks.email_tasks.send_registration_email_task.delay"
+        ) as delay:
+            registration = register_member(db, activity, member, price.id)
+            assert registration.status == "confirmed"
+            delay.assert_not_called()
+
+            db.commit()
+
+        delay.assert_called_once()
+        kwargs = delay.call_args.kwargs
+        assert kwargs["to"] == "mail-confirm@example9f2c1.com"
+        assert kwargs["status"] == "confirmed"
+        assert kwargs["activity_name"] == "Email Activity"
+
+    def test_cancellation_and_promotion_are_queued_until_commit(
+        self, db, org, membership_type
+    ):
+        activity, price = _activity(db, max_participants=1)
+        first = _member(db, membership_type, "first")
+        second = _member(db, membership_type, "second")
+
+        with patch("app.tasks.email_tasks.send_registration_email_task.delay"):
+            held = register_member(db, activity, first, price.id)
+            waiting = register_member(db, activity, second, price.id)
+            db.commit()
+        assert held.status == "confirmed"
+        assert waiting.status == "waitlist"
+
+        with (
+            patch(
+                "app.tasks.email_tasks.send_cancellation_email_task.delay"
+            ) as cancel_delay,
+            patch(
+                "app.tasks.email_tasks.send_promotion_email_task.delay"
+            ) as promote_delay,
+        ):
+            cancel_registration(db, held)
+            assert waiting.status == "confirmed"
+            cancel_delay.assert_not_called()
+            promote_delay.assert_not_called()
+
+            db.commit()
+
+        cancel_delay.assert_called_once()
+        assert cancel_delay.call_args.kwargs["to"] == "mail-first@example9f2c1.com"
+        promote_delay.assert_called_once()
+        assert promote_delay.call_args.kwargs["to"] == "mail-second@example9f2c1.com"
+
+    def test_rolled_back_registration_sends_nothing(self, db, org, membership_type):
+        activity, price = _activity(db)
+        member = _member(db, membership_type, "rollback")
+
+        with patch(
+            "app.tasks.email_tasks.send_registration_email_task.delay"
+        ) as delay:
+            register_member(db, activity, member, price.id)
+            db.rollback()
+            db.commit()
+
+        delay.assert_not_called()


### PR DESCRIPTION
register_member, cancel_registration and _promote_from_waitlist called the Celery task's .delay() from inside the service while the endpoint committed afterwards. A worker could run before the registration row was visible, and a commit that failed left the member told about a registration that never existed.

Add run_after_commit, which parks a callable on the session and runs it from the after_commit event, discarding it on rollback (a SAVEPOINT rollback from begin_nested keeps the queue, since the outer transaction may still commit). The dispatch helpers resolve the email payload while the ORM objects are loaded and queue the .delay() call through it, so the task still receives explicit values and never re-reads the row.

Closes #96

Assisted-by: Claude Code