### PR TITLE
Load week availability counts in two queries, not per slot

### DIFF
--- a/backend/app/domains/bookings/service.py
+++ b/backend/app/domains/bookings/service.py
@@ -511,6 +511,43 @@ def _member_active_booking(
     )
 
 
+def _counts_by_slot(db: Session, slot_ids: list[int]) -> dict[tuple[int, str], int]:
+    """Booked / waitlisted counts for many slots in one query, keyed by
+    ``(slot_id, status)``. The week view is the member-facing calendar that
+    everyone opens at once when booking opens; a query per slot per count made
+    it two round trips per cell."""
+    if not slot_ids:
+        return {}
+    rows = (
+        db.query(Booking.space_slot_id, Booking.status, func.count(Booking.id))
+        .filter(
+            Booking.space_slot_id.in_(slot_ids),
+            Booking.status.in_(ACTIVE_STATUSES),
+        )
+        .group_by(Booking.space_slot_id, Booking.status)
+        .all()
+    )
+    return {(slot_id, status): count for slot_id, status, count in rows}
+
+
+def _member_statuses_by_slot(
+    db: Session, slot_ids: list[int], member_id: int
+) -> dict[int, str]:
+    """The member's active booking status per slot, for the slots they hold."""
+    if not slot_ids:
+        return {}
+    rows = (
+        db.query(Booking.space_slot_id, Booking.status)
+        .filter(
+            Booking.space_slot_id.in_(slot_ids),
+            Booking.member_id == member_id,
+            Booking.status.in_(ACTIVE_STATUSES),
+        )
+        .all()
+    )
+    return {slot_id: status for slot_id, status in rows}
+
+
 # --- Availability ---------------------------------------------------------
 
 
@@ -535,17 +572,18 @@ def space_week_availability(
         .order_by(SpaceSlot.slot_date, SpaceSlot.start_time)
         .all()
     )
+    slot_ids = [slot.id for slot in slots]
+    counts = _counts_by_slot(db, slot_ids)
+    my_statuses = (
+        _member_statuses_by_slot(db, slot_ids, member_id) if member_id is not None else {}
+    )
+
     cells: list[dict] = []
     for slot in slots:
         on = slot.slot_date
-        booked = _count(db, slot.id, BookingStatus.BOOKED)
-        waitlisted = _count(db, slot.id, BookingStatus.WAITLISTED)
-
-        my_status = "none"
-        if member_id is not None:
-            mine = _member_active_booking(db, slot.id, member_id)
-            if mine is not None:
-                my_status = mine.status
+        booked = counts.get((slot.id, BookingStatus.BOOKED), 0)
+        waitlisted = counts.get((slot.id, BookingStatus.WAITLISTED), 0)
+        my_status = my_statuses.get(slot.id, "none")
 
         slot_start = datetime.combine(on, slot.start_time, tzinfo=tz)
         if slot_start <= now_local:

--- a/backend/tests/integration/test_bookings_service.py
+++ b/backend/tests/integration/test_bookings_service.py
@@ -8,6 +8,7 @@ and query back within the same transaction.
 from datetime import date, time, timedelta
 
 import pytest
+from sqlalchemy import event
 from pydantic import ValidationError
 
 from app.core.security.password import hash_password
@@ -710,6 +711,57 @@ def test_availability_reports_counts_and_state(db):
     assert cell["capacity"] == 1
     assert cell["my_status"] == "booked"
     assert cell["cell_state"] == "full"
+
+
+def test_availability_reports_waitlist_and_other_members_per_slot(db):
+    """Counts are per slot and per status; a member's status is their own."""
+    _org(db)
+    space = _space(db)
+    target = _future(3)
+    week_start = target - timedelta(days=target.weekday())
+    full = _slot(db, space, target, capacity=1)
+    empty = _slot(db, space, target, start=time(12, 0), end=time(13, 0))
+    m1, m2 = _member(db, 1), _member(db, 2)
+    service.create_booking(db, m1, full.id)
+    service.create_booking(db, m2, full.id)  # waitlisted
+
+    by_id = {
+        c["space_slot_id"]: c
+        for c in service.space_week_availability(db, space, week_start, m2.id)
+    }
+    assert by_id[full.id]["booked_count"] == 1
+    assert by_id[full.id]["waitlist_count"] == 1
+    assert by_id[full.id]["my_status"] == "waitlisted"
+    assert by_id[empty.id]["booked_count"] == 0
+    assert by_id[empty.id]["waitlist_count"] == 0
+    assert by_id[empty.id]["my_status"] == "none"
+
+
+def test_availability_query_count_does_not_grow_with_slots(db):
+    """The week view is the page everyone opens at once: a fixed number of
+    queries however many slots the week holds, not two or three per slot."""
+    _org(db)
+    space = _space(db)
+    target = _future(3)
+    week_start = target - timedelta(days=target.weekday())
+    for hour in range(8, 20):
+        _slot(db, space, target, start=time(hour, 0), end=time(hour + 1, 0))
+    m1 = _member(db, 1)
+
+    seen = []
+
+    def record(conn, cursor, statement, params, context, executemany):
+        seen.append(statement)
+
+    event.listen(db.get_bind(), "before_cursor_execute", record)
+    try:
+        cells = service.space_week_availability(db, space, week_start, m1.id)
+    finally:
+        event.remove(db.get_bind(), "before_cursor_execute", record)
+
+    assert len(cells) == 12
+    booking_queries = [q for q in seen if "FROM bookings" in q]
+    assert len(booking_queries) == 2, booking_queries
 
 
 def test_availability_only_covers_slots_dated_in_week(db):


### PR DESCRIPTION
space_week_availability ran two COUNT queries and one lookup per slot, so a week of hourly slots cost thirty-odd round trips per member — on the calendar every member opens at once when booking opens.

Replace them with one GROUP BY over the week's slot ids for the booked and waitlisted counts, and one query for the member's own active bookings across those slots. Cell contents are unchanged; a test pins the query count so it cannot creep back up with the slot count.

Closes #107

Assisted-by: Claude Code