### PR TITLE
Defuse formula-injection in CSV exports

### DIFF
--- a/backend/app/core/csv_export.py
+++ b/backend/app/core/csv_export.py
@@ -16,6 +16,22 @@ from fastapi.responses import StreamingResponse
 # Byte-order mark: makes Excel detect UTF-8 instead of the system code page.
 _BOM = "﻿"
 
+# A cell starting with one of these is evaluated as a formula by Excel and
+# LibreOffice when the file is opened, and the exports carry member-supplied
+# text (names, notes) straight into an admin's spreadsheet. A leading
+# apostrophe is the spreadsheet convention for "this is text" and defuses it.
+# Tab and carriage return are included because a cell beginning with either is
+# trimmed before the check, exposing whatever comes next.
+_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _defuse(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, str) and value.startswith(_FORMULA_TRIGGERS):
+        return "'" + value
+    return value
+
 
 def iter_csv(headers: list[str], rows: Iterable[Iterable[Any]]) -> Iterator[str]:
     """Yield CSV text a row at a time (header row first, prefixed with the BOM)."""
@@ -32,7 +48,7 @@ def iter_csv(headers: list[str], rows: Iterable[Iterable[Any]]) -> Iterator[str]
     yield _BOM + flush()
 
     for row in rows:
-        writer.writerow(["" if value is None else value for value in row])
+        writer.writerow([_defuse(value) for value in row])
         yield flush()
 
 

--- a/backend/tests/integration/api/v1/test_exports.py
+++ b/backend/tests/integration/api/v1/test_exports.py
@@ -188,6 +188,18 @@ class TestMembersExport:
         assert len(rows) == 1
         assert rows[0][1] == "M-m-ct-1"
 
+    def test_member_supplied_text_cannot_open_as_a_formula(self, client, db):
+        admin = _admin(db, "m-formula")
+        m = _member(db, "m-formula-1")
+        m.person.first_name = '=HYPERLINK("http://evil.example","click")'
+        db.flush()
+        client.cookies.update(_auth_cookie(admin))
+
+        resp = client.get("/api/v1/members/export.csv")
+        assert resp.status_code == 200
+        _, rows = _parse_csv(resp)
+        assert rows[0][2] == "'" + '=HYPERLINK("http://evil.example","click")'
+
     def test_empty_returns_header_only(self, client, db):
         admin = _admin(db, "m-empty")
         client.cookies.update(_auth_cookie(admin))

--- a/backend/tests/unit/test_csv_export.py
+++ b/backend/tests/unit/test_csv_export.py
@@ -1,0 +1,57 @@
+"""Exported cells must never open as formulas.
+
+The admin exports carry member-supplied text (names, notes) into a
+spreadsheet, and a cell starting with ``=``, ``+``, ``-`` or ``@`` is evaluated
+by Excel and LibreOffice when the file is opened. A leading apostrophe marks
+the cell as text.
+"""
+
+import csv
+import io
+from decimal import Decimal
+
+import pytest
+
+from app.core.csv_export import iter_csv
+
+
+def _rows(headers, rows):
+    text = "".join(iter_csv(headers, rows)).lstrip("﻿")
+    return list(csv.reader(io.StringIO(text)))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "=1+1",
+        "=HYPERLINK(\"http://evil.example\",\"click\")",
+        "+cmd|' /C calc'!A0",
+        "-2+3",
+        "@SUM(A1:A2)",
+        "\t=1+1",
+        "\r=1+1",
+    ],
+)
+def test_formula_triggers_are_prefixed_with_an_apostrophe(payload):
+    _, row = _rows(["notes"], [[payload]])
+    assert row == ["'" + payload]
+
+
+def test_ordinary_text_is_untouched():
+    _, row = _rows(["name", "email"], [["María García-López", "m@example.com"]])
+    assert row == ["María García-López", "m@example.com"]
+
+
+def test_a_trigger_inside_the_cell_is_not_a_trigger():
+    _, row = _rows(["notes"], [["a = b + c"]])
+    assert row == ["a = b + c"]
+
+
+def test_non_string_values_are_written_as_is():
+    _, row = _rows(["id", "amount", "empty"], [[7, Decimal("-12.50"), None]])
+    assert row == ["7", "-12.50", ""]
+
+
+def test_headers_are_not_touched():
+    headers, _ = _rows(["=id"], [["x"]])
+    assert headers == ["=id"]


### PR DESCRIPTION
The admin exports (members, receipts, registrations) wrote every cell through unchanged, so a member whose name or notes began with =, +, - or @ became a live formula when the file was opened in Excel or LibreOffice — in the spreadsheet of the person with the most access.

iter_csv now prefixes an apostrophe to any string cell starting with one of those characters, or with a tab or carriage return (which the spreadsheet trims before checking). Numbers and dates pass through untouched, and headers are not member-supplied.

Closes #101

Assisted-by: Claude Code