### PR TITLE
Move a member's login address with their profile address

### DIFF
--- a/backend/app/api/v1/endpoints/members.py
+++ b/backend/app/api/v1/endpoints/members.py
@@ -30,9 +30,11 @@ from app.domains.members.schemas import (
 from app.core.csv_export import stream_csv
 from app.domains.member_card.schemas import AssignNumbersResponse
 from app.domains.members.service import (
+    EmailTaken,
     approve_registration,
     assign_missing_member_numbers,
     build_members_query,
+    change_member_email,
     change_member_status,
     create_member,
     is_minor_by_dob,
@@ -250,9 +252,18 @@ def update_member(
 
     update_data = data.model_dump(exclude_unset=True)
 
+    # The address also lives on the User row, and login reads it from there.
+    if "email" in update_data:
+        try:
+            change_member_email(db, member, update_data.pop("email"))
+        except EmailTaken as e:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
     # Person fields
     person_fields = {
-        "first_name", "last_name", "email", "date_of_birth", "gender", "national_id"
+        "first_name", "last_name", "date_of_birth", "gender", "national_id"
     }
     for field in person_fields:
         if field in update_data:

--- a/backend/app/domains/members/service.py
+++ b/backend/app/domains/members/service.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 from sqlalchemy import func
 from sqlalchemy.orm import Query, Session, joinedload
 
+from app.domains.auth.models import User
 from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
@@ -177,6 +178,36 @@ def create_member(
     db.flush()
 
     return member
+
+
+class EmailTaken(ValueError):
+    """Another account already signs in with this address."""
+
+
+def change_member_email(db: Session, member: Member, email: str | None) -> None:
+    """Write a member's address to the Person row and to their User row, if any.
+
+    Login reads ``User.email`` while every mail the app sends reads
+    ``Person.email``. Writing only the Person row — what the update endpoint
+    used to do — sent mail to the corrected address while sign-in still
+    expected the old one, and nothing surfaced the split. The two rows are one
+    address, so they move together.
+
+    ``users.email`` is unique, so the address must not belong to another
+    account. The Person row is only checked against Users: a person with no
+    login (an admin-created member) may share an address with one, as before.
+    """
+    user = member.person.user
+    if user is not None:
+        if not email:
+            raise ValueError("A member with a login must keep an email address")
+        taken = (
+            db.query(User).filter(User.email == email, User.id != user.id).first()
+        )
+        if taken:
+            raise EmailTaken("Email already registered")
+        user.email = email
+    member.person.email = email
 
 
 def change_member_status(

--- a/backend/tests/integration/api/v1/test_members.py
+++ b/backend/tests/integration/api/v1/test_members.py
@@ -205,6 +205,69 @@ class TestMemberCRUD:
         assert response.status_code == 200
         assert response.json()["person"]["first_name"] == "Updated"
 
+    def test_update_email_moves_the_login_address_too(self, client, db):
+        """Login reads User.email, mail reads Person.email — one address."""
+        admin = _create_admin(db)
+        user, member = _create_member_user(db, "old-address@examplee6e3b1.com")
+        client.cookies.update(_auth_cookie(admin))
+
+        response = client.put(
+            f"/api/v1/members/{member.id}",
+            json={"email": "new-address@examplee6e3b1.com"},
+        )
+        assert response.status_code == 200
+        assert response.json()["person"]["email"] == "new-address@examplee6e3b1.com"
+        db.refresh(user)
+        assert user.email == "new-address@examplee6e3b1.com"
+
+    def test_update_email_rejects_an_address_another_login_holds(self, client, db):
+        admin = _create_admin(db)
+        user, member = _create_member_user(db, "mine@examplee6e3b1.com")
+        _create_member_user(db, "theirs@examplee6e3b1.com")
+        client.cookies.update(_auth_cookie(admin))
+
+        response = client.put(
+            f"/api/v1/members/{member.id}",
+            json={"email": "theirs@examplee6e3b1.com"},
+        )
+        assert response.status_code == 409
+        db.refresh(user)
+        assert user.email == "mine@examplee6e3b1.com"
+        assert member.person.email == "mine@examplee6e3b1.com"
+
+    def test_update_email_cannot_clear_a_login_address(self, client, db):
+        admin = _create_admin(db)
+        _, member = _create_member_user(db, "keep-me@examplee6e3b1.com")
+        client.cookies.update(_auth_cookie(admin))
+
+        response = client.put(
+            f"/api/v1/members/{member.id}",
+            json={"email": None},
+        )
+        assert response.status_code == 400
+
+    def test_update_email_on_a_member_without_login_touches_only_the_person(
+        self, client, db
+    ):
+        admin = _create_admin(db)
+        mt = _ensure_membership_type(db)
+        client.cookies.update(_auth_cookie(admin))
+        created = client.post(
+            "/api/v1/members/",
+            json={"first_name": "No", "last_name": "Login", "membership_type_id": mt.id},
+        ).json()
+
+        response = client.put(
+            f"/api/v1/members/{created['id']}",
+            json={"email": "no-login@examplee6e3b1.com"},
+        )
+        assert response.status_code == 200
+        assert response.json()["person"]["email"] == "no-login@examplee6e3b1.com"
+        assert (
+            db.query(User).filter(User.email == "no-login@examplee6e3b1.com").first()
+            is None
+        )
+
     def test_member_cannot_list(self, client, db):
         _, member = _create_member_user(db, "no-list@examplee6e3b1.com")
         user = db.query(User).filter(User.id == member.user_id).first()


### PR DESCRIPTION
Updating a member through PUT /members/{id} wrote Person.email and never touched User.email. Authentication reads the User row and every mail the app sends reads the Person row, so after an admin corrected an address the mail went to the new one while sign-in still expected the old, and nothing surfaced the split.

Add change_member_email, which writes both rows when the member has a login and refuses an address another account already signs in with (409) or an empty one on an account that needs it to sign in (400). A member without a login keeps the Person-only behaviour. Members editing their own record still cannot change the address — MemberSelfUpdate already excludes it.

Closes #98

Assisted-by: Claude Code