### PR TITLE
Stop returning the full IBAN next to its masked form

### DIFF
--- a/backend/app/api/v1/endpoints/members.py
+++ b/backend/app/api/v1/endpoints/members.py
@@ -488,8 +488,11 @@ class PaymentMethodUpdate(BaseModel):
 
 
 class PaymentMethodResponse(BaseModel):
+    """The full IBAN is write-only. The response carries the masked form so the
+    member can recognise the account on file; anything that sees the payload
+    (browser devtools, a proxy log) sees no more than that."""
+
     payment_method: str | None = None
-    bank_iban: str | None = None
     bank_iban_masked: str | None = None
     bank_bic: str | None = None
     bank_holder_name: str | None = None
@@ -542,7 +545,6 @@ def _build_payment_response(person: Person, db: Session) -> PaymentMethodRespons
 
     return PaymentMethodResponse(
         payment_method=person.payment_method,
-        bank_iban=person.bank_iban,
         bank_iban_masked=_mask_iban(person.bank_iban),
         bank_bic=person.bank_bic,
         bank_holder_name=person.bank_holder_name,

--- a/backend/tests/integration/api/v1/test_payment_method.py
+++ b/backend/tests/integration/api/v1/test_payment_method.py
@@ -65,7 +65,7 @@ class TestGetPaymentMethod:
         assert r.status_code == 200
         data = r.json()
         assert data["payment_method"] is None
-        assert data["bank_iban"] is None
+        assert data["bank_iban_masked"] is None
         assert data["mandate_status"] == "none"
         assert data["warnings"] == []
 
@@ -84,7 +84,7 @@ class TestGetPaymentMethod:
         assert r.status_code == 200
         data = r.json()
         assert data["payment_method"] == "direct_debit"
-        assert data["bank_iban"] == "ES6621000418401234567891"
+        assert "bank_iban" not in data
         assert data["bank_iban_masked"] == "ES66 **** **** **** 7891"
         assert data["mandate_status"] == "active"
         assert data["mandate_reference"] == "TEST-PM-001"
@@ -119,7 +119,8 @@ class TestUpdatePaymentMethod:
         assert r.status_code == 200
         data = r.json()
         assert data["payment_method"] == "bank_transfer"
-        assert data["bank_iban"] == "ES7920385778983000760236"
+        assert "bank_iban" not in data
+        assert data["bank_iban_masked"] == "ES79 **** **** **** 0236"
         assert data["bank_holder_name"] == "Test Member"
 
     def test_iban_normalized_uppercase(self, client, db):
@@ -129,7 +130,9 @@ class TestUpdatePaymentMethod:
             "bank_iban": "es79 2038 5778 9830 0076 0236",
         })
         assert r.status_code == 200
-        assert r.json()["bank_iban"] == "ES7920385778983000760236"
+        assert r.json()["bank_iban_masked"] == "ES79 **** **** **** 0236"
+        db.refresh(user.person)
+        assert user.person.bank_iban == "ES7920385778983000760236"
 
     def test_invalid_payment_method_rejected(self, client, db):
         user, _ = _setup(db)
@@ -151,6 +154,18 @@ class TestUpdatePaymentMethod:
         assert "missing_iban" in data["warnings"]
         assert "no_active_mandate" in data["warnings"]
 
+    def test_omitting_iban_keeps_the_one_on_file(self, client, db):
+        """The form no longer echoes the IBAN back, so a save that does not
+        mention it must not wipe it."""
+        user, _ = _setup(db, iban="ES6621000418401234567891")
+        db.commit()
+        r = client.put("/api/v1/members/me/payment-method", cookies=_auth(user), json={
+            "payment_method": "direct_debit",
+            "bank_holder_name": "Test Member",
+        })
+        assert r.status_code == 200
+        assert r.json()["bank_iban_masked"] == "ES66 **** **** **** 7891"
+
     def test_clear_iban(self, client, db):
         user, _ = _setup(db, iban="ES6621000418401234567891")
         db.commit()
@@ -158,7 +173,7 @@ class TestUpdatePaymentMethod:
             "bank_iban": None,
         })
         assert r.status_code == 200
-        assert r.json()["bank_iban"] is None
+        assert r.json()["bank_iban_masked"] is None
 
 
 class TestPaymentMethodAuth:

--- a/frontend/features/members/components/my-payment-method.tsx
+++ b/frontend/features/members/components/my-payment-method.tsx
@@ -18,7 +18,6 @@ import { useFormatters } from "@/hooks/use-formatters";
 
 interface PaymentMethodData {
   payment_method: string | null;
-  bank_iban: string | null;
   bank_iban_masked: string | null;
   bank_bic: string | null;
   bank_holder_name: string | null;
@@ -63,10 +62,13 @@ export function MyPaymentMethod() {
   const [holderName, setHolderName] = useState("");
   const [dirty, setDirty] = useState(false);
 
+  // The IBAN is write-only: the API only returns the masked form, so the field
+  // starts empty and shows the account on file as its placeholder. Leaving it
+  // blank keeps that account; typing one replaces it.
   useEffect(() => {
     if (data) {
       setMethod(data.payment_method || "");
-      setIban(data.bank_iban || "");
+      setIban("");
       setBic(data.bank_bic || "");
       setHolderName(data.bank_holder_name || "");
     }
@@ -85,7 +87,7 @@ export function MyPaymentMethod() {
     try {
       await mutation.mutateAsync({
         payment_method: method || null,
-        bank_iban: iban || null,
+        ...(iban ? { bank_iban: iban } : {}),
         bank_bic: bic || null,
         bank_holder_name: holderName || null,
       });
@@ -180,7 +182,15 @@ export function MyPaymentMethod() {
             <div className="grid gap-3 sm:grid-cols-2">
               <div>
                 <Label className="text-xs">{t("paymentMethod.iban")}</Label>
-                <Input className="h-8 mt-1 font-mono" value={iban} onChange={(e) => handleChange(setIban)(e.target.value)} placeholder="ES9121000418450200051332" />
+                <Input
+                  className="h-8 mt-1 font-mono"
+                  value={iban}
+                  onChange={(e) => handleChange(setIban)(e.target.value)}
+                  placeholder={data?.bank_iban_masked || "ES9121000418450200051332"}
+                />
+                {data?.bank_iban_masked && (
+                  <p className="text-xs text-muted-foreground mt-1">{t("paymentMethod.ibanOnFileHint")}</p>
+                )}
               </div>
               <div>
                 <Label className="text-xs">{t("paymentMethod.bic")}</Label>

--- a/frontend/locales/ca/payment-method.json
+++ b/frontend/locales/ca/payment-method.json
@@ -15,6 +15,7 @@
     "iban": "IBAN",
     "bic": "BIC / SWIFT",
     "bicHint": "Normalment es detecta automàticament a partir de l'IBAN",
+    "ibanOnFileHint": "Deixa-ho en blanc per mantenir el compte registrat",
     "holderName": "Titular del compte",
     "mandate": "Mandat SEPA",
     "mandateReference": "Referència del mandat",

--- a/frontend/locales/en/payment-method.json
+++ b/frontend/locales/en/payment-method.json
@@ -15,6 +15,7 @@
     "iban": "IBAN",
     "bic": "BIC / SWIFT",
     "bicHint": "Usually auto-detected from IBAN",
+    "ibanOnFileHint": "Leave blank to keep the account on file",
     "holderName": "Account Holder Name",
     "mandate": "SEPA Mandate",
     "mandateReference": "Mandate Reference",

--- a/frontend/locales/es/payment-method.json
+++ b/frontend/locales/es/payment-method.json
@@ -15,6 +15,7 @@
     "iban": "IBAN",
     "bic": "BIC / SWIFT",
     "bicHint": "Normalmente se detecta automáticamente a partir del IBAN",
+    "ibanOnFileHint": "Déjalo en blanco para mantener la cuenta registrada",
     "holderName": "Titular de la cuenta",
     "mandate": "Mandato SEPA",
     "mandateReference": "Referencia del mandato",


### PR DESCRIPTION
GET /members/me/payment-method carried bank_iban alongside bank_iban_masked, so the masking was decorative: anything that saw the payload — browser devtools, a proxy log — saw the unmasked account number. Only the member's own form read the full value, and only to prefill the input.

Drop bank_iban from the response. The form now treats the IBAN as write-only: the field starts empty with the masked account as its placeholder, and the save omits bank_iban unless the member typed one, so leaving it blank keeps the account on file.

Closes #104

Assisted-by: Claude Code