### PR TITLE
Check existing slots when a space's opening hours are narrowed

### DIFF
--- a/backend/app/api/v1/endpoints/bookings.py
+++ b/backend/app/api/v1/endpoints/bookings.py
@@ -114,13 +114,25 @@ def get_space_admin(
 def update_space(
     space_id: int,
     data: SpaceUpdate,
+    force: bool = False,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_permission("bookings.write")),
 ):
+    """Narrowing the hours past existing upcoming slots answers 409 with the
+    slot and affected-member counts when force is absent — the UI confirms,
+    then retries with force=true and those slots are deleted."""
     _require_bookings_enabled(db)
     space = _load_space_or_404(db, space_id)
     try:
-        service.update_space(db, space, data)
+        service.update_space(db, space, data, force=force, notifier=_notifier)
+    except service.SlotsOutsideHours as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "slots_outside_hours": exc.slot_count,
+                "affected_members": exc.affected_members,
+            },
+        )
     except service.BookingError as exc:
         raise _slot_error_422(exc)
     db.commit()

--- a/backend/app/domains/bookings/service.py
+++ b/backend/app/domains/bookings/service.py
@@ -118,6 +118,17 @@ class HasActiveBookings(BookingError):
         self.affected_members = affected_members
 
 
+class SlotsOutsideHours(BookingError):
+    """Narrowing a space's hours would leave slots outside them."""
+
+    def __init__(self, slot_count: int, affected_members: int):
+        super().__init__(
+            f"{slot_count} slot(s) fall outside the new opening hours"
+        )
+        self.slot_count = slot_count
+        self.affected_members = affected_members
+
+
 # --- Settings / time helpers ---------------------------------------------
 
 
@@ -185,7 +196,19 @@ def create_space(db: Session, data: SpaceCreate) -> Space:
     return space
 
 
-def update_space(db: Session, space: Space, data: SpaceUpdate) -> Space:
+def update_space(
+    db: Session,
+    space: Space,
+    data: SpaceUpdate,
+    *,
+    force: bool = False,
+    notifier: BookingNotifier | None = None,
+) -> Space:
+    """Update a space. Narrowing its hours is checked against the slots that
+    already exist: without ``force`` it refuses when upcoming active slots fall
+    outside the new window, so members cannot keep booking a time the space is
+    closed; with ``force`` those slots are deleted the way ``delete_slot`` does
+    it, and every member holding one is notified."""
     payload = data.model_dump(exclude_unset=True)
     if "allowed_membership_types" in payload:
         # An empty list and NULL both mean "open to everyone"; store one of them
@@ -197,7 +220,36 @@ def update_space(db: Session, space: Space, data: SpaceUpdate) -> Space:
         setattr(space, key, value)
     if space.close_time <= space.open_time:
         raise SlotOutsideOpeningHours("close_time must be after open_time")
+
+    if payload.keys() & {"open_time", "close_time"}:
+        stranded = _slots_outside_hours(db, space)
+        if stranded:
+            affected = _affected_active_bookings(db, [s.id for s in stranded])
+            if not force:
+                raise SlotsOutsideHours(
+                    len(stranded), len({b.member_id for b in affected})
+                )
+            for slot in stranded:
+                delete_slot(db, slot, force=True, notifier=notifier)
     return space
+
+
+def _slots_outside_hours(db: Session, space: Space) -> list[SpaceSlot]:
+    """Upcoming active slots that start before the space opens or end after it
+    closes. Past slots are history and stay as they are."""
+    today = datetime.now(_tz(db)).date()
+    return (
+        db.query(SpaceSlot)
+        .filter(
+            SpaceSlot.space_id == space.id,
+            SpaceSlot.is_active.is_(True),
+            SpaceSlot.slot_date >= today,
+            (SpaceSlot.start_time < space.open_time)
+            | (SpaceSlot.end_time > space.close_time),
+        )
+        .order_by(SpaceSlot.slot_date, SpaceSlot.start_time)
+        .all()
+    )
 
 
 def deactivate_space(db: Session, space: Space) -> Space:

--- a/backend/tests/integration/api/v1/test_bookings.py
+++ b/backend/tests/integration/api/v1/test_bookings.py
@@ -304,6 +304,34 @@ class TestDeleteGuards:
         )
 
 
+    def test_space_hours_narrowing_409_then_force(self, client, db):
+        _org(db)
+        admin = _user(db, "admin")
+        space_id, slot_id = _make_space_and_slot(client, admin)  # 10:00-11:00
+        u1, _ = _member_user(db, "h1@examplee6e3b1.com")
+        client.post(
+            "/api/v1/bookings", json={"space_slot_id": slot_id}, cookies=_auth(u1)
+        )
+
+        r = client.put(
+            f"/api/v1/spaces/{space_id}",
+            json={"open_time": "12:00:00"},
+            cookies=_auth(admin),
+        )
+        assert r.status_code == 409
+        assert r.json()["detail"] == {"slots_outside_hours": 1, "affected_members": 1}
+
+        rf = client.put(
+            f"/api/v1/spaces/{space_id}?force=true",
+            json={"open_time": "12:00:00"},
+            cookies=_auth(admin),
+        )
+        assert rf.status_code == 200
+        assert rf.json()["open_time"] == "12:00:00"
+        slots = client.get(f"/api/v1/spaces/{space_id}/slots", cookies=_auth(admin)).json()
+        assert slots == []
+
+
 class TestBooking:
     def test_member_books_a_free_slot(self, client, db):
         _org(db)

--- a/backend/tests/integration/test_bookings_service.py
+++ b/backend/tests/integration/test_bookings_service.py
@@ -184,6 +184,96 @@ def test_update_space_accepts_widened_hours(db):
     assert space.close_time == time(23, 0)
 
 
+# --- Narrowing hours against existing slots -------------------------------
+#
+# Opening hours are validated when a slot is created, but nothing used to look
+# back at the slots when the hours changed: narrow them and the slots outside
+# the new window stayed bookable.
+
+
+def test_update_space_refuses_to_narrow_hours_past_upcoming_slots(db):
+    _org(db)
+    space = _space(db)
+    early = _slot(db, space, _future(3), start=time(8, 0), end=time(9, 0))
+    _slot(db, space, _future(3), start=time(12, 0), end=time(13, 0))
+    m1 = _member(db, 1)
+    service.create_booking(db, m1, early.id)
+
+    with pytest.raises(service.SlotsOutsideHours) as exc:
+        service.update_space(db, space, SpaceUpdate(open_time=time(10, 0)))
+
+    assert exc.value.slot_count == 1
+    assert exc.value.affected_members == 1
+
+
+def test_update_space_ignores_past_slots_outside_the_new_hours(db):
+    _org(db)
+    space = _space(db)
+    past = SpaceSlot(
+        space_id=space.id, slot_date=date.today() - timedelta(days=3),
+        start_time=time(8, 0), end_time=time(9, 0), capacity=1, is_active=True,
+    )
+    db.add(past)
+    db.flush()
+
+    service.update_space(db, space, SpaceUpdate(open_time=time(10, 0)))
+    db.flush()
+    assert space.open_time == time(10, 0)
+    assert past.is_active
+
+
+def test_update_space_ignores_slots_inside_the_new_hours(db):
+    _org(db)
+    space = _space(db)
+    _slot(db, space, _future(3), start=time(12, 0), end=time(13, 0))
+
+    service.update_space(
+        db, space, SpaceUpdate(open_time=time(11, 0), close_time=time(14, 0))
+    )
+    db.flush()
+    assert (space.open_time, space.close_time) == (time(11, 0), time(14, 0))
+
+
+def test_update_space_with_force_deletes_stranded_slots_and_notifies(db):
+    _org(db)
+    space = _space(db)
+    early = _slot(db, space, _future(3), start=time(8, 0), end=time(9, 0))
+    late = _slot(db, space, _future(4), start=time(21, 0), end=time(22, 0))
+    kept = _slot(db, space, _future(3), start=time(12, 0), end=time(13, 0))
+    m1, m2 = _member(db, 1), _member(db, 2)
+    service.create_booking(db, m1, early.id)
+    service.create_booking(db, m2, late.id)
+    notifier = RecordingNotifier()
+
+    service.update_space(
+        db, space,
+        SpaceUpdate(open_time=time(10, 0), close_time=time(20, 0)),
+        force=True, notifier=notifier,
+    )
+    db.flush()
+
+    remaining = {s.id for s in service.list_slots(db, space.id)}
+    assert remaining == {kept.id}
+    assert sorted(n.to for kind, n in notifier.calls if kind == "admin_cancellation") == [
+        "m1@t.com", "m2@t.com"
+    ]
+
+
+def test_update_space_without_hours_change_never_touches_slots(db):
+    """Only a change to the window triggers the check; renaming a space whose
+    slots already sit outside its hours (legacy data) must still work."""
+    _org(db)
+    space = _space(db)
+    slot = _slot(db, space, _future(3), start=time(8, 0), end=time(9, 0))
+    space.open_time = time(10, 0)
+    db.flush()
+
+    service.update_space(db, space, SpaceUpdate(name="Court 2"))
+    db.flush()
+    assert space.name == "Court 2"
+    assert slot.is_active
+
+
 # --- Slot validation + creation -------------------------------------------
 
 

--- a/frontend/features/bookings/components/space-form.tsx
+++ b/frontend/features/bookings/components/space-form.tsx
@@ -18,10 +18,13 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { useQueryClient } from "@tanstack/react-query";
+import { useConfirmDialog } from "@/components/ui/confirm-dialog";
+import { ClientApiError } from "@/lib/client-api";
 import { mapApiErrorsToForm } from "@/lib/errors";
 import { useMembershipTypes } from "@/features/members/hooks/use-members";
 import { useCreateSpace, useUpdateSpace } from "../hooks/use-bookings";
-import type { Space } from "../services/bookings-api";
+import { updateSpace, type Space } from "../services/bookings-api";
 
 const toTimeInput = (s: string | null | undefined) => (s ? s.slice(0, 5) : "");
 
@@ -74,6 +77,8 @@ export function SpaceForm({
   const t = useTranslations();
   const createMutation = useCreateSpace();
   const updateMutation = useUpdateSpace();
+  const qc = useQueryClient();
+  const [confirmDialog, confirmAction] = useConfirmDialog();
   const { data: membershipTypes } = useMembershipTypes();
   const activeTypes = (membershipTypes ?? []).filter((mt) => mt.is_active);
 
@@ -104,13 +109,50 @@ export function SpaceForm({
     };
     try {
       if (space) {
-        await updateMutation.mutateAsync({ id: space.id, data: payload });
+        // The raw call so the expected 409 — upcoming slots outside the new
+        // hours — skips the global error toast and reaches the confirm below.
+        await updateSpace(space.id, payload);
+        qc.invalidateQueries({ queryKey: ["spaces"] });
+        qc.invalidateQueries({ queryKey: ["space", space.id] });
       } else {
         await createMutation.mutateAsync(payload);
       }
       toast.success(t("toast.success.saved"));
       onSuccess();
     } catch (error) {
+      if (space && error instanceof ClientApiError && error.status === 409) {
+        const detail = error.detail as unknown as {
+          slots_outside_hours?: number;
+          affected_members?: number;
+        };
+        confirmAction({
+          title: t("bookings.spaces.confirmHours"),
+          description:
+            t("bookings.spaces.hoursSlotsAffected", {
+              count: detail?.slots_outside_hours ?? 0,
+            }) +
+            " " +
+            t("bookings.spaces.deleteAffected", {
+              count: detail?.affected_members ?? 0,
+            }),
+          cancelLabel: t("common.cancel"),
+          confirmLabel: t("common.save"),
+          onConfirm: async () => {
+            try {
+              await updateMutation.mutateAsync({
+                id: space.id,
+                data: payload,
+                force: true,
+              });
+              toast.success(t("toast.success.saved"));
+              onSuccess();
+            } catch {
+              /* global handler */
+            }
+          },
+        });
+        return;
+      }
       mapApiErrorsToForm(error, form);
     }
   }
@@ -274,6 +316,7 @@ export function SpaceForm({
           </Button>
         )}
       </form>
+      {confirmDialog}
     </Form>
   );
 }

--- a/frontend/features/bookings/hooks/use-bookings.ts
+++ b/frontend/features/bookings/hooks/use-bookings.ts
@@ -49,8 +49,15 @@ export function useCreateSpace() {
 export function useUpdateSpace() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<SpaceInput> }) =>
-      updateSpace(id, data),
+    mutationFn: ({
+      id,
+      data,
+      force,
+    }: {
+      id: number;
+      data: Partial<SpaceInput>;
+      force?: boolean;
+    }) => updateSpace(id, data, force),
     onSuccess: (_res, { id }) => {
       qc.invalidateQueries({ queryKey: ["spaces"] });
       qc.invalidateQueries({ queryKey: ["space", id] });

--- a/frontend/features/bookings/services/bookings-api.ts
+++ b/frontend/features/bookings/services/bookings-api.ts
@@ -103,11 +103,15 @@ export async function createSpace(data: SpaceInput): Promise<Space> {
   });
 }
 
+// Narrowing the hours past existing upcoming slots answers 409 +
+// {slots_outside_hours, affected_members} without force — the UI confirms,
+// then retries with force and those slots are deleted.
 export async function updateSpace(
   id: number,
-  data: Partial<SpaceInput>
+  data: Partial<SpaceInput>,
+  force = false
 ): Promise<Space> {
-  return apiClient<Space>(`/spaces/${id}`, {
+  return apiClient<Space>(`/spaces/${id}${force ? "?force=true" : ""}`, {
     method: "PUT",
     body: JSON.stringify(data),
   });

--- a/frontend/locales/ca/bookings.json
+++ b/frontend/locales/ca/bookings.json
@@ -54,6 +54,8 @@
       "notFound": "Espai no trobat.",
       "confirmDelete": "Vols eliminar aquest espai? Se n'eliminaran les franges i les reserves. Per deixar d'acceptar reserves sense esborrar res, desactiva'l des d'Edita.",
       "deleteAffected": "{count, plural, one {# soci té reserves actives que es cancel·laran i se l'avisarà per correu.} other {# socis tenen reserves actives que es cancel·laran i se'ls avisarà per correu.}}",
+      "confirmHours": "Vols reduir l'horari d'obertura?",
+      "hoursSlotsAffected": "{count, plural, one {# franja propera queda fora del nou horari i s'eliminarà.} other {# franges properes queden fora del nou horari i s'eliminaran.}}",
       "allowedTypes": "Tipus de soci amb accés",
       "allowedTypesHint": "Sense cap marcat, l'espai queda obert a tots els socis. En marcar tipus, només aquests socis el podran reservar.",
       "allowedTypesNone": "Encara no hi ha tipus de soci actius.",

--- a/frontend/locales/en/bookings.json
+++ b/frontend/locales/en/bookings.json
@@ -54,6 +54,8 @@
       "notFound": "Space not found.",
       "confirmDelete": "Delete this space? Its slots and bookings will be removed. To stop taking bookings without deleting anything, deactivate it from Edit.",
       "deleteAffected": "{count, plural, one {# member has active bookings that will be cancelled and notified by email.} other {# members have active bookings that will be cancelled and notified by email.}}",
+      "confirmHours": "Narrow the opening hours?",
+      "hoursSlotsAffected": "{count, plural, one {# upcoming slot falls outside the new hours and will be deleted.} other {# upcoming slots fall outside the new hours and will be deleted.}}",
       "allowedTypes": "Membership types with access",
       "allowedTypesHint": "With none ticked the space is open to every member. Tick types and only those members can book it.",
       "allowedTypesNone": "No active membership types yet.",

--- a/frontend/locales/es/bookings.json
+++ b/frontend/locales/es/bookings.json
@@ -54,6 +54,8 @@
       "notFound": "Espacio no encontrado.",
       "confirmDelete": "¿Eliminar este espacio? Se eliminarán sus franjas y reservas. Para dejar de aceptar reservas sin borrar nada, desactívalo desde Editar.",
       "deleteAffected": "{count, plural, one {# socio tiene reservas activas que se cancelarán y se le avisará por correo.} other {# socios tienen reservas activas que se cancelarán y se les avisará por correo.}}",
+      "confirmHours": "¿Reducir el horario de apertura?",
+      "hoursSlotsAffected": "{count, plural, one {# franja próxima queda fuera del nuevo horario y se eliminará.} other {# franjas próximas quedan fuera del nuevo horario y se eliminarán.}}",
       "allowedTypes": "Tipos de socio con acceso",
       "allowedTypesHint": "Sin ninguno marcado, el espacio queda abierto a todos los socios. Al marcar tipos, solo esos socios podrán reservarlo.",
       "allowedTypesNone": "Aún no hay tipos de socio activos.",


### PR DESCRIPTION
Opening hours were validated when a slot was created and never looked at again, so narrowing them left slots outside the new window active and bookable — members kept booking a time the space is closed.

update_space now finds the upcoming active slots that start before the new open_time or end after the new close_time. Without force it refuses with a 409 carrying the slot and affected-member counts, mirroring the delete paths; with force those slots are deleted through delete_slot, so every member holding one is notified. Past slots are history and are left alone, and an edit that does not touch the hours never runs the check. The space form confirms the counts and retries with force.

Closes #111

Assisted-by: Claude Code