### PR TITLE
Lock discount usage and release it on cancellation

### DIFF
--- a/backend/app/domains/activities/discount_service.py
+++ b/backend/app/domains/activities/discount_service.py
@@ -15,18 +15,28 @@ class DiscountError(Exception):
 
 
 def validate_discount_code(
-    db: Session, activity_id: int, code: str
+    db: Session, activity_id: int, code: str, *, for_update: bool = False
 ) -> DiscountCode:
-    """Validate a discount code for an activity. Returns the code or raises DiscountError."""
-    discount = (
-        db.query(DiscountCode)
-        .filter(
-            DiscountCode.activity_id == activity_id,
-            DiscountCode.code == code,
-            DiscountCode.is_active.is_(True),
-        )
-        .first()
+    """Validate a discount code for an activity. Returns the code or raises DiscountError.
+
+    ``for_update`` locks the row for the rest of the transaction. A caller that
+    goes on to redeem the code needs it: the ``max_uses`` check here and the
+    increment in ``increment_usage`` are a read-modify-write on
+    ``current_uses``, and without the lock two registrations arriving together
+    both pass the check and the cap is exceeded by one. The preview endpoint
+    only reads, so it leaves the row unlocked.
+    """
+    query = db.query(DiscountCode).filter(
+        DiscountCode.activity_id == activity_id,
+        DiscountCode.code == code,
+        DiscountCode.is_active.is_(True),
     )
+    if for_update:
+        # populate_existing: the row may already be in the session from an
+        # earlier read, and without it the locked SELECT would hand back the
+        # stale in-memory counter instead of the one just read under the lock.
+        query = query.with_for_update().populate_existing()
+    discount = query.first()
     if not discount:
         raise DiscountError("Discount code not found")
 
@@ -57,5 +67,32 @@ def apply_discount(price_amount: Decimal, discount: DiscountCode) -> Decimal:
 
 
 def increment_usage(db: Session, discount: DiscountCode) -> None:
-    """Increment the usage counter for a discount code."""
+    """Count one redemption. The row must be locked — see validate_discount_code."""
     discount.current_uses = (discount.current_uses or 0) + 1
+
+
+def release_usage(db: Session, discount_id: int) -> None:
+    """Give back the use a cancelled registration took, so the code can be
+    redeemed by someone else. Locks the row itself: cancellation does not
+    come through validate_discount_code."""
+    discount = (
+        db.query(DiscountCode)
+        .filter(DiscountCode.id == discount_id)
+        .with_for_update()
+        .first()
+    )
+    if discount is not None:
+        discount.current_uses = max(0, (discount.current_uses or 0) - 1)
+
+
+def retake_usage(db: Session, discount_id: int) -> None:
+    """Count the use again when a cancelled registration is reinstated by an
+    admin. No cap check: the admin is overriding, and the seat is theirs to give."""
+    discount = (
+        db.query(DiscountCode)
+        .filter(DiscountCode.id == discount_id)
+        .with_for_update()
+        .first()
+    )
+    if discount is not None:
+        discount.current_uses = (discount.current_uses or 0) + 1

--- a/backend/app/domains/activities/registration_service.py
+++ b/backend/app/domains/activities/registration_service.py
@@ -14,6 +14,8 @@ from app.domains.activities.discount_service import (
     DiscountError,
     apply_discount,
     increment_usage,
+    release_usage,
+    retake_usage,
     validate_discount_code,
 )
 from app.domains.activities.eligibility import check_eligibility
@@ -124,7 +126,10 @@ def register_member(
     discounted_amount = original_amount
     if discount_code:
         try:
-            discount = validate_discount_code(db, activity.id, discount_code)
+            # Locked: the cap check and the increment below are one decision.
+            discount = validate_discount_code(
+                db, activity.id, discount_code, for_update=True
+            )
             discounted_amount = apply_discount(original_amount, discount)
         except DiscountError as e:
             raise RegistrationError(str(e))
@@ -281,6 +286,10 @@ def cancel_registration(
     elif was_waitlisted:
         activity.waitlist_count = max(0, (activity.waitlist_count or 0) - 1)
 
+    # The use this registration took goes back to the code.
+    if registration.discount_code_id:
+        release_usage(db, registration.discount_code_id)
+
     # Promote from waitlist if a confirmed spot freed up
     if was_confirmed:
         _promote_from_waitlist(db, activity, registration.modality_id)
@@ -374,6 +383,13 @@ def admin_change_status(
 
     if new_status == "cancelled":
         registration.cancelled_at = datetime.now(timezone.utc)
+
+    # The discount use follows the registration in and out of 'cancelled'.
+    if registration.discount_code_id:
+        if new_status == "cancelled":
+            release_usage(db, registration.discount_code_id)
+        elif old_status == "cancelled":
+            retake_usage(db, registration.discount_code_id)
 
     registration.status = new_status
     if new_status == "confirmed" and old_status != "confirmed":

--- a/backend/tests/integration/api/v1/test_discount_codes.py
+++ b/backend/tests/integration/api/v1/test_discount_codes.py
@@ -423,6 +423,82 @@ class TestRegisterWithDiscount:
         db.refresh(dc)
         assert dc.current_uses == 1
 
+    def test_cancellation_releases_the_use(self, client, db):
+        """A use is only spent while the registration stands."""
+        admin = _create_user(db, "admin", suffix="-regd8")
+        user, member = _create_member_with_user(db, suffix="-regd8")
+        activity, price = _create_published_activity(
+            db, admin.id, allow_self_cancellation=True,
+        )
+        dc = DiscountCode(
+            activity_id=activity.id, code="ONCE",
+            discount_type="percentage", discount_value=5, is_active=True,
+            max_uses=1,
+        )
+        db.add(dc)
+        db.flush()
+
+        client.cookies.update(_auth_cookie(user))
+        response = client.post(
+            f"/api/v1/activities/{activity.id}/register",
+            json={"price_id": price.id, "discount_code": "ONCE"},
+        )
+        assert response.status_code == 201
+        reg_id = response.json()["id"]
+        db.refresh(dc)
+        assert dc.current_uses == 1
+
+        response = client.delete(f"/api/v1/registrations/{reg_id}")
+        assert response.status_code == 204
+        db.refresh(dc)
+        assert dc.current_uses == 0
+
+        # The freed use is redeemable by the next member.
+        other_user, _ = _create_member_with_user(db, suffix="-regd8b")
+        client.cookies.update(_auth_cookie(other_user))
+        response = client.post(
+            f"/api/v1/activities/{activity.id}/register",
+            json={"price_id": price.id, "discount_code": "ONCE"},
+        )
+        assert response.status_code == 201
+        db.refresh(dc)
+        assert dc.current_uses == 1
+
+    def test_admin_status_change_moves_the_use_with_the_registration(self, client, db):
+        admin = _create_user(db, "admin", suffix="-regd9")
+        user, member = _create_member_with_user(db, suffix="-regd9")
+        activity, price = _create_published_activity(db, admin.id)
+        dc = DiscountCode(
+            activity_id=activity.id, code="ADMIN",
+            discount_type="percentage", discount_value=5, is_active=True,
+            max_uses=5,
+        )
+        db.add(dc)
+        db.flush()
+
+        client.cookies.update(_auth_cookie(user))
+        reg_id = client.post(
+            f"/api/v1/activities/{activity.id}/register",
+            json={"price_id": price.id, "discount_code": "ADMIN"},
+        ).json()["id"]
+        db.refresh(dc)
+        assert dc.current_uses == 1
+
+        client.cookies.update(_auth_cookie(admin))
+        response = client.put(
+            f"/api/v1/registrations/{reg_id}/status", json={"status": "cancelled"}
+        )
+        assert response.status_code == 200
+        db.refresh(dc)
+        assert dc.current_uses == 0
+
+        response = client.put(
+            f"/api/v1/registrations/{reg_id}/status", json={"status": "confirmed"}
+        )
+        assert response.status_code == 200
+        db.refresh(dc)
+        assert dc.current_uses == 1
+
     def test_register_without_discount_stores_amounts(self, client, db):
         """Registration without discount still stores original/discounted amounts (equal)."""
         admin = _create_user(db, "admin", suffix="-regd6")

--- a/backend/tests/integration/test_discount_usage.py
+++ b/backend/tests/integration/test_discount_usage.py
@@ -1,0 +1,204 @@
+"""Discount usage is decided under a lock and released on cancellation.
+
+``current_uses`` is a cached counter incremented in Python. Without a row lock
+two redemptions arriving together both read ``max_uses - 1``, both pass the
+check and both increment, so a code capped at N is redeemed N + 1 times. And a
+use taken by a registration that is later cancelled must go back, or the code
+burns a slot nobody used.
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from itertools import count
+
+import pytest
+from sqlalchemy import event
+
+from app.domains.activities.discount_service import (
+    DiscountError,
+    validate_discount_code,
+)
+from app.domains.activities.models import Activity, ActivityPrice, DiscountCode
+from app.domains.activities.registration_service import (
+    RegistrationError,
+    cancel_registration,
+    register_member,
+)
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+_seq = count(1)
+
+
+@pytest.fixture
+def org(db):
+    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
+    if not org:
+        org = OrganizationSettings(id=1, name="Discount Club", default_vat_rate=21)
+        db.add(org)
+        db.flush()
+    return org
+
+
+@pytest.fixture
+def membership_type(db):
+    mt = MembershipType(name="Discount", slug=f"discount-{next(_seq)}", is_active=True)
+    db.add(mt)
+    db.flush()
+    return mt
+
+
+def _member(db, membership_type, suffix):
+    person = Person(
+        first_name="Disc", last_name=suffix, email=f"disc-{suffix}@example7a1c4.com"
+    )
+    db.add(person)
+    db.flush()
+    member = Member(
+        person_id=person.id,
+        membership_type_id=membership_type.id,
+        member_number=f"DISC-{suffix}",
+        status="active",
+    )
+    db.add(member)
+    db.flush()
+    return member
+
+
+def _activity(db, *, code="SAVE", max_uses=1):
+    now = datetime.now(timezone.utc)
+    activity = Activity(
+        name="Discount Activity",
+        slug=f"discount-activity-{next(_seq)}",
+        starts_at=now + timedelta(days=10),
+        ends_at=now + timedelta(days=11),
+        registration_starts_at=now - timedelta(days=1),
+        registration_ends_at=now + timedelta(days=9),
+        max_participants=50,
+        status="published",
+        is_active=True,
+        features={"waiting_list": True},
+    )
+    db.add(activity)
+    db.flush()
+    price = ActivityPrice(
+        activity_id=activity.id,
+        name="Standard",
+        amount=Decimal("10.00"),
+        is_default=True,
+        is_active=True,
+    )
+    discount = DiscountCode(
+        activity_id=activity.id,
+        code=code,
+        discount_type="percentage",
+        discount_value=Decimal("10"),
+        max_uses=max_uses,
+        current_uses=0,
+        is_active=True,
+    )
+    db.add_all([price, discount])
+    db.flush()
+    return activity, price, discount
+
+
+def _statements(db, fn):
+    seen = []
+
+    def record(conn, cursor, statement, params, context, executemany):
+        seen.append(" ".join(statement.split()))
+
+    event.listen(db.get_bind(), "before_cursor_execute", record)
+    try:
+        fn()
+    finally:
+        event.remove(db.get_bind(), "before_cursor_execute", record)
+    return seen
+
+
+class TestUsageIsLocked:
+    """Asserts the lock is requested, not that two connections contend — the
+    ``db`` fixture is one rolled-back transaction, and a test that blocks on a
+    lock is the kind that turns flaky in parallel (see issue #58)."""
+
+    def test_redemption_locks_the_code_row(self, db, org, membership_type):
+        activity, price, _ = _activity(db)
+        member = _member(db, membership_type, "lock")
+
+        seen = _statements(
+            db,
+            lambda: register_member(db, activity, member, price.id, discount_code="SAVE"),
+        )
+        locks = [s for s in seen if "discount_codes" in s and "FOR UPDATE" in s]
+        assert locks, "register_member must SELECT ... FOR UPDATE the discount row"
+
+    def test_preview_does_not_lock(self, db, org, membership_type):
+        activity, _, _ = _activity(db)
+
+        seen = _statements(
+            db, lambda: validate_discount_code(db, activity.id, "SAVE")
+        )
+        assert not [s for s in seen if "discount_codes" in s and "FOR UPDATE" in s]
+
+    def test_cap_is_read_through_the_lock(self, db, org, membership_type):
+        """A stale in-session counter must not let a redemption past the cap."""
+        activity, price, discount = _activity(db, max_uses=1)
+        first = _member(db, membership_type, "stale1")
+        second = _member(db, membership_type, "stale2")
+
+        register_member(db, activity, first, price.id, discount_code="SAVE")
+        # Simulate another transaction having spent the last use.
+        db.execute(
+            DiscountCode.__table__.update()
+            .where(DiscountCode.id == discount.id)
+            .values(current_uses=1)
+        )
+        discount.current_uses = 0  # stale in-session value
+
+        with pytest.raises(RegistrationError, match="maximum uses"):
+            register_member(db, activity, second, price.id, discount_code="SAVE")
+
+
+class TestUsageIsReleased:
+    def test_cancelling_gives_the_use_back(self, db, org, membership_type):
+        activity, price, discount = _activity(db, max_uses=1)
+        first = _member(db, membership_type, "rel1")
+        second = _member(db, membership_type, "rel2")
+
+        reg = register_member(db, activity, first, price.id, discount_code="SAVE")
+        assert discount.current_uses == 1
+        with pytest.raises(DiscountError, match="maximum uses"):
+            validate_discount_code(db, activity.id, "SAVE")
+
+        cancel_registration(db, reg)
+        db.flush()
+        db.refresh(discount)
+        assert discount.current_uses == 0
+
+        register_member(db, activity, second, price.id, discount_code="SAVE")
+        db.flush()
+        db.refresh(discount)
+        assert discount.current_uses == 1
+
+    def test_release_never_goes_below_zero(self, db, org, membership_type):
+        activity, price, discount = _activity(db, max_uses=5)
+        member = _member(db, membership_type, "floor")
+        reg = register_member(db, activity, member, price.id, discount_code="SAVE")
+        discount.current_uses = 0  # counter already drifted low
+        db.flush()
+
+        cancel_registration(db, reg)
+        db.flush()
+        db.refresh(discount)
+        assert discount.current_uses == 0
+
+    def test_cancelling_without_a_code_touches_nothing(self, db, org, membership_type):
+        activity, price, discount = _activity(db, max_uses=5)
+        member = _member(db, membership_type, "none")
+        reg = register_member(db, activity, member, price.id)
+
+        cancel_registration(db, reg)
+        db.flush()
+        db.refresh(discount)
+        assert discount.current_uses == 0


### PR DESCRIPTION
increment_usage was an unlocked read-modify-write on current_uses, so two redemptions arriving together both passed the max_uses check and the cap was exceeded by one. Activity capacity already decides under SELECT ... FOR UPDATE; the discount counter did not. And nothing gave a use back when the registration was cancelled, so a code burned a slot nobody took up.

validate_discount_code takes for_update=True from register_member and locks the row with populate_existing, so the cap check and the increment are one decision; the preview endpoint keeps reading unlocked. Both cancellation paths release the use, and an admin reinstating a cancelled registration takes it again.

Closes #99

Assisted-by: Claude Code