### PR TITLE
Store recovery tokens as digests and compare them in constant time

### DIFF
--- a/backend/app/domains/auth/service.py
+++ b/backend/app/domains/auth/service.py
@@ -1,5 +1,7 @@
 """Authentication service — business logic for auth operations."""
 
+import hashlib
+import hmac
 import secrets
 from datetime import datetime, timedelta, timezone
 
@@ -49,9 +51,38 @@ def authenticate_user(db: Session, email: str, password: str) -> User | None:
     return user
 
 
+def token_digest(token: str) -> str:
+    """What the users table holds in place of a recovery token.
+
+    The verification and reset tokens are single-factor account recovery, so
+    the row stores a SHA-256 of the token rather than the token itself: a read
+    of the table (a backup, a log, a stray SELECT) yields nothing usable, and
+    the lookup below compares digests — an attacker who could time the SQL
+    equality would be timing a hash they cannot invert, not the secret.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _find_by_token(db: Session, column, token: str) -> User | None:
+    """Look an active user up by a recovery token, comparing in constant time.
+
+    The digest narrows the query; ``compare_digest`` over the stored value is
+    the check that decides, so no byte of the comparison leaks through timing
+    even if the database lookup were to.
+    """
+    digest = token_digest(token)
+    user = db.query(User).filter(column == digest, User.is_active == True).first()
+    if user is None:
+        return None
+    stored = getattr(user, column.key) or ""
+    if not hmac.compare_digest(stored, digest):
+        return None
+    return user
+
+
 def _issue_verification_token(user: User) -> str:
     token = secrets.token_urlsafe(32)
-    user.verification_token = token
+    user.verification_token = token_digest(token)
     user.verification_token_expires_at = datetime.now(timezone.utc) + timedelta(
         hours=VERIFICATION_TOKEN_TTL_HOURS
     )
@@ -126,11 +157,7 @@ def register_user(
 
 def verify_email(db: Session, token: str) -> User | None:
     """Consume a verification token. Returns the user, or None if invalid/expired."""
-    user = (
-        db.query(User)
-        .filter(User.verification_token == token, User.is_active == True)
-        .first()
-    )
+    user = _find_by_token(db, User.verification_token, token)
     if not user:
         return None
 
@@ -191,7 +218,7 @@ def request_password_reset(db: Session, email: str) -> str | None:
         return None
 
     token = secrets.token_urlsafe(32)
-    user.reset_token = token
+    user.reset_token = token_digest(token)
     user.reset_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
     db.flush()
 
@@ -199,14 +226,7 @@ def request_password_reset(db: Session, email: str) -> str | None:
 
 
 def reset_password(db: Session, token: str, new_password: str) -> bool:
-    user = (
-        db.query(User)
-        .filter(
-            User.reset_token == token,
-            User.is_active == True,
-        )
-        .first()
-    )
+    user = _find_by_token(db, User.reset_token, token)
     if not user:
         return False
 

--- a/backend/tests/integration/api/v1/test_auth.py
+++ b/backend/tests/integration/api/v1/test_auth.py
@@ -350,6 +350,34 @@ class TestPasswordReset:
         )
         assert response.status_code == 200
 
+    def test_reset_token_is_stored_as_a_digest(self, client, db):
+        """The row never holds the token the member was mailed, and the mailed
+        token is what resets — not its digest."""
+        from app.domains.auth.service import token_digest
+
+        user = _create_test_user(db, email="digest@examplee6e3b1.com", password="oldpassword1")
+        token = client.post(
+            "/api/v1/auth/password-reset-request",
+            json={"email": "digest@examplee6e3b1.com"},
+        ).json()["reset_token"]
+
+        db.refresh(user)
+        assert user.reset_token == token_digest(token)
+        assert user.reset_token != token
+
+        # Presenting the stored digest itself must not work.
+        response = client.post(
+            "/api/v1/auth/password-reset",
+            json={"token": user.reset_token, "new_password": "newpassword1"},
+        )
+        assert response.status_code == 400
+
+        response = client.post(
+            "/api/v1/auth/password-reset",
+            json={"token": token, "new_password": "newpassword1"},
+        )
+        assert response.status_code == 200
+
     def test_password_reset_invalid_token(self, client):
         response = client.post(
             "/api/v1/auth/password-reset",
@@ -432,8 +460,10 @@ class TestPasswordReset:
         """A token already in flight when this shipped must stop working too."""
         from datetime import datetime, timedelta, timezone
 
+        from app.domains.auth.service import token_digest
+
         user = _create_test_user(db, email="owner2@examplee6e3b1.com", role="super_admin")
-        user.reset_token = "still-inside-its-hour"
+        user.reset_token = token_digest("still-inside-its-hour")
         user.reset_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         db.flush()
 

--- a/backend/tests/integration/api/v1/test_registration_flow.py
+++ b/backend/tests/integration/api/v1/test_registration_flow.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 from app.core.security.password import hash_password
 from app.domains.auth.models import User
+from app.domains.auth.service import token_digest
 from app.domains.members.models import Member, MembershipType
 from app.domains.organizations.models import OrganizationSettings
 from app.domains.persons.models import Person
@@ -139,6 +140,9 @@ class TestRegistrationCreatesPendingMember:
         user = db.query(User).filter(User.email == REGISTER_PAYLOAD["email"]).first()
         assert user.email_verified is False
         assert user.verification_token is not None
+        # Stored as a digest, never the token the member was mailed.
+        assert user.verification_token != response.json()["verification_token"]
+        assert user.verification_token == token_digest(response.json()["verification_token"])
 
     def test_register_blocked_when_public_registration_disabled(self, client, db):
         _set_features(db, public_registration=False)


### PR DESCRIPTION
verify_email and reset_password looked the user up with User.reset_token == token — a SQL equality on the secret itself, with the secret sitting in plain text in the users table. Timing recovery over a network is impractical, but these tokens are single-factor account recovery, and the row holding them turns up in backups and logs.

Issue the token as before, store its SHA-256, and look up by the digest; the row that comes back is then checked with hmac.compare_digest, so the comparison that decides never leaks a byte through timing. A stray read of the table yields nothing that can be presented, and presenting the digest itself does not work either.

Tokens issued before this ships stop matching. Reset tokens live one hour; a member with an unused verification link requests a new one.

Closes #116

Assisted-by: Claude Code