### PR TITLE
Derive receipt totals from one place so edits keep the discount

### DIFF
--- a/backend/alembic/versions/b8c9d0e1f2a3_store_gross_receipt_base.py
+++ b/backend/alembic/versions/b8c9d0e1f2a3_store_gross_receipt_base.py
@@ -1,0 +1,60 @@
+"""Store the gross base on discounted receipts
+
+Revision ID: b8c9d0e1f2a3
+Revises: a7b8c9d0e1f2
+Create Date: 2026-09-12
+
+create_receipt used to subtract the discount and store the net figure in
+base_amount, with discount_amount holding the money taken off. update_receipt
+then recomputed VAT from that net base and ignored the discount fields, so
+editing a discounted receipt broke its arithmetic.
+
+Receipts now keep what the admin entered — base_amount gross, discount_amount
+as a percentage or a fixed sum per discount_type — and derive the rest. This
+moves existing discounted rows to that shape: the discount goes back onto the
+base, and a percentage discount is expressed as the percentage again. VAT and
+totals are unchanged, since they were computed from the net figure either way.
+"""
+
+from alembic import op
+
+revision = "b8c9d0e1f2a3"
+down_revision = "a7b8c9d0e1f2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Right-hand sides see the old values, so the percentage is derived from
+    # the gross base the row is about to hold.
+    op.execute(
+        """
+        UPDATE receipts
+        SET base_amount = base_amount + discount_amount,
+            discount_amount = CASE
+                WHEN discount_type = 'percentage'
+                    THEN round(discount_amount * 100 / (base_amount + discount_amount), 2)
+                ELSE discount_amount
+            END
+        WHERE discount_amount > 0
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE receipts
+        SET base_amount = base_amount - CASE
+                WHEN discount_type = 'percentage'
+                    THEN round(base_amount * discount_amount / 100, 2)
+                ELSE discount_amount
+            END,
+            discount_amount = CASE
+                WHEN discount_type = 'percentage'
+                    THEN round(base_amount * discount_amount / 100, 2)
+                ELSE discount_amount
+            END
+        WHERE discount_amount > 0
+        """
+    )

--- a/backend/app/domains/billing/pdf.py
+++ b/backend/app/domains/billing/pdf.py
@@ -1,5 +1,6 @@
 """Receipt PDF generation using WeasyPrint + Jinja2."""
 
+from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 
@@ -7,6 +8,7 @@ from jinja2 import Environment, FileSystemLoader
 from sqlalchemy.orm import Session
 
 from app.domains.billing.models import Receipt
+from app.domains.billing.service import resolve_discount
 from app.domains.members.models import Member
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Address, Person
@@ -145,6 +147,9 @@ def generate_receipt_pdf(db: Session, receipt: Receipt) -> bytes:
 
     org_address = _get_org_address(db)
     member_address = _get_member_address(db, person.id) if person else None
+    discount = resolve_discount(
+        Decimal(str(receipt.base_amount)), receipt.discount_amount, receipt.discount_type
+    )
 
     context = {
         "org": {
@@ -168,11 +173,17 @@ def generate_receipt_pdf(db: Session, receipt: Receipt) -> bytes:
             ),
             "description": receipt.description,
             "base_amount": f"{receipt.base_amount:.2f}",
+            "net_amount": f"{Decimal(str(receipt.base_amount)) - discount:.2f}",
             "vat_rate": f"{receipt.vat_rate:.0f}" if receipt.vat_rate == int(receipt.vat_rate) else f"{receipt.vat_rate:.2f}",
             "vat_amount": f"{receipt.vat_amount:.2f}",
             "total_amount": f"{receipt.total_amount:.2f}",
-            "discount_amount": f"{receipt.discount_amount:.2f}" if receipt.discount_amount else None,
-            "discount_type": receipt.discount_type,
+            # The money taken off, and the percentage it came from when it did.
+            "discount_amount": f"{discount:.2f}" if discount else None,
+            "discount_percentage": (
+                f"{receipt.discount_amount:g}"
+                if discount and receipt.discount_type == "percentage"
+                else None
+            ),
             "status": receipt.status,
             "emission_date": receipt.emission_date.strftime("%d/%m/%Y") if receipt.emission_date else None,
             "due_date": receipt.due_date.strftime("%d/%m/%Y") if receipt.due_date else None,

--- a/backend/app/domains/billing/service.py
+++ b/backend/app/domains/billing/service.py
@@ -97,6 +97,39 @@ def calculate_vat(base_amount: Decimal, vat_rate: Decimal) -> tuple[Decimal, Dec
     return vat_amount, total_amount
 
 
+def resolve_discount(
+    base_amount: Decimal, discount_amount: Decimal | None, discount_type: str | None
+) -> Decimal:
+    """The money a receipt's discount takes off its base.
+
+    ``discount_amount`` is what the admin entered: a percentage of the base when
+    ``discount_type`` is ``percentage``, otherwise a fixed sum. Never more than
+    the base itself.
+    """
+    value = Decimal(str(discount_amount or 0))
+    if value <= 0:
+        return Decimal("0")
+    if discount_type == "percentage":
+        value = round_money(base_amount * value / Decimal("100"))
+    return min(value, base_amount)
+
+
+def apply_amounts(receipt: Receipt) -> None:
+    """Derive ``vat_amount`` and ``total_amount`` from the receipt's inputs.
+
+    ``base_amount`` is the gross figure the admin entered and ``discount_amount``
+    / ``discount_type`` the discount as entered; VAT is charged on what is left.
+    The one place this arithmetic lives, so create and update cannot disagree —
+    they used to: create applied the discount and stored the net base, update
+    wrote the discount fields and then ignored them.
+    """
+    base = Decimal(str(receipt.base_amount))
+    net = base - resolve_discount(base, receipt.discount_amount, receipt.discount_type)
+    receipt.vat_amount, receipt.total_amount = calculate_vat(
+        net, Decimal(str(receipt.vat_rate))
+    )
+
+
 # --- Receipt Number Generation ---
 
 
@@ -185,21 +218,6 @@ def create_receipt(
     db: Session, data: ReceiptCreate, created_by_id: int
 ) -> Receipt:
     """Create a new receipt with calculated VAT."""
-    org = db.query(OrganizationSettings).filter(OrganizationSettings.id == 1).first()
-    vat_rate = Decimal(str(data.vat_rate))
-    base_amount = Decimal(str(data.base_amount))
-
-    # Apply discount
-    discount_amount = Decimal(str(data.discount_amount or 0))
-    if data.discount_type == "percentage" and discount_amount > 0:
-        discount_amount = round_money(base_amount * discount_amount / Decimal("100"))
-
-    effective_base = base_amount - discount_amount
-    if effective_base < 0:
-        effective_base = Decimal("0")
-
-    vat_amount, total_amount = calculate_vat(effective_base, vat_rate)
-
     receipt_number = generate_receipt_number(db, data.emission_date)
 
     receipt = Receipt(
@@ -209,11 +227,9 @@ def create_receipt(
         registration_id=data.registration_id,
         origin=data.origin,
         description=data.description,
-        base_amount=effective_base,
-        vat_rate=vat_rate,
-        vat_amount=vat_amount,
-        total_amount=total_amount,
-        discount_amount=discount_amount if data.discount_amount else Decimal("0"),
+        base_amount=Decimal(str(data.base_amount)),
+        vat_rate=Decimal(str(data.vat_rate)),
+        discount_amount=Decimal(str(data.discount_amount or 0)),
         discount_type=data.discount_type,
         status="pending",
         emission_date=data.emission_date,
@@ -224,6 +240,7 @@ def create_receipt(
         is_batchable=data.is_batchable,
         created_by=created_by_id,
     )
+    apply_amounts(receipt)
     db.add(receipt)
     db.flush()
     return receipt
@@ -238,16 +255,11 @@ def update_receipt(db: Session, receipt: Receipt, data: ReceiptUpdate) -> Receip
         )
 
     update_data = data.model_dump(exclude_unset=True)
-
-    # Recalculate amounts if base or vat changed
-    recalculate = "base_amount" in update_data or "vat_rate" in update_data
     for key, value in update_data.items():
         setattr(receipt, key, value)
 
-    if recalculate:
-        base = Decimal(str(receipt.base_amount))
-        vat_rate = Decimal(str(receipt.vat_rate))
-        receipt.vat_amount, receipt.total_amount = calculate_vat(base, vat_rate)
+    if update_data.keys() & {"base_amount", "vat_rate", "discount_amount", "discount_type"}:
+        apply_amounts(receipt)
 
     db.flush()
     return receipt
@@ -508,9 +520,10 @@ def create_credit_note(
     if amount == total and already_credited == 0:
         # Crediting the whole thing mirrors the original exactly, rather than
         # re-deriving the split and risking a cent of drift against the document
-        # it is meant to cancel out.
-        base_amount = Decimal(str(receipt.base_amount))
+        # it is meant to cancel out. The base is the net one — the receipt's
+        # base_amount is gross of any discount, and a credit note carries none.
         vat_amount = Decimal(str(receipt.vat_amount))
+        base_amount = total - vat_amount
     else:
         base_amount = round_money(amount / (Decimal("1") + vat_rate / Decimal("100")))
         vat_amount = amount - base_amount

--- a/backend/app/templates/pdf/receipt_ca.html
+++ b/backend/app/templates/pdf/receipt_ca.html
@@ -96,13 +96,13 @@
     </tbody>
   </table>
 
-  {% if receipt.discount_amount and receipt.discount_amount > 0 %}
-  <p style="font-size:9pt;color:#666;">Descompte aplicat: {{ receipt.discount_amount }} {{ org.currency }}</p>
-  {% endif %}
-
   <div class="totals">
     <table>
-      <tr><td class="label">Base imposable</td><td class="value">{{ receipt.base_amount }} {{ org.currency }}</td></tr>
+      {% if receipt.discount_amount %}
+      <tr><td class="label">Base</td><td class="value">{{ receipt.base_amount }} {{ org.currency }}</td></tr>
+      <tr><td class="label">Descompte{% if receipt.discount_percentage %} ({{ receipt.discount_percentage }}%){% endif %}</td><td class="value">-{{ receipt.discount_amount }} {{ org.currency }}</td></tr>
+      {% endif %}
+      <tr><td class="label">Base imposable</td><td class="value">{{ receipt.net_amount }} {{ org.currency }}</td></tr>
       <tr><td class="label">IVA ({{ receipt.vat_rate }}%)</td><td class="value">{{ receipt.vat_amount }} {{ org.currency }}</td></tr>
       <tr class="total-row"><td>TOTAL</td><td class="value">{{ receipt.total_amount }} {{ org.currency }}</td></tr>
     </table>

--- a/backend/app/templates/pdf/receipt_en.html
+++ b/backend/app/templates/pdf/receipt_en.html
@@ -96,13 +96,13 @@
     </tbody>
   </table>
 
-  {% if receipt.discount_amount and receipt.discount_amount > 0 %}
-  <p style="font-size:9pt;color:#666;">Discount applied: {{ receipt.discount_amount }} {{ org.currency }}</p>
-  {% endif %}
-
   <div class="totals">
     <table>
-      <tr><td class="label">Subtotal</td><td class="value">{{ receipt.base_amount }} {{ org.currency }}</td></tr>
+      {% if receipt.discount_amount %}
+      <tr><td class="label">Base</td><td class="value">{{ receipt.base_amount }} {{ org.currency }}</td></tr>
+      <tr><td class="label">Discount{% if receipt.discount_percentage %} ({{ receipt.discount_percentage }}%){% endif %}</td><td class="value">-{{ receipt.discount_amount }} {{ org.currency }}</td></tr>
+      {% endif %}
+      <tr><td class="label">Subtotal</td><td class="value">{{ receipt.net_amount }} {{ org.currency }}</td></tr>
       <tr><td class="label">VAT ({{ receipt.vat_rate }}%)</td><td class="value">{{ receipt.vat_amount }} {{ org.currency }}</td></tr>
       <tr class="total-row"><td>TOTAL</td><td class="value">{{ receipt.total_amount }} {{ org.currency }}</td></tr>
     </table>

--- a/backend/app/templates/pdf/receipt_es.html
+++ b/backend/app/templates/pdf/receipt_es.html
@@ -97,13 +97,13 @@
     </tbody>
   </table>
 
-  {% if receipt.discount_amount and receipt.discount_amount > 0 %}
-  <p style="font-size:9pt;color:#666;">Descuento aplicado: {{ receipt.discount_amount }} {{ org.currency }}{% if receipt.discount_type == 'percentage' %} ({{ receipt.discount_amount }}%){% endif %}</p>
-  {% endif %}
-
   <div class="totals">
     <table>
-      <tr><td class="label">Base imponible</td><td class="value">{{ receipt.base_amount }} {{ org.currency }}</td></tr>
+      {% if receipt.discount_amount %}
+      <tr><td class="label">Base</td><td class="value">{{ receipt.base_amount }} {{ org.currency }}</td></tr>
+      <tr><td class="label">Descuento{% if receipt.discount_percentage %} ({{ receipt.discount_percentage }}%){% endif %}</td><td class="value">-{{ receipt.discount_amount }} {{ org.currency }}</td></tr>
+      {% endif %}
+      <tr><td class="label">Base imponible</td><td class="value">{{ receipt.net_amount }} {{ org.currency }}</td></tr>
       <tr><td class="label">IVA ({{ receipt.vat_rate }}%)</td><td class="value">{{ receipt.vat_amount }} {{ org.currency }}</td></tr>
       <tr class="total-row"><td>TOTAL</td><td class="value">{{ receipt.total_amount }} {{ org.currency }}</td></tr>
     </table>

--- a/backend/tests/integration/api/v1/test_receipts.py
+++ b/backend/tests/integration/api/v1/test_receipts.py
@@ -185,10 +185,37 @@ class TestReceiptCRUD:
         )
         assert resp.status_code == 201
         data = resp.json()
-        # 10% of 200 = 20 discount, base = 180, VAT = 37.80, total = 217.80
-        assert float(data["base_amount"]) == 180.0
+        # The base stays the gross figure entered; 10% off it is 20, VAT is
+        # charged on the remaining 180 = 37.80, total 217.80.
+        assert float(data["base_amount"]) == 200.0
+        assert float(data["discount_amount"]) == 10.0
+        assert data["discount_type"] == "percentage"
         assert float(data["vat_amount"]) == 37.80
         assert float(data["total_amount"]) == 217.80
+
+    def test_fixed_discount_cannot_exceed_the_base(self, client, db):
+        _ensure_org_settings(db)
+        user = _create_user(db, "admin", "rcpt-disc-cap")
+        member, _ = _create_member(db, "disc-cap")
+
+        resp = client.post(
+            "/api/v1/receipts/",
+            json={
+                "member_id": member.id,
+                "origin": "manual",
+                "description": "Over-discounted",
+                "base_amount": 50,
+                "vat_rate": 21,
+                "discount_amount": 80,
+                "discount_type": "fixed",
+                "emission_date": "2026-03-26",
+            },
+            cookies=_auth_cookie(user),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert float(data["vat_amount"]) == 0.0
+        assert float(data["total_amount"]) == 0.0
 
     def test_list_receipts(self, client, db):
         _ensure_org_settings(db)
@@ -222,6 +249,109 @@ class TestReceiptCRUD:
         user = _create_user(db, "member", "rcpt-auth")
         resp = client.get("/api/v1/receipts/", cookies=_auth_cookie(user))
         assert resp.status_code == 403
+
+
+class TestDiscountedReceiptEdits:
+    """Whatever was edited last, total == (base - discount) + VAT.
+
+    update_receipt used to write discount_amount / discount_type to the row and
+    leave the totals alone, and a base_amount edit was stored as-is against a
+    base that create_receipt had already netted the discount out of.
+    """
+
+    def _create(self, client, db, suffix, **fields):
+        _ensure_org_settings(db)
+        user = _create_user(db, "admin", f"rcpt-edit-{suffix}")
+        member, _ = _create_member(db, f"edit-{suffix}")
+        body = {
+            "member_id": member.id,
+            "origin": "manual",
+            "description": "Editable",
+            "base_amount": 200,
+            "vat_rate": 21,
+            "emission_date": "2026-03-26",
+            **fields,
+        }
+        resp = client.post("/api/v1/receipts/", json=body, cookies=_auth_cookie(user))
+        assert resp.status_code == 201
+        return user, resp.json()["id"]
+
+    def _update(self, client, user, receipt_id, **fields):
+        resp = client.put(
+            f"/api/v1/receipts/{receipt_id}", json=fields, cookies=_auth_cookie(user)
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    def test_changing_the_discount_changes_the_totals(self, client, db):
+        user, rid = self._create(client, db, "disc")
+
+        data = self._update(client, user, rid, discount_amount=10, discount_type="percentage")
+        assert float(data["base_amount"]) == 200.0
+        assert float(data["vat_amount"]) == 37.80
+        assert float(data["total_amount"]) == 217.80
+
+        data = self._update(client, user, rid, discount_amount=50, discount_type="fixed")
+        assert float(data["vat_amount"]) == 31.50
+        assert float(data["total_amount"]) == 181.50
+
+    def test_changing_the_base_keeps_the_discount_applied(self, client, db):
+        user, rid = self._create(
+            client, db, "base", discount_amount=10, discount_type="percentage"
+        )
+
+        data = self._update(client, user, rid, base_amount=100)
+        assert float(data["base_amount"]) == 100.0
+        assert float(data["discount_amount"]) == 10.0
+        # 10% of 100 = 10 off, VAT on 90 = 18.90, total 108.90
+        assert float(data["vat_amount"]) == 18.90
+        assert float(data["total_amount"]) == 108.90
+
+    def test_changing_the_vat_rate_charges_it_on_the_net_base(self, client, db):
+        user, rid = self._create(
+            client, db, "vat", discount_amount=20, discount_type="fixed"
+        )
+
+        data = self._update(client, user, rid, vat_rate=10)
+        # 200 - 20 = 180, 10% of that = 18, total 198
+        assert float(data["vat_amount"]) == 18.0
+        assert float(data["total_amount"]) == 198.0
+
+    def test_percentage_behaves_the_same_on_update_as_on_create(self, client, db):
+        user, created_rid = self._create(
+            client, db, "same-c", discount_amount=15, discount_type="percentage"
+        )
+        created = client.get(
+            f"/api/v1/receipts/{created_rid}", cookies=_auth_cookie(user)
+        ).json()
+
+        updated_rid = client.post(
+            "/api/v1/receipts/",
+            json={
+                "member_id": created["member_id"],
+                "origin": "manual",
+                "description": "Editable",
+                "base_amount": 200,
+                "vat_rate": 21,
+                "emission_date": "2026-03-26",
+            },
+            cookies=_auth_cookie(user),
+        ).json()["id"]
+        updated = self._update(
+            client, user, updated_rid, discount_amount=15, discount_type="percentage"
+        )
+
+        for key in ("base_amount", "discount_amount", "vat_amount", "total_amount"):
+            assert float(updated[key]) == float(created[key]), key
+
+    def test_removing_the_discount_restores_the_full_amount(self, client, db):
+        user, rid = self._create(
+            client, db, "clear", discount_amount=10, discount_type="percentage"
+        )
+
+        data = self._update(client, user, rid, discount_amount=0)
+        assert float(data["vat_amount"]) == 42.0
+        assert float(data["total_amount"]) == 242.0
 
 
 # --- Status Transition Tests ---
@@ -346,7 +476,7 @@ class TestCreditNotes:
     unbroken and the correction traceable, which "cancel and reissue" does not.
     """
 
-    def _issued_receipt(self, client, db, suffix, base_amount=100):
+    def _issued_receipt(self, client, db, suffix, base_amount=100, **fields):
         _ensure_org_settings(db)
         user = _create_user(db, "admin", f"rcpt-cn-{suffix}")
         member, _ = _create_member(db, f"cn-{suffix}")
@@ -359,6 +489,7 @@ class TestCreditNotes:
                 "base_amount": base_amount,
                 "vat_rate": 21,
                 "emission_date": "2026-03-26",
+                **fields,
             },
             cookies=_auth_cookie(user),
         ).json()
@@ -385,6 +516,24 @@ class TestCreditNotes:
         assert note["is_batchable"] is False
         assert note["due_date"] is None
         assert note["member_id"] == receipt["member_id"]
+
+    def test_credit_note_for_a_discounted_receipt_adds_up(self, client, db):
+        """The receipt's base is gross of its discount; the note's is net."""
+        receipt, user = self._issued_receipt(
+            client, db, "disc", base_amount=200,
+            discount_amount=10, discount_type="percentage",
+        )
+        assert float(receipt["total_amount"]) == 217.80
+
+        note = client.post(
+            f"/api/v1/receipts/{receipt['id']}/credit-note",
+            json={"reason": "Cancelled"},
+            cookies=_auth_cookie(user),
+        ).json()
+        assert float(note["total_amount"]) == -217.80
+        assert float(note["base_amount"]) == -180.0
+        assert float(note["vat_amount"]) == -37.80
+        assert float(note["base_amount"]) + float(note["vat_amount"]) == float(note["total_amount"])
 
     def test_credit_note_takes_the_next_number_in_the_series(self, client, db):
         """No gap: the rectifying document is numbered like everything else."""
@@ -675,6 +824,32 @@ class TestReceiptPDF:
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/pdf"
         assert resp.content[:5] == b"%PDF-"  # Valid PDF header
+
+    def test_discounted_receipt_renders(self, client, db):
+        _ensure_org_settings(db)
+        user = _create_user(db, "admin", "pdf-disc")
+        member, _ = _create_member(db, "pdf-disc")
+
+        create_resp = client.post(
+            "/api/v1/receipts/",
+            json={
+                "member_id": member.id,
+                "origin": "manual",
+                "description": "Discounted PDF",
+                "base_amount": 200,
+                "vat_rate": 21,
+                "discount_amount": 10,
+                "discount_type": "percentage",
+                "emission_date": "2026-03-26",
+            },
+            cookies=_auth_cookie(user),
+        )
+        receipt_id = create_resp.json()["id"]
+        client.post(f"/api/v1/receipts/{receipt_id}/emit", cookies=_auth_cookie(user))
+
+        resp = client.get(f"/api/v1/receipts/{receipt_id}/pdf", cookies=_auth_cookie(user))
+        assert resp.status_code == 200
+        assert resp.content[:5] == b"%PDF-"
 
     def test_member_cannot_download_other_receipt(self, client, db):
         _ensure_org_settings(db)

--- a/frontend/app/[locale]/(portal)/receipts/[id]/page.tsx
+++ b/frontend/app/[locale]/(portal)/receipts/[id]/page.tsx
@@ -199,6 +199,14 @@ export default function ReceiptDetailPage() {
     { label: t("receipts.description"), value: receipt.description },
     { label: t("receipts.origin"), value: t(`receipts.origin${receipt.origin.charAt(0).toUpperCase() + receipt.origin.slice(1)}`) },
     { label: t("receipts.base"), value: formatCurrency(receipt.base_amount) },
+    ...(Number(receipt.discount_amount) > 0
+      ? [{
+          label: t("receipts.discount"),
+          value: receipt.discount_type === "percentage"
+            ? `${Number(receipt.discount_amount)}%`
+            : formatCurrency(Number(receipt.discount_amount)),
+        }]
+      : []),
     { label: t("receipts.vatRate"), value: `${Number(receipt.vat_rate)}%` },
     { label: t("receipts.vat"), value: formatCurrency(receipt.vat_amount) },
     { label: t("receipts.total"), value: formatCurrency(receipt.total_amount) },


### PR DESCRIPTION
create_receipt subtracted the discount and stored the net figure in base_amount; update_receipt wrote discount_amount and discount_type to the row and then recomputed VAT from base_amount alone. So editing the discount changed nothing, and editing the base on a discounted receipt stored the new figure gross while the stale discount stayed on the row.

Receipts now keep what the admin entered — base_amount gross, and the discount as a percentage or a fixed sum per discount_type — and apply_amounts derives vat_amount and total_amount from those on both create and update. A migration moves existing discounted rows to that shape; their VAT and totals do not change. The PDF shows base, discount and net rows, and a full credit note mirrors the net base so it still adds up. The receipt detail page shows the discount when there is one.

Closes #105

Assisted-by: Claude Code