### PR TITLE
Draw remittance numbers from a locked per-year counter

### DIFF
--- a/backend/alembic/versions/a7b8c9d0e1f2_add_remittance_sequences.py
+++ b/backend/alembic/versions/a7b8c9d0e1f2_add_remittance_sequences.py
@@ -1,0 +1,57 @@
+"""Add remittance_sequences — a locked remittance number per year
+
+Revision ID: a7b8c9d0e1f2
+Revises: c9d0e1f2a3b4
+Create Date: 2026-09-11
+
+Receipt numbers moved to a per-year counter locked FOR UPDATE in
+f4c0f3226f34; remittance numbers stayed on COUNT(remittances in year) + 1,
+which two concurrent generations can both read before either inserts. This
+gives remittances the same counter, backfilled from the highest number each
+year has already issued so an existing install continues its series.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a7b8c9d0e1f2"
+down_revision = "c9d0e1f2a3b4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "remittance_sequences",
+        sa.Column("year", sa.Integer(), nullable=False, autoincrement=False),
+        sa.Column("next_number", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("year"),
+    )
+
+    # Seed each year from the highest number already issued in it, read from
+    # the number itself rather than by counting rows. Numbers are
+    # `REM-{year}-{NNNN}`; the year is taken from the number, not from
+    # emission_date, because that is the series the number was drawn against.
+    op.execute(
+        """
+        INSERT INTO remittance_sequences (year, next_number)
+        SELECT
+            CAST(substring(remittance_number from '([0-9]{4})-[0-9]+$') AS INTEGER)
+                AS series_year,
+            MAX(CAST(substring(remittance_number from '([0-9]+)$') AS INTEGER)) + 1
+        FROM remittances
+        WHERE remittance_number ~ '[0-9]{4}-[0-9]+$'
+        GROUP BY 1
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("remittance_sequences")

--- a/backend/app/cli/reset.py
+++ b/backend/app/cli/reset.py
@@ -37,17 +37,18 @@ KNOWN_TABLES = frozenset({
     "groups", "invoice_sequences", "members", "membership_types",
     "notifications", "organization_settings", "payment_providers", "persons",
     "receipt_reminders", "receipts", "registration_attachments",
-    "registration_consents", "registrations", "reminders", "remittances",
-    "role_permissions", "roles", "sepa_mandates", "spaces", "space_slots",
+    "registration_consents", "registrations", "reminders",
+    "remittance_sequences", "remittances", "role_permissions", "roles", "sepa_mandates", "spaces", "space_slots",
     "user_identities", "user_roles", "users", "webhook_events",
 })
 
-# `invoice_sequences` is club data and goes with the receipts. Preserving it
-# would leave a counter with nothing behind it, so the first invoice of the new
-# club would be numbered as though dozens had already been issued. Nothing is
-# reused either, because the receipts those numbers belonged to are gone in the
-# same operation — the series restarts because the series it continued no longer
-# exists.
+# `invoice_sequences` is club data and goes with the receipts, and
+# `remittance_sequences` with the remittances for the same reason. Preserving
+# either would leave a counter with nothing behind it, so the first document of
+# the new club would be numbered as though dozens had already been issued.
+# Nothing is reused either, because the documents those numbers belonged to are
+# gone in the same operation — the series restarts because the series it
+# continued no longer exists.
 
 # Instance-level configuration and lookups. A club reset never touches these.
 PRESERVED_TABLES = frozenset({

--- a/backend/app/domains/billing/models.py
+++ b/backend/app/domains/billing/models.py
@@ -482,3 +482,21 @@ class InvoiceSequence(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
+
+class RemittanceSequence(Base):
+    """The next remittance number for one year — the same counter shape as
+    ``InvoiceSequence``, for the same reason.
+
+    Remittance numbers were still ``COUNT(remittances in year) + 1`` after
+    receipts moved to a locked counter, so two batches generated together could
+    draw the same number and the second failed on the unique index (or, with
+    the old collision loop, skipped one).
+    """
+
+    __tablename__ = "remittance_sequences"
+
+    year = Column(Integer, primary_key=True, autoincrement=False)
+    next_number = Column(Integer, nullable=False, default=1)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+

--- a/backend/app/domains/billing/remittance_service.py
+++ b/backend/app/domains/billing/remittance_service.py
@@ -5,12 +5,17 @@ from decimal import Decimal
 from pathlib import Path
 
 from fastapi import HTTPException, status
-from sqlalchemy import extract, func
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.domains.billing.models import Receipt, Remittance, SepaMandate
+from app.domains.billing.models import (
+    Receipt,
+    Remittance,
+    RemittanceSequence,
+    SepaMandate,
+)
 from app.domains.billing.schemas import RemittanceCreate
+from app.domains.billing.sequences import next_yearly_number
 from app.domains.billing.sepa_xml import SepaExportError, generate_sepa_xml
 from app.domains.billing.service import mark_receipts_paid
 from app.domains.organizations.models import OrganizationSettings
@@ -22,21 +27,27 @@ from app.domains.organizations.models import OrganizationSettings
 def generate_remittance_number(db: Session, emission_date: date) -> str:
     """Generate the next remittance number.
 
-    Format: REM-{year}-{sequence:04d}, annual reset.
+    Format: REM-{year}-{sequence:04d}, annual reset. Drawn from a per-year
+    counter locked FOR UPDATE (see RemittanceSequence), the same way receipt
+    numbers are — COUNT(remittances) + 1 let two concurrent generations pick
+    the same number.
     """
     year = emission_date.year
-    count = (
-        db.query(func.count(Remittance.id))
-        .filter(extract("year", Remittance.emission_date) == year)
-        .scalar()
-    )
-    sequence = count + 1
+    sequence = next_yearly_number(db, RemittanceSequence, year)
     number = f"REM-{year}-{sequence:04d}"
 
-    # Ensure uniqueness
-    while db.query(Remittance).filter(Remittance.remittance_number == number).first():
-        sequence += 1
-        number = f"REM-{year}-{sequence:04d}"
+    # Under the lock a collision means the counter is behind the remittances
+    # already issued — a number written outside this function — and stepping
+    # past it would hide that. Surface it instead.
+    if db.query(Remittance).filter(Remittance.remittance_number == number).first():
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                f"Remittance number {number} already exists. The remittance "
+                f"sequence for {year} is behind the remittances already issued "
+                "and must be corrected before more are created."
+            ),
+        )
 
     return number
 

--- a/backend/app/domains/billing/sequences.py
+++ b/backend/app/domains/billing/sequences.py
@@ -1,0 +1,48 @@
+"""Per-year document counters, allocated under a row lock.
+
+Receipts and remittances each keep one ``{year, next_number}`` row per year
+(``InvoiceSequence``, ``RemittanceSequence``). A number is drawn by locking that
+row ``FOR UPDATE``, reading it, and bumping it in the same transaction, so two
+callers allocating at once serialise on the row instead of both reading the
+same value. ``COUNT(rows in year) + 1`` — what both used to do — has no such
+guarantee and also moves backwards when a row is deactivated.
+"""
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.db.base import Base
+
+
+def next_yearly_number(db: Session, sequence_model: type[Base], year: int) -> int:
+    """Allocate and return the next number for ``year``, bumping the counter.
+
+    ``sequence_model`` is a mapped class with ``year`` (primary key) and
+    ``next_number`` columns. The caller must hold any coarser lock it needs
+    (the org row, for receipts) before calling, and always in the same order.
+    """
+    row = (
+        db.query(sequence_model)
+        .filter(sequence_model.year == year)
+        .with_for_update()
+        .first()
+    )
+    if row is None:
+        # First document of this year. Two callers can reach this at once, so
+        # the loser of the insert re-reads the winner's row under the lock
+        # rather than both starting at 1.
+        try:
+            with db.begin_nested():
+                row = sequence_model(year=year, next_number=1)
+                db.add(row)
+                db.flush()
+        except IntegrityError:
+            row = (
+                db.query(sequence_model)
+                .filter(sequence_model.year == year)
+                .with_for_update()
+                .one()
+            )
+    number = row.next_number or 1
+    row.next_number = number + 1
+    return number

--- a/backend/app/domains/billing/service.py
+++ b/backend/app/domains/billing/service.py
@@ -9,8 +9,6 @@ from fastapi import HTTPException, status
 from sqlalchemy import extract, func, or_
 from sqlalchemy.orm import Query, Session, joinedload, selectinload
 
-from sqlalchemy.exc import IntegrityError
-
 from app.core.money import round_money
 from app.domains.billing.models import Concept, InvoiceSequence, Receipt
 from app.domains.billing.schemas import (
@@ -20,6 +18,7 @@ from app.domains.billing.schemas import (
     ReceiptReturnRequest,
     ReceiptUpdate,
 )
+from app.domains.billing.sequences import next_yearly_number
 from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
@@ -131,30 +130,7 @@ def generate_receipt_number(db: Session, emission_date: date) -> str:
         # unbroken, and that made it neither. See InvoiceSequence.
         #
         # Its own row lock, taken after the org lock and always in that order.
-        seq_row = (
-            db.query(InvoiceSequence)
-            .filter(InvoiceSequence.year == year)
-            .with_for_update()
-            .first()
-        )
-        if seq_row is None:
-            # First receipt of this year. Two callers can reach this at once, so
-            # the loser of the insert re-reads the winner's row under the lock
-            # rather than both starting at 1.
-            try:
-                with db.begin_nested():
-                    seq_row = InvoiceSequence(year=year, next_number=1)
-                    db.add(seq_row)
-                    db.flush()
-            except IntegrityError:
-                seq_row = (
-                    db.query(InvoiceSequence)
-                    .filter(InvoiceSequence.year == year)
-                    .with_for_update()
-                    .one()
-                )
-        sequence = seq_row.next_number or 1
-        seq_row.next_number = sequence + 1
+        sequence = next_yearly_number(db, InvoiceSequence, year)
     else:
         # Global sequential — use org counter
         sequence = org.invoice_next_number or 1

--- a/backend/tests/integration/test_remittance_numbering.py
+++ b/backend/tests/integration/test_remittance_numbering.py
@@ -1,0 +1,106 @@
+"""Remittance numbers come from a locked per-year counter.
+
+Receipt numbering moved onto ``InvoiceSequence`` under ``SELECT ... FOR UPDATE``;
+remittances stayed on ``COUNT(remittances in year) + 1``, which two concurrent
+generations can both read before either inserts. This gives them the same
+counter and checks it behaves the same way.
+"""
+
+from datetime import date
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import event
+
+from app.domains.billing.models import Remittance, RemittanceSequence
+from app.domains.billing.remittance_service import generate_remittance_number
+
+
+def _remittance(number, year=2026, day=15, status="draft"):
+    return Remittance(
+        remittance_number=number,
+        remittance_type="sepa",
+        status=status,
+        emission_date=date(year, 6, day),
+        due_date=date(year, 7, day),
+        total_amount=0,
+        receipt_count=0,
+        creditor_name="Numbering Club",
+        creditor_iban="ES9121000418450200051332",
+        creditor_bic="CAIXESBBXXX",
+        creditor_id="ES12ZZZ12345678",
+    )
+
+
+def _issue(db, year=2026, day=15, status="draft"):
+    """Allocate a number and persist a remittance holding it, as callers do."""
+    number = generate_remittance_number(db, date(year, 6, day))
+    db.add(_remittance(number, year, day, status))
+    db.flush()
+    return number
+
+
+class TestSequential:
+    def test_numbers_run_consecutively(self, db):
+        assert [_issue(db) for _ in range(3)] == [
+            "REM-2026-0001",
+            "REM-2026-0002",
+            "REM-2026-0003",
+        ]
+
+    def test_a_cancelled_number_is_not_reissued(self, db):
+        _issue(db)
+        _issue(db, status="cancelled")
+        assert _issue(db) == "REM-2026-0003"
+
+
+class TestPerYear:
+    def test_each_year_keeps_its_own_counter(self, db):
+        assert _issue(db, year=2025) == "REM-2025-0001"
+        assert _issue(db, year=2026) == "REM-2026-0001"
+        assert _issue(db, year=2025) == "REM-2025-0002"
+
+    def test_the_counter_row_tracks_the_next_number(self, db):
+        _issue(db)
+        _issue(db)
+        row = db.query(RemittanceSequence).filter_by(year=2026).one()
+        assert row.next_number == 3
+
+
+class TestLocking:
+    """The counter row must be read under FOR UPDATE.
+
+    Asserts the statement is emitted rather than staging real contention: the
+    ``db`` fixture is one connection inside a rolled-back transaction, and a
+    test that blocks on a lock is the kind that turns flaky in parallel.
+    """
+
+    def test_sequence_row_is_locked(self, db):
+        seen = []
+
+        def record(conn, cursor, statement, params, context, executemany):
+            seen.append(" ".join(statement.split()))
+
+        event.listen(db.get_bind(), "before_cursor_execute", record)
+        try:
+            _issue(db)
+            _issue(db)
+        finally:
+            event.remove(db.get_bind(), "before_cursor_execute", record)
+
+        locks = [
+            s for s in seen if "remittance_sequences" in s and "FOR UPDATE" in s
+        ]
+        assert locks, "generate_remittance_number must SELECT ... FOR UPDATE the counter"
+
+
+class TestCollision:
+    def test_a_number_issued_outside_the_counter_is_an_error(self, db):
+        """Stepping past a collision would hide a counter that has fallen behind."""
+        db.add(_remittance("REM-2026-0001", day=1))
+        db.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            generate_remittance_number(db, date(2026, 6, 15))
+        assert exc.value.status_code == 500
+        assert "REM-2026-0001" in exc.value.detail


### PR DESCRIPTION
generate_remittance_number was still COUNT(remittances in year) + 1 after receipt numbering moved to a row-locked counter, so two remittances generated together could read the same count and draw the same number.

Extract the lock-or-insert allocation from generate_receipt_number into next_yearly_number and give remittances their own RemittanceSequence row per year, allocated under SELECT ... FOR UPDATE. The migration backfills each year from the highest number already issued so an existing install continues its series. A collision now raises instead of stepping past it, as receipts do — under the lock it means the counter is behind.

Closes #97

Assisted-by: Claude Code