### PR TITLE
Send manual payment reminders from the worker, not the request

### DIFF
--- a/backend/alembic/versions/9c1d2e3f4a5b_queued_reminder_status.py
+++ b/backend/alembic/versions/9c1d2e3f4a5b_queued_reminder_status.py
@@ -1,0 +1,38 @@
+"""Allow 'queued' on receipt_reminders.status
+
+Revision ID: 9c1d2e3f4a5b
+Revises: d0e1f2a3b4c5
+Create Date: 2026-09-12
+
+The admin's "send reminder" button used to send the email inside the request
+and write the row with the outcome. It now writes the row as ``queued`` and a
+Celery task delivers the email after the commit, recording ``sent`` or
+``failed`` on the same row.
+"""
+
+from alembic import op
+
+revision = "9c1d2e3f4a5b"
+down_revision = "d0e1f2a3b4c5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("valid_receipt_reminder_status", "receipt_reminders", type_="check")
+    op.create_check_constraint(
+        "valid_receipt_reminder_status",
+        "receipt_reminders",
+        "status IN ('queued', 'sent', 'failed', 'skipped')",
+    )
+
+
+def downgrade() -> None:
+    # A row still in flight has no place in the old set; call it failed.
+    op.execute("UPDATE receipt_reminders SET status = 'failed' WHERE status = 'queued'")
+    op.drop_constraint("valid_receipt_reminder_status", "receipt_reminders", type_="check")
+    op.create_check_constraint(
+        "valid_receipt_reminder_status",
+        "receipt_reminders",
+        "status IN ('sent', 'failed', 'skipped')",
+    )

--- a/backend/app/api/v1/endpoints/receipts.py
+++ b/backend/app/api/v1/endpoints/receipts.py
@@ -14,7 +14,7 @@ from app.core.security.dependencies import get_current_user
 from app.db.session import get_db
 from app.domains.auth.models import User
 from app.domains.billing.models import Receipt, ReceiptReminder
-from app.domains.billing.reminder_service import send_reminder
+from app.domains.billing.reminder_service import COUNTED_STATUSES, queue_reminder
 from app.domains.billing.schemas import (
     CreditNoteCreate,
     GenerateMembershipFeesRequest,
@@ -459,7 +459,7 @@ def send_receipt_reminder(
         db.query(ReceiptReminder)
         .filter(
             ReceiptReminder.receipt_id == receipt.id,
-            ReceiptReminder.status == "sent",
+            ReceiptReminder.status.in_(COUNTED_STATUSES),
         )
         .count()
     )
@@ -469,7 +469,7 @@ def send_receipt_reminder(
         )
 
     try:
-        reminder = send_reminder(db, receipt, "manual", user_id=current_user.id)
+        reminder = queue_reminder(db, receipt, "manual", user_id=current_user.id)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
     db.commit()

--- a/backend/app/domains/billing/models.py
+++ b/backend/app/domains/billing/models.py
@@ -429,7 +429,7 @@ class ReceiptReminder(Base):
             name="valid_receipt_reminder_channel",
         ),
         CheckConstraint(
-            "status IN ('sent', 'failed', 'skipped')",
+            "status IN ('queued', 'sent', 'failed', 'skipped')",
             name="valid_receipt_reminder_status",
         ),
         CheckConstraint(

--- a/backend/app/domains/billing/reminder_service.py
+++ b/backend/app/domains/billing/reminder_service.py
@@ -9,6 +9,10 @@ Three concerns, mirroring ``recurring_billing_service``:
   due, repeat every Y days, max N) to decide which overdue receipts need a
   reminder today.
 - ``send_reminder`` renders + sends the email and logs a ``ReceiptReminder`` row.
+  It runs inside the Celery worker (the scheduled pass). The admin's manual
+  button goes through ``queue_reminder`` instead, which logs a ``queued`` row
+  and hands the send to a task once the request commits — an admin must not
+  wait on SMTP, and a slow mail server must not turn the click into a timeout.
 
 Email-only for now. Does not commit — the caller owns the transaction.
 """
@@ -19,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.email import send_payment_reminder_email
+from app.db.after_commit import run_after_commit
 from app.domains.billing.models import PaymentProvider, Receipt, ReceiptReminder
 from app.domains.members.models import Member
 from app.domains.organizations.models import OrganizationSettings
@@ -62,8 +67,14 @@ def mark_overdue(db: Session, today: date | None = None) -> int:
     return len(rows)
 
 
+# Reminders that count against the schedule and the cap: delivered ones, and
+# ones handed to the worker that have not come back yet. Leaving ``queued`` out
+# would let a second click queue a duplicate before the first is sent.
+COUNTED_STATUSES = ("sent", "queued")
+
+
 def _sent_reminders(receipt: Receipt) -> list[ReceiptReminder]:
-    return [rem for rem in receipt.reminders if rem.status == "sent"]
+    return [rem for rem in receipt.reminders if rem.status in COUNTED_STATUSES]
 
 
 def reminders_due(
@@ -127,20 +138,14 @@ def _recipient(db: Session, receipt: Receipt) -> tuple[Person | None, Organizati
     return person, org
 
 
-def send_reminder(
-    db: Session,
-    receipt: Receipt,
-    triggered_by: str,
-    user_id: int | None = None,
-    today: date | None = None,
-) -> ReceiptReminder:
-    """Render and send a payment reminder for ``receipt``, logging a row.
+def _prepare_reminder(
+    db: Session, receipt: Receipt, today: date
+) -> tuple[Person, dict]:
+    """Resolve the recipient and the email payload for a reminder.
 
     Raises ``ValueError`` if the member has no email (a precondition the manual
-    endpoint surfaces to the admin). Send-transport failures are recorded as a
-    ``failed`` row rather than raised. Does not commit.
+    endpoint surfaces to the admin).
     """
-    today = today or date.today()
     person, org = _recipient(db, receipt)
     if person is None or not person.email:
         raise ValueError("Member has no email address")
@@ -163,39 +168,98 @@ def send_reminder(
     elif org and org.bank_iban:
         bank_details = " — ".join(filter(None, [org.bank_name, org.bank_iban]))
 
-    reminder_number = len(_sent_reminders(receipt)) + 1
+    payload = dict(
+        to=person.email,
+        member_name=member_name,
+        receipt_number=receipt.receipt_number,
+        amount=f"{receipt.total_amount:.2f}",
+        currency=currency,
+        due_date=receipt.due_date.isoformat() if receipt.due_date else "",
+        days_overdue=days_overdue,
+        org_name=org_name,
+        pay_now_url=pay_now_url,
+        bank_details=bank_details,
+        locale=locale,
+    )
+    return person, payload
 
-    sent_ok = False
-    error = None
-    try:
-        sent_ok = send_payment_reminder_email(
-            to=person.email,
-            member_name=member_name,
-            receipt_number=receipt.receipt_number,
-            amount=f"{receipt.total_amount:.2f}",
-            currency=currency,
-            due_date=receipt.due_date.isoformat() if receipt.due_date else "",
-            days_overdue=days_overdue,
-            org_name=org_name,
-            pay_now_url=pay_now_url,
-            bank_details=bank_details,
-            locale=locale,
-        )
-    except Exception as exc:  # noqa: BLE001 — recorded on the row for the admin
-        error = str(exc)
 
-    reminder = ReceiptReminder(
+def _new_reminder_row(
+    receipt: Receipt, person: Person, triggered_by: str, user_id: int | None
+) -> ReceiptReminder:
+    return ReceiptReminder(
         receipt_id=receipt.id,
-        reminder_number=reminder_number,
+        reminder_number=len(_sent_reminders(receipt)) + 1,
         channel="email",
-        status="sent" if sent_ok else "failed",
+        status="queued",
         to_email=person.email,
         triggered_by=triggered_by,
         triggered_by_user_id=user_id,
-        error=error if error else (None if sent_ok else "Email transport unavailable or send failed"),
     )
+
+
+def deliver(payload: dict) -> tuple[bool, str | None]:
+    """Send one reminder email. Returns ``(sent_ok, error)``; never raises."""
+    try:
+        return send_payment_reminder_email(**payload), None
+    except Exception as exc:  # noqa: BLE001 — recorded on the row for the admin
+        return False, str(exc)
+
+
+def record_outcome(reminder: ReceiptReminder, sent_ok: bool, error: str | None) -> None:
+    reminder.status = "sent" if sent_ok else "failed"
+    reminder.error = error if error else (None if sent_ok else "Email transport unavailable or send failed")
+
+
+def send_reminder(
+    db: Session,
+    receipt: Receipt,
+    triggered_by: str,
+    user_id: int | None = None,
+    today: date | None = None,
+) -> ReceiptReminder:
+    """Render and send a payment reminder for ``receipt`` now, logging a row.
+
+    For the worker (scheduled pass). Send-transport failures are recorded as a
+    ``failed`` row rather than raised. Does not commit.
+    """
+    today = today or date.today()
+    person, payload = _prepare_reminder(db, receipt, today)
+    reminder = _new_reminder_row(receipt, person, triggered_by, user_id)
+    record_outcome(reminder, *deliver(payload))
     db.add(reminder)
     db.flush()
+    return reminder
+
+
+def queue_reminder(
+    db: Session,
+    receipt: Receipt,
+    triggered_by: str,
+    user_id: int | None = None,
+    today: date | None = None,
+) -> ReceiptReminder:
+    """Log a ``queued`` reminder and hand the send to Celery once the caller's
+    transaction commits. The task records ``sent`` / ``failed`` on the row.
+
+    For the request path: the admin gets their response as soon as the row is
+    written, and a slow or failing mail server shows up on the row rather than
+    as a timeout. Does not commit.
+    """
+    today = today or date.today()
+    person, payload = _prepare_reminder(db, receipt, today)
+    reminder = _new_reminder_row(receipt, person, triggered_by, user_id)
+    db.add(reminder)
+    db.flush()
+
+    reminder_id = reminder.id
+
+    def dispatch() -> None:
+        from app.tasks.billing_tasks import send_queued_reminder
+
+        send_queued_reminder.delay(reminder_id, payload)
+
+    run_after_commit(db, dispatch)
     return reminder
 
 

--- a/backend/app/tasks/billing_tasks.py
+++ b/backend/app/tasks/billing_tasks.py
@@ -217,3 +217,30 @@ def send_payment_notification(self, receipt_id: int) -> bool:
             f"Payment notification failed: receipt_id={receipt_id}, error={exc}"
         )
         raise self.retry(exc=exc)
+
+
+@celery.task
+def send_queued_reminder(reminder_id: int, payload: dict) -> str:
+    """Deliver a reminder the request path queued, and record the outcome on
+    its row. The payload was resolved when the row was written, so the task
+    does not re-read the receipt; a transport failure lands as ``failed`` with
+    the error, the same as the synchronous path, rather than retrying blind.
+    """
+    from app.db.session import SessionLocal
+    from app.domains.billing.models import ReceiptReminder
+    from app.domains.billing.reminder_service import deliver, record_outcome
+
+    db = SessionLocal()
+    try:
+        reminder = db.query(ReceiptReminder).filter(ReceiptReminder.id == reminder_id).first()
+        if reminder is None or reminder.status != "queued":
+            return "skipped"
+        record_outcome(reminder, *deliver(payload))
+        db.commit()
+        return reminder.status
+    except Exception as exc:
+        db.rollback()
+        logger.error(f"Queued reminder {reminder_id} failed: {exc}")
+        raise
+    finally:
+        db.close()

--- a/backend/tests/integration/api/v1/test_payment_reminders.py
+++ b/backend/tests/integration/api/v1/test_payment_reminders.py
@@ -12,10 +12,12 @@ from app.domains.auth.models import User
 from app.domains.billing.models import PaymentProvider, Receipt, ReceiptReminder
 from app.domains.billing.reminder_service import (
     mark_overdue,
+    queue_reminder,
     reminders_due,
     run_scheduled_reminders,
     send_reminder,
 )
+from app.tasks.billing_tasks import send_queued_reminder
 from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
@@ -390,19 +392,127 @@ class TestRunScheduled:
 # --- Manual endpoint ---
 
 
-class TestManualEndpoint:
-    def test_send_reminder_ok(self, client, db, monkeypatch):
+class TestQueueReminder:
+    """The request path writes the row and hands the send to the worker after
+    the commit — the admin never waits on SMTP."""
+
+    def test_row_is_queued_and_the_task_fires_after_commit(self, db):
+        _ensure_org_settings(db)
+        member = _create_member(db, "qr1")
+        r = _create_receipt(db, member, "qr1", "overdue", due_date=TODAY - timedelta(days=5))
+
+        with patch("app.tasks.billing_tasks.send_queued_reminder.delay") as delay:
+            reminder = queue_reminder(db, r, "manual", user_id=None, today=TODAY)
+            assert reminder.status == "queued"
+            assert reminder.reminder_number == 1
+            assert reminder.to_email == "maria-qr1@examplee6e3b1.com"
+            delay.assert_not_called()
+
+            db.commit()
+
+        delay.assert_called_once()
+        reminder_id, payload = delay.call_args.args
+        assert reminder_id == reminder.id
+        assert payload["to"] == "maria-qr1@examplee6e3b1.com"
+        assert payload["receipt_number"] == r.receipt_number
+        assert payload["days_overdue"] == 5
+
+    def test_a_queued_reminder_counts_towards_the_next_number(self, db):
+        """A second click before the worker has run must not restart at #1
+        or slip past the cap."""
+        _ensure_org_settings(db)
+        member = _create_member(db, "qr2")
+        r = _create_receipt(db, member, "qr2", "overdue", due_date=TODAY - timedelta(days=5))
+
+        with patch("app.tasks.billing_tasks.send_queued_reminder.delay"):
+            first = queue_reminder(db, r, "manual", today=TODAY)
+            db.refresh(r)
+            second = queue_reminder(db, r, "manual", today=TODAY)
+        assert (first.reminder_number, second.reminder_number) == (1, 2)
+
+    def test_raises_when_no_email(self, db):
+        _ensure_org_settings(db)
+        member = _create_member(db, "qr3", email=None)
+        r = _create_receipt(db, member, "qr3", "overdue", due_date=TODAY - timedelta(days=5))
+        with pytest.raises(ValueError):
+            queue_reminder(db, r, "manual", today=TODAY)
+        assert db.query(ReceiptReminder).filter_by(receipt_id=r.id).count() == 0
+
+
+class TestQueuedReminderTask:
+    def _queued(self, db, suffix):
+        _ensure_org_settings(db)
+        member = _create_member(db, suffix)
+        r = _create_receipt(db, member, suffix, "overdue", due_date=TODAY - timedelta(days=5))
+        with patch("app.tasks.billing_tasks.send_queued_reminder.delay") as delay:
+            queue_reminder(db, r, "manual", today=TODAY)
+            db.commit()
+        return delay.call_args.args
+
+    def test_records_sent(self, db, monkeypatch):
         _patch_email_sent(monkeypatch, ok=True)
+        reminder_id, payload = self._queued(db, "qt1")
+        monkeypatch.setattr("app.db.session.SessionLocal", lambda: db)
+
+        assert send_queued_reminder.run(reminder_id, payload) == "sent"
+        row = db.get(ReceiptReminder, reminder_id)
+        assert row.status == "sent"
+        assert row.error is None
+
+    def test_records_failed_with_the_error(self, db, monkeypatch):
+        def boom(**kwargs):
+            raise RuntimeError("smtp down")
+
+        monkeypatch.setattr(
+            "app.domains.billing.reminder_service.send_payment_reminder_email", boom
+        )
+        reminder_id, payload = self._queued(db, "qt2")
+        monkeypatch.setattr("app.db.session.SessionLocal", lambda: db)
+
+        assert send_queued_reminder.run(reminder_id, payload) == "failed"
+        row = db.get(ReceiptReminder, reminder_id)
+        assert row.status == "failed"
+        assert row.error == "smtp down"
+
+    def test_skips_a_row_that_is_no_longer_queued(self, db, monkeypatch):
+        _patch_email_sent(monkeypatch, ok=True)
+        reminder_id, payload = self._queued(db, "qt3")
+        db.get(ReceiptReminder, reminder_id).status = "sent"
+        db.flush()
+        monkeypatch.setattr("app.db.session.SessionLocal", lambda: db)
+
+        assert send_queued_reminder.run(reminder_id, payload) == "skipped"
+
+
+class TestManualEndpoint:
+    def test_send_reminder_queues_and_returns_at_once(self, client, db, monkeypatch):
         _ensure_org_settings(db)
         user = _create_user(db, "admin", "me1")
         member = _create_member(db, "me1")
         r = _create_receipt(db, member, "me1", "overdue", due_date=TODAY - timedelta(days=5))
-        resp = client.post(
-            f"/api/v1/receipts/{r.id}/send-reminder", cookies=_auth_cookie(user)
-        )
+        with patch("app.tasks.billing_tasks.send_queued_reminder.delay") as delay:
+            resp = client.post(
+                f"/api/v1/receipts/{r.id}/send-reminder", cookies=_auth_cookie(user)
+            )
         assert resp.status_code == 200
-        assert resp.json()["status"] == "sent"
+        assert resp.json()["status"] == "queued"
         assert resp.json()["triggered_by"] == "manual"
+        delay.assert_called_once()
+
+    def test_a_queued_reminder_counts_against_the_cap(self, client, db, monkeypatch):
+        _ensure_org_settings(db, features={"reminder_max_count": 1})
+        user = _create_user(db, "admin", "me6")
+        member = _create_member(db, "me6")
+        r = _create_receipt(db, member, "me6", "overdue", due_date=TODAY - timedelta(days=5))
+        with patch("app.tasks.billing_tasks.send_queued_reminder.delay"):
+            first = client.post(
+                f"/api/v1/receipts/{r.id}/send-reminder", cookies=_auth_cookie(user)
+            )
+            second = client.post(
+                f"/api/v1/receipts/{r.id}/send-reminder", cookies=_auth_cookie(user)
+            )
+        assert first.status_code == 200
+        assert second.status_code == 409
 
     def test_send_forbidden_for_member(self, client, db):
         _ensure_org_settings(db)

--- a/e2e/cypress/e2e/payment-reminders/payment-reminders.cy.ts
+++ b/e2e/cypress/e2e/payment-reminders/payment-reminders.cy.ts
@@ -49,7 +49,7 @@ describe("Payment Reminders — receipt detail (admin)", () => {
     cy.url().should("match", /\/receipts\/\d+/);
 
     cy.contains("button", "Send reminder").click();
-    cy.contains(/reminder sent/i).should("be.visible");
+    cy.contains(/reminder queued/i).should("be.visible");
 
     // The history card appears with at least one reminder row.
     cy.get('[data-cy="reminder-history"]').should("be.visible");

--- a/frontend/app/[locale]/(portal)/receipts/[id]/page.tsx
+++ b/frontend/app/[locale]/(portal)/receipts/[id]/page.tsx
@@ -185,7 +185,11 @@ export default function ReceiptDetailPage() {
   const canCancel = canWrite && !isCreditNote && !["paid", "cancelled"].includes(receipt.status);
   const canReemit = canWrite && receipt.status === "returned";
   const canRemind = canWrite && !isCreditNote && ["emitted", "overdue"].includes(receipt.status);
-  const sentReminderCount = (reminders ?? []).filter((r) => r.status === "sent").length;
+  // Queued ones count too: the worker sends them after the click, and a second
+  // click meanwhile must not slip past the cap.
+  const sentReminderCount = (reminders ?? []).filter(
+    (r) => r.status === "sent" || r.status === "queued"
+  ).length;
   const maxReminders = Number(settings?.features?.reminder_max_count ?? 3);
   const remindersExhausted = sentReminderCount >= maxReminders;
 

--- a/frontend/locales/ca/reminders.json
+++ b/frontend/locales/ca/reminders.json
@@ -1,7 +1,7 @@
 {
   "reminders": {
     "sendReminder": "Enviar recordatori",
-    "sentToast": "Recordatori enviat",
+    "sentToast": "Recordatori a la cua d'enviament",
     "maxReached": "Ja s'ha enviat el nombre màxim de recordatoris",
     "historyTitle": "Recordatoris de pagament",
     "number": "Núm.",
@@ -10,6 +10,7 @@
     "statusLabel": "Estat",
     "none": "Encara no s'ha enviat cap recordatori",
     "status": {
+      "queued": "A la cua",
       "sent": "Enviat",
       "failed": "Fallit",
       "skipped": "Omès"

--- a/frontend/locales/en/reminders.json
+++ b/frontend/locales/en/reminders.json
@@ -1,7 +1,7 @@
 {
   "reminders": {
     "sendReminder": "Send reminder",
-    "sentToast": "Reminder sent",
+    "sentToast": "Reminder queued for sending",
     "maxReached": "Maximum number of reminders already sent",
     "historyTitle": "Payment reminders",
     "number": "#",
@@ -10,6 +10,7 @@
     "statusLabel": "Status",
     "none": "No reminders sent yet",
     "status": {
+      "queued": "Queued",
       "sent": "Sent",
       "failed": "Failed",
       "skipped": "Skipped"

--- a/frontend/locales/es/reminders.json
+++ b/frontend/locales/es/reminders.json
@@ -1,7 +1,7 @@
 {
   "reminders": {
     "sendReminder": "Enviar recordatorio",
-    "sentToast": "Recordatorio enviado",
+    "sentToast": "Recordatorio en cola de envío",
     "maxReached": "Ya se ha enviado el número máximo de recordatorios",
     "historyTitle": "Recordatorios de pago",
     "number": "Nº",
@@ -10,6 +10,7 @@
     "statusLabel": "Estado",
     "none": "Aún no se ha enviado ningún recordatorio",
     "status": {
+      "queued": "En cola",
       "sent": "Enviado",
       "failed": "Fallido",
       "skipped": "Omitido"


### PR DESCRIPTION
The admin's "send reminder" button rendered and sent the email inside the request, so the admin waited on SMTP and a slow or failing mail server turned the click into a timeout. The scheduled pass already ran in the Celery worker; only the manual path was synchronous.

queue_reminder writes the ReceiptReminder row as `queued`, resolves the email payload while the receipt is loaded, and hands the send to send_queued_reminder once the request commits. The task delivers and records `sent` or `failed` (with the error) on the same row, exactly as the synchronous path did. Queued rows count towards the reminder number and the cap, so a second click before the worker runs cannot slip past it. send_reminder stays for the scheduled pass, which is already in the worker. The history shows the queued state and the toast says so.

Closes #114

Assisted-by: Claude Code