### PR TITLE
Match discount codes regardless of case

### DIFF
--- a/backend/alembic/versions/d0e1f2a3b4c5_uppercase_discount_codes.py
+++ b/backend/alembic/versions/d0e1f2a3b4c5_uppercase_discount_codes.py
@@ -1,0 +1,40 @@
+"""Store discount codes in upper case
+
+Revision ID: d0e1f2a3b4c5
+Revises: b8c9d0e1f2a3
+Create Date: 2026-09-12
+
+Codes were matched with a case-sensitive equality, so SUMMER20 failed against
+a row holding summer20. Input is now normalised to upper case before it is
+stored or looked up; this brings the existing rows in line. A row whose
+upper-cased code would collide with another code on the same activity is left
+as it is rather than failing the upgrade — the unique constraint stands, and
+that pair is for a person to sort out.
+"""
+
+from alembic import op
+
+revision = "d0e1f2a3b4c5"
+down_revision = "b8c9d0e1f2a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE discount_codes d
+        SET code = upper(code)
+        WHERE code <> upper(code)
+          AND NOT EXISTS (
+              SELECT 1 FROM discount_codes o
+              WHERE o.activity_id = d.activity_id
+                AND o.id <> d.id
+                AND o.code = upper(d.code)
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/domains/activities/discount_schemas.py
+++ b/backend/app/domains/activities/discount_schemas.py
@@ -2,13 +2,24 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.domains.shared.enums import DiscountType
 
 
+def normalize_code(value: str | None) -> str | None:
+    """Codes are printed on posters and retyped from messages in whatever case
+    the member likes; ``summer20`` and ``SUMMER20`` are the same code. Stored
+    and looked up in upper case, so the unique constraint and the lookup agree."""
+    if value is None:
+        return None
+    return value.strip().upper()
+
+
 class DiscountCodeCreate(BaseModel):
     code: str = Field(min_length=1, max_length=50)
+
+    _normalize_code = field_validator("code")(normalize_code)
     description: str | None = Field(default=None, max_length=2000)
     discount_type: DiscountType
     discount_value: float = Field(gt=0)
@@ -27,6 +38,8 @@ class DiscountCodeCreate(BaseModel):
 
 class DiscountCodeUpdate(BaseModel):
     code: str | None = Field(default=None, min_length=1, max_length=50)
+
+    _normalize_code = field_validator("code")(normalize_code)
     description: str | None = Field(default=None, max_length=2000)
     discount_type: DiscountType | None = None
     discount_value: float | None = Field(default=None, gt=0)
@@ -63,6 +76,8 @@ class DiscountCodeResponse(BaseModel):
 
 class ValidateDiscountRequest(BaseModel):
     code: str = Field(min_length=1, max_length=50)
+
+    _normalize_code = field_validator("code")(normalize_code)
 
 
 class ValidateDiscountResponse(BaseModel):

--- a/backend/app/domains/activities/discount_service.py
+++ b/backend/app/domains/activities/discount_service.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from sqlalchemy.orm import Session
 
 from app.core.money import round_money
+from app.domains.activities.discount_schemas import normalize_code
 from app.domains.activities.models import DiscountCode
 
 
@@ -28,7 +29,7 @@ def validate_discount_code(
     """
     query = db.query(DiscountCode).filter(
         DiscountCode.activity_id == activity_id,
-        DiscountCode.code == code,
+        DiscountCode.code == normalize_code(code),
         DiscountCode.is_active.is_(True),
     )
     if for_update:

--- a/backend/app/domains/activities/registration_schemas.py
+++ b/backend/app/domains/activities/registration_schemas.py
@@ -2,8 +2,9 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from app.domains.activities.discount_schemas import normalize_code
 from app.domains.shared.enums import RegistrationStatus
 
 
@@ -19,6 +20,8 @@ class RegisterRequest(BaseModel):
     consents: list[ConsentAcceptanceInput] = []
     registration_data: dict = {}
     member_notes: str | None = Field(default=None, max_length=2000)
+
+    _normalize_code = field_validator("discount_code")(normalize_code)
 
 
 class CancelRegistrationRequest(BaseModel):

--- a/backend/tests/integration/api/v1/test_discount_codes.py
+++ b/backend/tests/integration/api/v1/test_discount_codes.py
@@ -209,6 +209,63 @@ class TestDiscountCodeCRUD:
         assert response.status_code == 403
 
 
+class TestCodeCase:
+    """summer20 and SUMMER20 are the same code, however it was typed."""
+
+    def test_create_stores_the_code_in_upper_case(self, client, db):
+        admin = _create_user(db, "admin", suffix="-case1")
+        activity, _ = _create_published_activity(db, admin.id)
+        client.cookies.update(_auth_cookie(admin))
+
+        r = client.post(
+            f"/api/v1/activities/{activity.id}/discount-codes",
+            json={"code": " summer20 ", "discount_type": "percentage", "discount_value": 20},
+        )
+        assert r.status_code == 201
+        assert r.json()["code"] == "SUMMER20"
+
+    def test_duplicate_differing_only_in_case_is_rejected(self, client, db):
+        admin = _create_user(db, "admin", suffix="-case2")
+        activity, _ = _create_published_activity(db, admin.id)
+        db.add(DiscountCode(
+            activity_id=activity.id, code="SUMMER20",
+            discount_type="percentage", discount_value=20, is_active=True,
+        ))
+        db.flush()
+        client.cookies.update(_auth_cookie(admin))
+
+        r = client.post(
+            f"/api/v1/activities/{activity.id}/discount-codes",
+            json={"code": "Summer20", "discount_type": "fixed", "discount_value": 5},
+        )
+        assert r.status_code == 400
+
+    def test_validate_and_register_accept_any_case(self, client, db):
+        admin = _create_user(db, "admin", suffix="-case3")
+        user, _ = _create_member_with_user(db, suffix="-case3")
+        activity, price = _create_published_activity(db, admin.id)
+        db.add(DiscountCode(
+            activity_id=activity.id, code="SUMMER20",
+            discount_type="percentage", discount_value=20, is_active=True,
+        ))
+        db.flush()
+        client.cookies.update(_auth_cookie(user))
+
+        r = client.post(
+            f"/api/v1/activities/{activity.id}/validate-discount",
+            json={"code": "summer20"},
+        )
+        assert r.status_code == 200
+        assert r.json()["valid"] is True
+
+        r = client.post(
+            f"/api/v1/activities/{activity.id}/register",
+            json={"price_id": price.id, "discount_code": "Summer20"},
+        )
+        assert r.status_code == 201
+        assert r.json()["discounted_amount"] == 80.0
+
+
 class TestValidateDiscount:
     def test_validate_valid_code(self, client, db):
         admin = _create_user(db, "admin", suffix="-val1")


### PR DESCRIPTION
validate_discount_code filtered on DiscountCode.code == code with no normalisation, so SUMMER20 failed against a row holding summer20. Codes are printed on posters and retyped from messages in whatever case the member likes, and a miss reads as a broken code, not a typo.

Normalise the code to upper case at every boundary — create, update, the validation preview, registration, and the service lookup itself — so storage, the per-activity unique constraint and the match all agree. A migration upper-cases the existing rows, leaving any that would collide with another code on the same activity for a person to resolve.

Closes #113

Assisted-by: Claude Code