### PR TITLE
Take staff accounts out of the club's member register

### DIFF
--- a/backend/alembic/versions/e2f3a4b5c6d7_staff_accounts_leave_the_member_register.py
+++ b/backend/alembic/versions/e2f3a4b5c6d7_staff_accounts_leave_the_member_register.py
@@ -1,0 +1,85 @@
+"""Take staff accounts out of the club's member register
+
+Revision ID: e2f3a4b5c6d7
+Revises: 9c1d2e3f4a5b
+Create Date: 2026-09-12
+
+`member` used to be pinned to every account, so a super admin or club admin
+carried a member number, a membership type and a place in every member count,
+export and billing run. It is opt-in now (#168), and staff accounts are seeded
+without it — this brings the accounts an existing install already has into
+line: the member record goes, and with it the `member` role assignment.
+
+A member row is left alone when a receipt or a SEPA mandate points at it.
+Those two are the references that would make the delete fail outright, and an
+account with billing history behind it is one a person should look at rather
+than one a migration should quietly rewrite. Bookings, registrations and
+announcement recipients cascade with the row.
+
+The role assignment is removed only for an account whose member row actually
+went, so the pair stays consistent either way, and only where a staff role
+remains, so no account is left holding nothing.
+"""
+
+from alembic import op
+
+revision = "e2f3a4b5c6d7"
+down_revision = "9c1d2e3f4a5b"
+branch_labels = None
+depends_on = None
+
+STAFF_SLUGS = "('super_admin', 'admin')"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        DELETE FROM members m
+        USING users u, user_roles ur, roles r
+        WHERE m.user_id = u.id
+          AND ur.user_id = u.id
+          AND ur.role_id = r.id
+          AND r.slug IN {STAFF_SLUGS}
+          AND NOT EXISTS (SELECT 1 FROM receipts x WHERE x.member_id = m.id)
+          AND NOT EXISTS (SELECT 1 FROM sepa_mandates x WHERE x.member_id = m.id)
+        """
+    )
+
+    op.execute(
+        f"""
+        DELETE FROM user_roles ur
+        USING roles r
+        WHERE ur.role_id = r.id
+          AND r.slug = 'member'
+          AND EXISTS (
+              SELECT 1 FROM user_roles s
+              JOIN roles sr ON sr.id = s.role_id
+              WHERE s.user_id = ur.user_id AND sr.slug IN {STAFF_SLUGS}
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM members m WHERE m.user_id = ur.user_id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # The member rows cannot come back — their numbers were released and the
+    # rows that cascaded with them are gone. Restoring the role assignment is
+    # the half that is reversible, and it is what the old code would have
+    # re-added on the next write anyway.
+    op.execute(
+        f"""
+        INSERT INTO user_roles (user_id, role_id)
+        SELECT DISTINCT s.user_id, r.id
+        FROM user_roles s
+        JOIN roles sr ON sr.id = s.role_id
+        CROSS JOIN roles r
+        WHERE sr.slug IN {STAFF_SLUGS}
+          AND r.slug = 'member'
+          AND NOT EXISTS (
+              SELECT 1 FROM user_roles e
+              WHERE e.user_id = s.user_id AND e.role_id = r.id
+          )
+        """
+    )

--- a/backend/app/api/v1/endpoints/bookings.py
+++ b/backend/app/api/v1/endpoints/bookings.py
@@ -9,9 +9,10 @@ per-space week calendar and manage their own reservations.
 from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from app.core.authorization import require_permission, user_has
+from app.core.db_utils import current_member_or_403
 from app.core.pagination import paginate
 from app.core.security.dependencies import get_current_user
 from app.db.session import get_db
@@ -33,7 +34,6 @@ from app.domains.bookings.schemas import (
     SpaceUpdate,
     WeekAvailability,
 )
-from app.domains.members.models import Member
 from app.domains.organizations.models import OrganizationSettings
 
 router = APIRouter(prefix="/spaces", tags=["bookings"])
@@ -47,18 +47,6 @@ def _require_bookings_enabled(db: Session) -> None:
     features = (org.features or {}) if org else {}
     if not features.get("bookings"):
         raise HTTPException(status_code=404, detail="Not found")
-
-
-def _current_member(db: Session, user: User) -> Member:
-    member = (
-        db.query(Member)
-        .options(joinedload(Member.person))
-        .filter(Member.user_id == user.id)
-        .first()
-    )
-    if member is None:
-        raise HTTPException(status_code=403, detail="No member profile")
-    return member
 
 
 def _load_space_or_404(db: Session, space_id: int) -> "service.Space":
@@ -327,7 +315,7 @@ def get_availability(
     space = service.get_space(db, space_id)
     if space is None or not space.is_active:
         raise HTTPException(status_code=404, detail="Space not found")
-    member = _current_member(db, current_user)
+    member = current_member_or_403(db, current_user)
     cells = service.space_week_availability(db, space, week_start, member.id)
     eligibility = check_space_eligibility(space, member)
     return WeekAvailability(
@@ -348,7 +336,7 @@ def create_booking(
     current_user: User = Depends(require_permission("self.bookings.write")),
 ):
     _require_bookings_enabled(db)
-    member = _current_member(db, current_user)
+    member = current_member_or_403(db, current_user)
     try:
         booking = service.create_booking(
             db,
@@ -386,7 +374,7 @@ def get_my_bookings(
     current_user: User = Depends(require_permission("self.bookings.read")),
 ):
     _require_bookings_enabled(db)
-    member = _current_member(db, current_user)
+    member = current_member_or_403(db, current_user)
     scope = scope if scope in ("upcoming", "past") else "upcoming"
     return service.my_bookings(db, member.id, scope=scope)
 
@@ -406,7 +394,7 @@ def cancel_booking(
 
     is_admin = user_has(current_user, "bookings.write")
     if not is_admin:
-        member = _current_member(db, current_user)
+        member = current_member_or_403(db, current_user)
         if booking.member_id != member.id:
             raise HTTPException(status_code=403, detail="Not your booking")
 

--- a/backend/app/api/v1/endpoints/member_card.py
+++ b/backend/app/api/v1/endpoints/member_card.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session, joinedload
 
 from app.core.authorization import require_permission
+from app.core.db_utils import current_member_or_403
 from app.core.security.dependencies import get_current_user
 from app.db.session import get_db
 from app.domains.auth.models import User
@@ -40,18 +41,6 @@ def _require_card_enabled(db: Session) -> None:
     features = (org.features or {}) if org else {}
     if not features.get("member_card"):
         raise HTTPException(status_code=404, detail="Not found")
-
-
-def _current_member(db: Session, user: User) -> Member:
-    member = (
-        db.query(Member)
-        .options(joinedload(Member.person))
-        .filter(Member.user_id == user.id)
-        .first()
-    )
-    if member is None:
-        raise HTTPException(status_code=403, detail="No member profile")
-    return member
 
 
 def _load_member_or_404(db: Session, member_id: int) -> Member:
@@ -90,7 +79,7 @@ def get_my_card(
     current_user: User = Depends(require_permission("self.card.read")),
 ):
     _require_card_enabled(db)
-    member = _current_member(db, current_user)
+    member = current_member_or_403(db, current_user)
     return build_card(db, member)
 
 
@@ -100,7 +89,7 @@ def get_my_card_qr(
     current_user: User = Depends(require_permission("self.card.read")),
 ):
     _require_card_enabled(db)
-    member = _current_member(db, current_user)
+    member = current_member_or_403(db, current_user)
     return _qr_response(member)
 
 
@@ -110,7 +99,7 @@ def get_my_card_pdf(
     current_user: User = Depends(require_permission("self.card.read")),
 ):
     _require_card_enabled(db)
-    member = _current_member(db, current_user)
+    member = current_member_or_403(db, current_user)
     return _pdf_response(db, member)
 
 

--- a/backend/app/api/v1/endpoints/membership_purchase.py
+++ b/backend/app/api/v1/endpoints/membership_purchase.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.core.authorization import require_permission
+from app.core.db_utils import current_member_or_403
 from app.db.session import get_db
 from app.domains.auth.models import User
 from app.domains.billing.membership_purchase_service import (
@@ -28,26 +29,9 @@ from app.domains.billing.schemas import (
     MembershipPurchaseRequest,
     MembershipPurchaseResponse,
 )
-from app.domains.members.models import Member, MembershipType
+from app.domains.members.models import MembershipType
 
 router = APIRouter(prefix="/members/me/membership", tags=["members"])
-
-
-def _own_member(db: Session, user: User) -> Member:
-    """The caller's own member record, resolved through the foreign key.
-
-    Never through ``Person.email``: that column is non-unique and a minor
-    routinely shares a guardian's address, so an email match can return somebody
-    else's member row — and this endpoint would then bill them.
-    """
-    member = (
-        db.query(Member)
-        .filter(Member.user_id == user.id, Member.is_active.is_(True))
-        .first()
-    )
-    if not member:
-        raise HTTPException(status_code=404, detail="Member not found")
-    return member
 
 
 def _membership_type(db: Session, membership_type_id: int) -> MembershipType:
@@ -92,7 +76,7 @@ def quote_membership(
     cannot be quoted either and the portal never offers a price it would then
     reject.
     """
-    member = _own_member(db, current_user)
+    member = current_member_or_403(db, current_user, active_only=True)
     mtype = _membership_type(db, membership_type_id)
     quote = quote_membership_purchase(db, member, mtype)
     return MembershipPurchaseQuote(**_quote_fields(quote))
@@ -115,7 +99,7 @@ def purchase_membership_endpoint(
     later. Any purchase still awaiting payment is voided by this one, so a
     member who picked the wrong plan can simply pick again.
     """
-    member = _own_member(db, current_user)
+    member = current_member_or_403(db, current_user, active_only=True)
     mtype = _membership_type(db, data.membership_type_id)
 
     receipt, quote = purchase_membership(

--- a/backend/app/api/v1/endpoints/receipts.py
+++ b/backend/app/api/v1/endpoints/receipts.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.core.authorization import require_permission, user_has
 from app.core.csv_export import stream_csv
+from app.core.db_utils import current_member_or_403
 from app.core.pagination import paginate
 from app.core.security.dependencies import get_current_user
 from app.db.session import get_db
@@ -589,9 +590,7 @@ def list_my_receipts(
     current_user: User = Depends(require_permission("self.billing.read")),
 ):
     """List current user's receipts (member self-service)."""
-    member = _own_member(db, current_user)
-    if not member:
-        raise HTTPException(status_code=404, detail="Member not found")
+    member = current_member_or_403(db, current_user, active_only=True)
 
     query = (
         db.query(Receipt)

--- a/backend/app/api/v1/endpoints/registrations.py
+++ b/backend/app/api/v1/endpoints/registrations.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.core.authorization import require_permission, user_has
 from app.core.csv_export import stream_csv
+from app.core.db_utils import current_member_or_403
 from app.core.pagination import paginate
 from app.core.security.dependencies import get_current_user
 from app.db.session import get_db
@@ -41,13 +42,6 @@ def _get_activity_or_404(db: Session, activity_id: int) -> Activity:
     if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
     return activity
-
-
-def _get_member_for_user(db: Session, user: User) -> Member:
-    member = db.query(Member).filter(Member.user_id == user.id).first()
-    if not member:
-        raise HTTPException(status_code=400, detail="No member profile found")
-    return member
 
 
 def _to_detail_response(registration: Registration) -> RegistrationDetailResponse:
@@ -186,7 +180,7 @@ def register_for_activity(
 ):
     """Register current user's member for an activity."""
     activity = _get_activity_or_404(db, activity_id)
-    member = _get_member_for_user(db, current_user)
+    member = current_member_or_403(db, current_user)
 
     try:
         registration = register_member(
@@ -218,7 +212,7 @@ def check_activity_eligibility(
 ):
     """Check if current user is eligible to register."""
     activity = _get_activity_or_404(db, activity_id)
-    member = _get_member_for_user(db, current_user)
+    member = current_member_or_403(db, current_user)
 
     result = check_eligibility(db, activity, member)
     return EligibilityResponse(eligible=result.eligible, reasons=result.reasons)
@@ -258,7 +252,7 @@ def cancel_own_registration(
 
     # Check ownership if not admin
     if not is_admin:
-        member = _get_member_for_user(db, current_user)
+        member = current_member_or_403(db, current_user)
         if registration.member_id != member.id:
             raise HTTPException(status_code=403, detail="Cannot cancel another member's registration")
 
@@ -323,7 +317,7 @@ def list_my_registrations(
     current_user: User = Depends(require_permission("self.registrations.read")),
 ):
     """List current user's registrations."""
-    member = _get_member_for_user(db, current_user)
+    member = current_member_or_403(db, current_user)
 
     query = (
         db.query(Registration)

--- a/backend/app/cli/seed.py
+++ b/backend/app/cli/seed.py
@@ -37,7 +37,7 @@ from sqlalchemy import text
 
 from app.cli.reset import preview_club_data, reset_club_data
 from app.core.config import settings as app_settings
-from app.core.permissions import ADMIN_SLUG, SUPER_ADMIN_SLUG
+from app.core.permissions import ADMIN_SLUG, MEMBER_SLUG, SUPER_ADMIN_SLUG
 from app.db.session import SessionLocal
 from app.domains.audit.models import AuditLog
 from app.domains.organizations.models import OrganizationSettings
@@ -454,7 +454,7 @@ def create_user_with_member(
     db.add(user)
     db.flush()
 
-    assign_roles(db, user, role)
+    assign_roles(db, user, role, MEMBER_SLUG)
 
     member_number = next_member_number(db)
     member = Member(
@@ -761,12 +761,11 @@ def seed_extra_members(db, default_membership_type: MembershipType) -> list[Memb
         db.add(user)
         db.flush()
 
-        # Every account holds `member` permanently — permissions come from
-        # user_roles, so without this the account authenticates and then gets
-        # 403 on its own portal. Missed when roles & permissions replaced the
-        # users.role column: the migration backfilled existing rows, but this
-        # seeding path kept creating users with no assignment at all.
-        assign_roles(db, user)
+        # Permissions come from user_roles, so without this the account
+        # authenticates and then gets 403 on its own portal. These are members,
+        # so `member` is named explicitly — it is no longer a floor every
+        # account gets (#168).
+        assign_roles(db, user, MEMBER_SLUG)
 
         member_number = next_member_number(db)
         status = statuses[i % len(statuses)]
@@ -1759,7 +1758,7 @@ def attach_login(db, member: Member, password: str) -> str:
     )
     db.add(user)
     db.flush()
-    assign_roles(db, user, "member")
+    assign_roles(db, user, MEMBER_SLUG)
     member.user_id = user.id
     db.flush()
     return person.email

--- a/backend/app/cli/seed.py
+++ b/backend/app/cli/seed.py
@@ -420,22 +420,26 @@ def next_member_number(db) -> str:
     return f"M-{max(numbers) + 1 if numbers else 1:04d}"
 
 
-def create_user_with_member(
-    db, details: dict, role: str, membership_type: MembershipType
-) -> None:
-    existing = db.query(User).filter_by(email=details["email"]).first()
-    if existing:
-        # These accounts and their passwords are a contract with the Cypress
-        # suite, so this has to converge on the known state rather than merely
-        # leave the row alone. Skipping meant that once the password had been
-        # changed — by `dev.sh passwd`, or by hand — reseeding never put it back
-        # and the suite failed on a login it had no reason to doubt. Development
-        # and CI only: the caller already refuses to run anywhere else.
-        existing.password_hash = ph.hash(details["password"])
-        db.flush()
-        print(f"  {role} user: exists, password set to the fixed test one")
-        return
+def _converge_existing(db, details: dict, role: str) -> bool:
+    """True when the account already exists and only its password was reset.
 
+    These accounts and their passwords are a contract with the Cypress suite,
+    so seeding has to converge on the known state rather than merely leave the
+    row alone. Skipping meant that once the password had been changed — by
+    `dev.sh passwd`, or by hand — reseeding never put it back and the suite
+    failed on a login it had no reason to doubt. Development and CI only: the
+    caller already refuses to run anywhere else.
+    """
+    existing = db.query(User).filter_by(email=details["email"]).first()
+    if not existing:
+        return False
+    existing.password_hash = ph.hash(details["password"])
+    db.flush()
+    print(f"  {role} user: exists, password set to the fixed test one")
+    return True
+
+
+def _create_account(db, details: dict, *slugs: str) -> User:
     person = Person(
         first_name=details["first_name"],
         last_name=details["last_name"],
@@ -454,11 +458,41 @@ def create_user_with_member(
     db.add(user)
     db.flush()
 
-    assign_roles(db, user, role, MEMBER_SLUG)
+    assign_roles(db, user, *slugs)
+    # Not left to the caller's next flush: `reset_club_data` decides what to
+    # keep by reading `user_roles`, so an assignment still pending there is an
+    # operator account that does not look like one yet.
+    db.flush()
+    return user
+
+
+def create_staff_user(db, details: dict, role: str) -> None:
+    """An account that administers the instance, and nothing more.
+
+    No member record, no member number, no membership type: an operator is not
+    a member of the club (#168). Where the same human is genuinely both, that
+    is a second account with a second address — `users.email` is UNIQUE, so it
+    is forced anyway — and no feature links the two.
+    """
+    if _converge_existing(db, details, role):
+        return
+
+    _create_account(db, details, role)
+    print(f"  {role} user: created ({details['email']}, not a club member)")
+
+
+def create_user_with_member(
+    db, details: dict, role: str, membership_type: MembershipType
+) -> None:
+    """An account that belongs to a person in the club's member register."""
+    if _converge_existing(db, details, role):
+        return
+
+    user = _create_account(db, details, role, MEMBER_SLUG)
 
     member_number = next_member_number(db)
     member = Member(
-        person_id=person.id,
+        person_id=user.person_id,
         user_id=user.id,
         membership_type_id=membership_type.id,
         member_number=member_number,
@@ -1698,14 +1732,20 @@ def super_admin_users(db) -> list[User]:
 
 
 def restore_member_records(db, users: list[User], membership_type: MembershipType) -> None:
-    """Give the surviving super admins a member record again after a reset.
+    """Give back a member record to a survivor of a reset that still holds `member`.
 
-    `members` is club data and goes with the rest of it, but every account the
-    setup creates has one — see `create_user_with_member`. Without this a super
-    admin comes out of a reset with a person record and no membership, which is
-    a shape nothing else in the app produces.
+    `members` is club data and goes with the rest of it. A super admin created
+    by the setup is not in it at all any more (#168), so for those this does
+    nothing — a person record and no membership is now the intended shape, not
+    the anomaly this function was written to prevent.
+
+    What it still covers is the account that was promoted rather than created:
+    a member who was granted `super_admin` keeps both roles, and a reset would
+    otherwise leave them holding `member` with no row to back it.
     """
     for user in users:
+        if not any(r.slug == MEMBER_SLUG for r in user.roles):
+            continue
         if db.query(Member).filter_by(person_id=user.person_id).first():
             continue
         db.add(
@@ -1779,7 +1819,7 @@ def create_demo_accounts(db, membership_type: MembershipType) -> list[tuple[str,
         set_password(db, existing, admin_password)
         print(f"  club admin: password reset ({DEMO_CLUB_ADMIN_EMAIL})")
     else:
-        create_user_with_member(
+        create_staff_user(
             db,
             {
                 "first_name": "Club",
@@ -1788,7 +1828,6 @@ def create_demo_accounts(db, membership_type: MembershipType) -> list[tuple[str,
                 "password": admin_password,
             },
             ADMIN_SLUG,
-            membership_type,
         )
     accounts.append(("club admin", DEMO_CLUB_ADMIN_EMAIL, admin_password))
 
@@ -1821,7 +1860,14 @@ def run_test_mode(db, membership_type: MembershipType) -> None:
 
     print("\nCreating test accounts...")
     for account in TEST_ACCOUNTS:
-        create_user_with_member(db, account, account["role"], membership_type)
+        # `super_admin` and `admin` administer the instance and are not in the
+        # member register (#168). `treasurer` is a custom club-officer role held
+        # by an actual member — its own `self.*` keys come from `member` and
+        # nowhere else, so taking that away would lock it out of its profile.
+        if account["role"] in (SUPER_ADMIN_SLUG, ADMIN_SLUG):
+            create_staff_user(db, account, account["role"])
+        else:
+            create_user_with_member(db, account, account["role"], membership_type)
 
     admin_id = any_admin_user_id(db)
     if admin_id:
@@ -2003,7 +2049,7 @@ def _run_interactive(db, membership_type: MembershipType) -> list[tuple[str, str
     accounts: list[tuple[str, str, str]] = []
     if super_details:
         print("\nCreating super admin...")
-        create_user_with_member(db, super_details, SUPER_ADMIN_SLUG, membership_type)
+        create_staff_user(db, super_details, SUPER_ADMIN_SLUG)
         accounts.append(("super admin", super_details["email"], "(the password you chose)"))
     elif reset_target is not None:
         set_password(db, reset_target, reset_password)
@@ -2069,7 +2115,7 @@ def _run_unattended(db, membership_type: MembershipType, args) -> list[tuple[str
             print(f"\n  super admin: password reset ({args.admin_email})")
         else:
             print("\nCreating super admin...")
-            create_user_with_member(
+            create_staff_user(
                 db,
                 {
                     "first_name": "Super",
@@ -2078,7 +2124,6 @@ def _run_unattended(db, membership_type: MembershipType, args) -> list[tuple[str
                     "password": password,
                 },
                 SUPER_ADMIN_SLUG,
-                membership_type,
             )
         accounts.append(("super admin", args.admin_email, "(from MEMSHIP_ADMIN_PASSWORD)"))
 

--- a/backend/app/core/db_utils.py
+++ b/backend/app/core/db_utils.py
@@ -1,7 +1,7 @@
 """Database utility helpers."""
 
 from fastapi import HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.db.base import Base
 
@@ -14,3 +14,46 @@ def get_or_404(db: Session, model: type[Base], id: int, detail: str | None = Non
             detail=detail or f"{model.__name__} not found",
         )
     return instance
+
+
+def current_member_or_403(db: Session, user, *, active_only: bool = False):
+    """The caller's own member record, or one refusal that says why there isn't one.
+
+    An account can be signed in, hold every ``self.*`` permission, and still have
+    no member record: a super admin or club admin administers the instance
+    without belonging to the club (#168). The ``self.*`` keys are the floor on
+    the endpoints staff and members share — `members.py:152` and
+    `receipts.py:312` widen from them rather than branch on them — so they are
+    not what tells the two apart. The member record is.
+
+    403 rather than 404: the request is well formed and the caller is known,
+    what is missing is a membership. The ``code`` is what lets a caller say that
+    instead of rendering a generic failure, the same way ``pending_approval``
+    does in `security/dependencies.py`.
+
+    ``active_only`` keeps the distinction the call sites already make: billing
+    routes resolve only a live membership, while the card and the booking
+    routes answer for a cancelled member too.
+
+    Resolved through ``Member.user_id``, never through ``Person.email``: that
+    column is non-unique and a minor routinely shares a guardian's address, so
+    an email match can return somebody else's member row.
+    """
+    from app.domains.members.models import Member
+
+    query = db.query(Member).options(joinedload(Member.person)).filter(
+        Member.user_id == user.id
+    )
+    if active_only:
+        query = query.filter(Member.is_active.is_(True))
+
+    member = query.first()
+    if member is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "not_a_member",
+                "message": "This account has no member record",
+            },
+        )
+    return member

--- a/backend/app/domains/auth/oauth_service.py
+++ b/backend/app/domains/auth/oauth_service.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
+from app.core.permissions import MEMBER_SLUG
 from app.domains.auth.models import User, UserIdentity
 from app.domains.auth.roles import assign_roles
 from app.domains.auth.service import get_registration_settings
@@ -107,7 +108,8 @@ def find_or_create_from_oauth(db: Session, profile: OAuthProfile) -> tuple[User,
     db.add(user)
     db.flush()
 
-    assign_roles(db, user)
+    # Sign-up through a provider is still a member signing up (#168).
+    assign_roles(db, user, MEMBER_SLUG)
 
     default_type = get_default_membership_type(db)
     member = Member(

--- a/backend/app/domains/auth/roles.py
+++ b/backend/app/domains/auth/roles.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm import Session
 from app.core.authorization import resolve_permissions
 from app.core.permissions import (
     ALL_KEYS,
-    MEMBER_SLUG,
     RESERVED_KEYS,
     SUPER_ADMIN_SLUG,
 )
@@ -62,9 +61,14 @@ class LastSuperAdmin(RoleError):
 
 
 def assign_roles(db: Session, user: User, *extra_slugs: str) -> None:
-    """Attach ``member`` — which every account holds permanently — plus any
-    staff role named by slug."""
-    slugs = {MEMBER_SLUG, *extra_slugs}
+    """Attach the roles named by slug, and only those.
+
+    ``member`` is one of them, not a floor: an account that administers the
+    instance is not thereby a member of the club (#168), so the caller that
+    means "this is a member" says so. Passing no slug at all leaves the account
+    with no roles and so no permissions — callers are expected to name one.
+    """
+    slugs = set(extra_slugs)
     roles = db.query(Role).filter(Role.slug.in_(slugs)).all()
 
     already = {a.role_id for a in user.role_assignments}
@@ -230,8 +234,7 @@ def replace_user_roles(db: Session, user: User, role_ids: list[int], *, caller: 
     if losing_super and _super_admin_count(db) <= 1:
         raise LastSuperAdmin()
 
-    member_role = db.query(Role).filter(Role.slug == MEMBER_SLUG).one()
-    keep = {r.id for r in roles} | {member_role.id}
+    keep = {r.id for r in roles}
 
     before = {r.slug: r.id for r in user.roles}
     by_id = {r.id: r for r in db.query(Role).filter(Role.id.in_(keep)).all()}

--- a/backend/app/domains/auth/service.py
+++ b/backend/app/domains/auth/service.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
-from app.core.permissions import SUPER_ADMIN_SLUG
+from app.core.permissions import MEMBER_SLUG, SUPER_ADMIN_SLUG
 from app.core.security.password import hash_password, verify_password
 from app.domains.auth.models import User
 from app.domains.auth.roles import assign_roles
@@ -128,7 +128,9 @@ def register_user(
     db.add(user)
     db.flush()
 
-    assign_roles(db, user)
+    # Someone signing themselves up is a member; staff accounts are made
+    # elsewhere and do not get this role (#168).
+    assign_roles(db, user, MEMBER_SLUG)
 
     default_type = get_default_membership_type(db)
 

--- a/backend/tests/integration/api/v1/test_admin_without_member.py
+++ b/backend/tests/integration/api/v1/test_admin_without_member.py
@@ -1,0 +1,258 @@
+"""What an account with no member record can and cannot reach.
+
+A super admin or club admin administers the instance without belonging to the
+club (#168), so it has no member row. That shape used to be impossible, and two
+things follow from it that pull in opposite directions:
+
+* every member-facing route has to refuse it cleanly rather than query a member
+  that is not there;
+* every route it shares with members has to keep working, because `self.*` is
+  the *floor* on those — `members.py:152` and `receipts.py:312` admit the caller
+  on `self.profile.read` / `self.billing.read` and then widen to "any member" on
+  `members.read` / `billing.read`. A staff role holds the `self.*` keys
+  (`ADMIN_SEED_KEYS` is the whole catalogue bar the reserved ones, and a super
+  admin resolves to `ALL_KEYS`), so they are not what distinguishes the two.
+
+The second half is the one worth guarding: taking `self.*` away from staff looks
+like the tidy fix for the first half and would lock every admin out of the
+member register, the receipt PDFs and the photo routes.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.core.security.jwt import create_access_token
+from app.core.security.password import hash_password
+from app.domains.auth.models import User
+from app.domains.billing.models import Receipt
+from app.domains.members.models import Member, MembershipType
+from app.domains.organizations.models import OrganizationSettings
+from app.domains.persons.models import Person
+
+
+def _cookie(user):
+    return {"access_token": create_access_token(user.id)}
+
+
+@pytest.fixture
+def org(db):
+    settings = db.query(OrganizationSettings).filter_by(id=1).first()
+    if not settings:
+        settings = OrganizationSettings(
+            id=1, name="Test Club", locale="es", timezone="Europe/Madrid",
+            currency="EUR", date_format="DD/MM/YYYY", brand_color="#0083ad",
+        )
+        db.add(settings)
+    # The card routes 404 when the feature is off, which would make the
+    # refusal test pass for entirely the wrong reason.
+    settings.features = {"member_card": True}
+    db.flush()
+    return settings
+
+
+@pytest.fixture
+def membership_type(db):
+    mt = MembershipType(
+        name="No Member Standard", slug="no-member-standard",
+        base_price=90, billing_frequency="annual",
+    )
+    db.add(mt)
+    db.flush()
+    return mt
+
+
+@pytest.fixture
+def operator(db):
+    """A super admin the way the seed now creates one: no member record."""
+    person = Person(first_name="Ops", last_name="Only", email="ops@examplee6e3b1.com")
+    db.add(person)
+    db.flush()
+    user = User(
+        person_id=person.id, email="ops@examplee6e3b1.com",
+        password_hash=hash_password("password123"), role="super_admin", is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture
+def club_admin(db):
+    person = Person(first_name="Club", last_name="Admin", email="ca@examplee6e3b1.com")
+    db.add(person)
+    db.flush()
+    user = User(
+        person_id=person.id, email="ca@examplee6e3b1.com",
+        password_hash=hash_password("password123"), role="admin", is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture
+def joiner(db, membership_type):
+    """An ordinary member, with a receipt, for the staff routes to act on."""
+    person = Person(first_name="Real", last_name="Member", email="joiner@examplee6e3b1.com")
+    db.add(person)
+    db.flush()
+    user = User(
+        person_id=person.id, email="joiner@examplee6e3b1.com",
+        password_hash=hash_password("password123"), role="member", is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    member = Member(
+        person_id=person.id, user_id=user.id,
+        membership_type_id=membership_type.id, member_number="M-0001",
+        status="active",
+    )
+    db.add(member)
+    db.flush()
+    receipt = Receipt(
+        receipt_number="R-9001", member_id=member.id, origin="membership",
+        description="Annual fee", base_amount=Decimal("90.00"),
+        vat_rate=Decimal("0.00"), vat_amount=Decimal("0.00"),
+        total_amount=Decimal("90.00"), status="emitted",
+        emission_date=date(2026, 1, 10),
+    )
+    db.add(receipt)
+    db.flush()
+    return user, member, receipt
+
+
+class TestTheSessionItself:
+    def test_me_returns_the_account_with_null_member_fields(self, client, db, operator):
+        r = client.get("/api/v1/auth/me", cookies=_cookie(operator))
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["member_id"] is None
+        assert body["member_number"] is None
+        assert body["member_status"] is None
+
+    def test_it_still_holds_the_self_namespace(self, client, db, operator):
+        """Not a quirk to clean up later — see the module docstring. This is
+        what admits staff to the routes they share with members."""
+        body = client.get("/api/v1/auth/me", cookies=_cookie(operator)).json()
+
+        assert {"self.profile.read", "self.billing.read"} <= set(body["permissions"])
+
+    def test_the_roles_say_operator_not_member(self, client, db, operator):
+        body = client.get("/api/v1/auth/me", cookies=_cookie(operator)).json()
+
+        assert {r["slug"] for r in body["roles"]} == {"super_admin"}
+
+
+class TestMemberFacingRoutesRefuseIt:
+    """One refusal, one code, so a caller can tell this from a real failure."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/v1/members/me/receipts",
+            "/api/v1/members/me/membership/quote/{membership_type_id}",
+            "/api/v1/me/card",
+        ],
+    )
+    def test_they_answer_403_not_a_member(
+        self, client, db, org, operator, membership_type, path
+    ):
+        r = client.get(
+            path.format(membership_type_id=membership_type.id),
+            cookies=_cookie(operator),
+        )
+
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "not_a_member"
+
+    def test_none_of_them_raise(self, client, db, org, operator, membership_type):
+        """The failure this guards is a 500 from querying a member that is not
+        there, which is what the old code would have done."""
+        for path in (
+            "/api/v1/members/me/receipts",
+            f"/api/v1/members/me/membership/quote/{membership_type.id}",
+            "/api/v1/me/card",
+            "/api/v1/me/card/qr.svg",
+        ):
+            r = client.get(path, cookies=_cookie(operator))
+            assert r.status_code < 500, f"{path} returned {r.status_code}"
+
+    def test_a_club_admin_is_refused_the_same_way(self, client, db, org, club_admin):
+        r = client.get("/api/v1/members/me/receipts", cookies=_cookie(club_admin))
+
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "not_a_member"
+
+
+class TestStaffRoutesKeepWorking:
+    """The regression the obvious fix would cause.
+
+    Every one of these is gated on a `self.*` key and widened by an
+    administrative one, so they break the moment `self.*` stops being granted to
+    staff — with a 403 from the dependency, before the handler runs.
+    """
+
+    def test_it_can_read_a_member(self, client, db, org, operator, joiner):
+        _, member, _ = joiner
+
+        r = client.get(f"/api/v1/members/{member.id}", cookies=_cookie(operator))
+
+        assert r.status_code == 200
+        assert r.json()["member_number"] == "M-0001"
+
+    def test_it_can_list_the_register(self, client, db, org, operator, joiner):
+        r = client.get("/api/v1/members/", cookies=_cookie(operator))
+
+        assert r.status_code == 200
+
+    def test_it_can_download_a_receipt_pdf(self, client, db, org, operator, joiner):
+        _, _, receipt = joiner
+
+        r = client.get(f"/api/v1/receipts/{receipt.id}/pdf", cookies=_cookie(operator))
+
+        assert r.status_code == 200
+
+    def test_a_club_admin_can_read_a_member_too(self, client, db, org, club_admin, joiner):
+        _, member, _ = joiner
+
+        r = client.get(f"/api/v1/members/{member.id}", cookies=_cookie(club_admin))
+
+        assert r.status_code == 200
+
+
+class TestItIsOutsideTheClub:
+    def test_the_register_does_not_list_it(self, client, db, org, operator, joiner):
+        body = client.get("/api/v1/members/", cookies=_cookie(operator)).json()
+
+        emails = {row["email"] for row in body["items"] if row.get("email")}
+        assert "ops@examplee6e3b1.com" not in emails
+
+    def test_the_count_excludes_it(self, db, org, operator, club_admin, joiner):
+        assert db.query(Member).count() == 1
+
+    def test_a_billing_run_raises_nothing_for_it(self, db, org, operator, membership_type, joiner):
+        """The real exposure in the issue: an operator active on a paid tier is
+        inside the population a membership-fee run charges."""
+        from app.domains.billing.schemas import GenerateMembershipFeesRequest
+        from app.domains.billing.service import generate_membership_fees
+
+        receipts = generate_membership_fees(
+            db,
+            GenerateMembershipFeesRequest(
+                billing_period_start=date(2027, 1, 1),
+                billing_period_end=date(2027, 12, 31),
+                emission_date=date(2027, 1, 1),
+                due_date=date(2027, 1, 31),
+            ),
+            created_by_id=operator.id,
+        )
+
+        billed = {r.member_id for r in receipts}
+        operator_members = {
+            m.id for m in db.query(Member).filter(Member.user_id == operator.id).all()
+        }
+        assert operator_members == set()
+        assert billed and operator_members.isdisjoint(billed)

--- a/backend/tests/integration/api/v1/test_oauth_sso.py
+++ b/backend/tests/integration/api/v1/test_oauth_sso.py
@@ -91,6 +91,15 @@ class TestFirstTimeSsoSignIn:
         assert member.status == "pending"
         assert member.member_number is None
 
+    def test_sso_signup_grants_the_member_role(self, db):
+        """`member` is opt-in since #168; signing up through a provider is
+        still a member signing up, so this path names it."""
+        _ensure_membership_type(db)
+
+        user, _ = find_or_create_from_oauth(db, _profile())
+
+        assert {r.slug for r in user.roles} == {"member"}
+
     def test_links_the_identity_to_the_new_user(self, db):
         _ensure_membership_type(db)
 

--- a/backend/tests/integration/api/v1/test_registration_flow.py
+++ b/backend/tests/integration/api/v1/test_registration_flow.py
@@ -129,6 +129,19 @@ class TestRegistrationCreatesPendingMember:
         assert member.status == "pending"
         assert member.member_number is None
 
+    def test_register_grants_the_member_role(self, client, db):
+        """`member` is opt-in since #168, so self-registration has to ask for
+        it. Without this the account authenticates and 403s on its own portal."""
+        _register(client, db)
+
+        user = (
+            db.query(User)
+            .filter(User.email == REGISTER_PAYLOAD["email"])
+            .one()
+        )
+
+        assert {r.slug for r in user.roles} == {"member"}
+
     def test_register_issues_verification_token_and_leaves_email_unverified(
         self, client, db
     ):

--- a/backend/tests/integration/api/v1/test_roles_api.py
+++ b/backend/tests/integration/api/v1/test_roles_api.py
@@ -213,7 +213,7 @@ class TestEscalationGuard:
         )
 
         assert r.status_code == 200
-        assert {x["slug"] for x in r.json()["roles"]} == {"admin", "member"}
+        assert {x["slug"] for x in r.json()["roles"]} == {"admin"}
 
     def test_assignable_flag_agrees_with_what_put_accepts(self, client, db):
         _ensure_org(db)
@@ -226,7 +226,7 @@ class TestEscalationGuard:
         assert by_slug["member"]["assignable"] is True
 
 
-class TestMemberPinAndEmptySet:
+class TestMemberRoleAndEmptySet:
     def test_an_empty_role_set_is_rejected(self, client, db):
         _ensure_org(db)
         boss = _user(db, "super_admin")
@@ -241,7 +241,9 @@ class TestMemberPinAndEmptySet:
         assert r.status_code == 400
         assert r.json()["detail"]["code"] == "roles_required"
 
-    def test_member_is_re_added_when_the_payload_omits_it(self, client, db):
+    def test_member_is_removed_when_the_payload_omits_it(self, client, db):
+        """#168: `member` used to be re-added here, so an admin could never
+        take it off through the UI or the API."""
         _ensure_org(db)
         boss = _user(db, "super_admin")
         target = _user(db, "member", email="pin-omitted@examplee6e3b1.com")
@@ -254,7 +256,25 @@ class TestMemberPinAndEmptySet:
         )
 
         assert r.status_code == 200
-        assert "member" in {x["slug"] for x in r.json()["roles"]}
+        assert {x["slug"] for x in r.json()["roles"]} == {"admin"}
+
+    def test_the_removal_survives_a_re_read(self, client, db):
+        """The write and the read-back are separate paths; the old pin made
+        the second one put the role straight back."""
+        _ensure_org(db)
+        boss = _user(db, "super_admin")
+        target = _user(db, "member", email="pin-stays-off@examplee6e3b1.com")
+        admin_role = db.query(Role).filter_by(slug="admin").one()
+
+        client.put(
+            f"/api/v1/users/{target.id}/roles",
+            json={"role_ids": [admin_role.id]},
+            cookies=_auth_cookie(boss),
+        )
+
+        body = client.get("/api/v1/auth/me", cookies=_auth_cookie(target)).json()
+
+        assert {r["slug"] for r in body["roles"]} == {"admin"}
 
     def test_the_last_super_admin_cannot_be_demoted(self, client, db):
         _ensure_org(db)
@@ -279,7 +299,7 @@ class TestAuthMePayload:
         body = client.get("/api/v1/auth/me", cookies=_auth_cookie(admin)).json()
 
         assert "role" not in body
-        assert {r["slug"] for r in body["roles"]} == {"admin", "member"}
+        assert {r["slug"] for r in body["roles"]} == {"admin"}
         assert "members.write" in body["permissions"]
         assert "roles.write" not in body["permissions"]
 
@@ -356,7 +376,7 @@ class TestAuditTrail:
             .filter(AuditLog.table_name == "user_roles", AuditLog.record_id == target.id)
             .one()
         )
-        assert row.changed_fields == ["+admin"]
+        assert row.changed_fields == ["+admin", "-member"]
         assert row.user_id == boss.id
 
     def test_a_refused_assignment_records_nothing(self, client, db):

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -163,10 +163,13 @@ def _install_role_assignment_hook(session):
 
     ``users.role`` is gone, so ``User(role="admin")`` would be a TypeError.
     Tests keep writing it as fixture shorthand: ``User.__init__`` pops the kwarg
-    and the flush hook turns it into real ``user_roles`` rows — ``member``
-    always (it is pinned to every account), plus the named staff role. Tests
-    build users directly rather than through registration, so without this
-    nothing would populate ``user_roles`` and every check would deny.
+    and the flush hook turns it into real ``user_roles`` rows. It grants exactly
+    what it names, because `member` is no longer a floor every account holds
+    (#168) — ``role="admin"`` is a staff account with no membership, which is
+    the shape that issue is about. Pass a tuple, ``role=("admin", "member")``,
+    for the person who is genuinely both. Tests build users directly rather
+    than through registration, so without this nothing would populate
+    ``user_roles`` and every check would deny.
     """
     from sqlalchemy import event, text
 
@@ -185,7 +188,8 @@ def _install_role_assignment_hook(session):
         for user in pending:
             if user.role_assignments:
                 continue
-            slugs = {"member", getattr(user, "_fixture_role", "member")}
+            named = getattr(user, "_fixture_role", "member")
+            slugs = {named} if isinstance(named, str) else set(named)
             user.role_assignments = [
                 UserRoleAssignment(role_id=role_ids[slug])
                 for slug in sorted(slugs)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -188,7 +188,14 @@ def _install_role_assignment_hook(session):
         for user in pending:
             if user.role_assignments:
                 continue
-            named = getattr(user, "_fixture_role", "member")
+            named = getattr(user, "_fixture_role", None)
+            # No `role=` means the account was built by the code under test —
+            # registration, SSO, seeding — which assigns its own roles right
+            # after this flush. Fabricating one here would put `member` back on
+            # the staff accounts #168 takes it off, and the test would be
+            # asserting against the shim rather than the app.
+            if named is None:
+                continue
             slugs = {named} if isinstance(named, str) else set(named)
             user.role_assignments = [
                 UserRoleAssignment(role_id=role_ids[slug])
@@ -201,7 +208,8 @@ def _accept_fixture_role_kwarg():
     original_init = User.__init__
 
     def __init__(self, **kwargs):
-        self._fixture_role = kwargs.pop("role", "member")
+        if "role" in kwargs:
+            self._fixture_role = kwargs.pop("role")
         original_init(self, **kwargs)
 
     User.__init__ = __init__

--- a/backend/tests/integration/test_authorization_parity.py
+++ b/backend/tests/integration/test_authorization_parity.py
@@ -56,10 +56,11 @@ class TestLegacyRoleParity:
         assert resolve_permissions(user) == set(MEMBER_SEED_KEYS)
 
     def test_restricted_lands_on_member_with_no_staff_reach(self, db):
-        """The tier is gone; a hand-provisioned account backfills to `member`.
-        Its two real capabilities — everyone's custom-field values, cancel any
-        booking — are deliberately lost."""
-        user = _user(db, "parity-restricted@examplee6e3b1.com", "restricted")
+        """The tier is gone; a hand-provisioned account backfills to `member`,
+        which is what the fixture holds here. Its two real capabilities —
+        everyone's custom-field values, cancel any booking — are deliberately
+        lost."""
+        user = _user(db, "parity-restricted@examplee6e3b1.com", "member")
 
         held = resolve_permissions(user)
 

--- a/backend/tests/integration/test_roles.py
+++ b/backend/tests/integration/test_roles.py
@@ -60,15 +60,16 @@ class TestResolutionAgainstTheDatabase:
         assert held == set(MEMBER_SEED_KEYS)
         assert not is_staff(held)
 
-    def test_every_account_holds_member(self, db):
+    def test_a_staff_account_does_not_hold_member(self, db):
+        """Was the opposite until #168: `member` used to be pinned to every
+        account, which put operators in the club's member register."""
         for email, role in (
             ("pin-super@examplee6e3b1.com", "super_admin"),
             ("pin-admin@examplee6e3b1.com", "admin"),
-            ("pin-member@examplee6e3b1.com", "member"),
         ):
             user = _user(db, email, role=role)
 
-            assert "member" in {r.slug for r in user.roles}
+            assert {r.slug for r in user.roles} == {role}
 
     def test_staff_accounts_also_hold_the_self_namespace(self, db):
         user = _user(db, "staff-self@examplee6e3b1.com", role="admin")
@@ -77,8 +78,31 @@ class TestResolutionAgainstTheDatabase:
 
 
 class TestAssignRoles:
-    def test_assigns_member_by_default(self, db):
+    def test_assigns_only_the_roles_it_is_named(self, db):
         user = _user(db, "assign-1@examplee6e3b1.com")
+        db.query(UserRoleAssignment).filter_by(user_id=user.id).delete()
+        db.expire(user)
+
+        assign_roles(db, user, "member")
+        db.flush()
+        db.refresh(user)
+
+        assert {r.slug for r in user.roles} == {"member"}
+
+    def test_a_staff_role_does_not_drag_member_along(self, db):
+        """The #168 invariant: administering the instance is not membership."""
+        user = _user(db, "assign-staff@examplee6e3b1.com")
+        db.query(UserRoleAssignment).filter_by(user_id=user.id).delete()
+        db.expire(user)
+
+        assign_roles(db, user, "admin")
+        db.flush()
+        db.refresh(user)
+
+        assert {r.slug for r in user.roles} == {"admin"}
+
+    def test_naming_nothing_assigns_nothing(self, db):
+        user = _user(db, "assign-none@examplee6e3b1.com")
         db.query(UserRoleAssignment).filter_by(user_id=user.id).delete()
         db.expire(user)
 
@@ -86,7 +110,18 @@ class TestAssignRoles:
         db.flush()
         db.refresh(user)
 
-        assert {r.slug for r in user.roles} == {"member"}
+        assert user.roles == []
+
+    def test_both_roles_can_be_held_together(self, db):
+        user = _user(db, "assign-both@examplee6e3b1.com")
+        db.query(UserRoleAssignment).filter_by(user_id=user.id).delete()
+        db.expire(user)
+
+        assign_roles(db, user, "admin", "member")
+        db.flush()
+        db.refresh(user)
+
+        assert sorted(r.slug for r in user.roles) == ["admin", "member"]
 
     def test_is_idempotent(self, db):
         user = _user(db, "assign-2@examplee6e3b1.com", role="admin")
@@ -95,7 +130,7 @@ class TestAssignRoles:
         db.flush()
         db.refresh(user)
 
-        assert sorted(r.slug for r in user.roles) == ["admin", "member"]
+        assert sorted(r.slug for r in user.roles) == ["admin"]
 
 
 class TestRoleDeletionIsRestricted:

--- a/backend/tests/integration/test_seed_reset.py
+++ b/backend/tests/integration/test_seed_reset.py
@@ -19,7 +19,9 @@ from app.cli.seed import (
     _run_unattended,
     any_admin_user_id,
     create_org_settings,
+    create_staff_user,
     create_user_with_member,
+    next_member_number,
     restore_member_records,
     seed_address_types,
     seed_contact_types,
@@ -65,6 +67,24 @@ def _account(email, role, membership_type, db):
         role,
         membership_type,
     )
+    return db.query(User).filter_by(email=email).one()
+
+
+def _staff(email, role, db):
+    create_staff_user(
+        db,
+        {
+            "first_name": "Test",
+            "last_name": "Operator",
+            "email": email,
+            "password": "correct horse battery staple",
+        },
+        role,
+    )
+    # `roles` is a selectin relationship loaded when the row was first flushed,
+    # before its assignments existed; without this the test reads the empty set
+    # that load cached rather than what the seed wrote.
+    db.expire_all()
     return db.query(User).filter_by(email=email).one()
 
 
@@ -181,7 +201,10 @@ class TestResetClears:
 
         assert second == {}
 
-    def test_survivors_get_their_member_record_back(self, db):
+    def test_a_promoted_member_gets_their_member_record_back(self, db):
+        """The case `restore_member_records` still covers after #168: an account
+        that was a member first and was granted `super_admin` afterwards holds
+        both roles, and a reset would otherwise leave the role with no row."""
         membership_type = _base_install(db)
         keeper = _account("owner@example.org", "super_admin", membership_type, db)
 
@@ -192,6 +215,74 @@ class TestResetClears:
         member = db.query(Member).filter_by(person_id=keeper.person_id).one()
         assert member.user_id == keeper.id
         assert member.status == "active"
+
+
+class TestStaffAreNotMembers:
+    """#168: an account that administers the instance is not in the club.
+
+    The register used to open with the operator on M-0001, who was `active` on
+    whatever tier the setup picked — inside every member count, every export,
+    and the population a billing run charges.
+    """
+
+    def test_a_seeded_super_admin_has_no_member_record(self, db):
+        _base_install(db)
+
+        user = _staff("owner@example.org", SUPER_ADMIN_SLUG, db)
+
+        assert db.query(Member).filter_by(person_id=user.person_id).first() is None
+        assert {r.slug for r in user.roles} == {SUPER_ADMIN_SLUG}
+
+    def test_a_seeded_club_admin_has_no_member_record(self, db):
+        _base_install(db)
+
+        user = _staff("club@example.org", "admin", db)
+
+        assert db.query(Member).filter_by(person_id=user.person_id).first() is None
+        assert {r.slug for r in user.roles} == {"admin"}
+
+    def test_the_first_real_member_gets_m_0001(self, db):
+        """The visible symptom in the issue: the operator took M-0001, so the
+        club's first actual member started at M-0002."""
+        membership_type = _base_install(db)
+        _staff("owner@example.org", SUPER_ADMIN_SLUG, db)
+
+        joiner = _account("first@example.org", MEMBER_SLUG, membership_type, db)
+
+        member = db.query(Member).filter_by(person_id=joiner.person_id).one()
+        assert member.member_number == "M-0001"
+
+    def test_the_register_is_empty_before_anyone_joins(self, db):
+        _base_install(db)
+        _staff("owner@example.org", SUPER_ADMIN_SLUG, db)
+        _staff("club@example.org", "admin", db)
+
+        assert db.query(Member).count() == 0
+        assert next_member_number(db) == "M-0001"
+
+    def test_an_unattended_install_leaves_the_register_empty(self, db, monkeypatch):
+        """The whole path an operator actually runs, not just the helper."""
+        membership_type = _base_install(db)
+        monkeypatch.setenv("MEMSHIP_ADMIN_PASSWORD", "correct horse battery staple")
+
+        _run_unattended(db, membership_type, _args(admin_email="owner@example.org"))
+
+        db.expire_all()
+        user = db.query(User).filter_by(email="owner@example.org").one()
+        assert {r.slug for r in user.roles} == {SUPER_ADMIN_SLUG}
+        assert db.query(Member).count() == 0
+
+    def test_a_reset_does_not_hand_a_staff_account_a_membership(self, db):
+        """`restore_member_records` used to give every surviving super admin a
+        member record, which is how the shape came back after every reset."""
+        _base_install(db)
+        keeper = _staff("owner@example.org", SUPER_ADMIN_SLUG, db)
+
+        reset_club_data(db)
+        membership_type = seed_membership_types(db, seed_groups(db))
+        restore_member_records(db, super_admin_users(db), membership_type)
+
+        assert db.query(Member).filter_by(person_id=keeper.person_id).first() is None
 
 
 class TestCreatedByResolution:

--- a/backend/tests/integration/test_staff_member_migration.py
+++ b/backend/tests/integration/test_staff_member_migration.py
@@ -1,0 +1,217 @@
+"""`e2f3a4b5c6d7`, run for real against a throwaway database.
+
+Taking staff out of the member register is a delete, so the interesting cases
+are the ones it must *not* touch: a plain member, and a staff account whose
+member row is referenced by billing it would be wrong to silently unpick.
+
+The rest of the suite builds its schema with ``create_all`` and never runs
+alembic, so nothing else would notice if this regressed on an install that
+upgrades rather than starts fresh.
+"""
+
+import os
+from datetime import date
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+from app.core.config import settings
+
+BEFORE = "9c1d2e3f4a5b"
+STAFF_OUT = "e2f3a4b5c6d7"
+
+BASE_URL = os.getenv("DATABASE_TEST_URL", settings.DATABASE_TEST_URL)
+_WORKER = os.getenv("PYTEST_XDIST_WORKER", "master")
+SCRATCH = f"memship_staff_member_migration_test_{_WORKER}"
+
+
+def _server_url() -> str:
+    return BASE_URL.rsplit("/", 1)[0] + "/postgres"
+
+
+def _scratch_url() -> str:
+    return BASE_URL.rsplit("/", 1)[0] + f"/{SCRATCH}"
+
+
+def _alembic_at(revision: str) -> None:
+    """Migrate the scratch database, not whatever ``DATABASE_URL`` points at.
+
+    ``alembic/env.py`` overrides the configured URL from the environment, so
+    without setting it here CI would migrate the shared test database that
+    hundreds of other tests are using concurrently.
+    """
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", _scratch_url())
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = _scratch_url()
+    try:
+        command.upgrade(cfg, revision)
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+@pytest.fixture(scope="module")
+def scratch_db():
+    admin = sa.create_engine(_server_url(), isolation_level="AUTOCOMMIT")
+    try:
+        with admin.connect() as conn:
+            conn.execute(sa.text(f'DROP DATABASE IF EXISTS "{SCRATCH}" WITH (FORCE)'))
+            conn.execute(sa.text(f'CREATE DATABASE "{SCRATCH}"'))
+    except sa.exc.OperationalError as exc:
+        pytest.skip(f"no database server for the migration test: {exc}")
+
+    engine = sa.create_engine(_scratch_url())
+    yield engine
+
+    engine.dispose()
+    with admin.connect() as conn:
+        conn.execute(sa.text(f'DROP DATABASE IF EXISTS "{SCRATCH}" WITH (FORCE)'))
+    admin.dispose()
+
+
+def _account(conn, email: str, slugs: tuple[str, ...], membership_type_id: int) -> int:
+    """An account in the shape the old code produced: roles plus a member row."""
+    person_id = conn.execute(
+        sa.text(
+            "INSERT INTO persons (first_name, last_name, email) "
+            "VALUES ('Legacy', 'Account', :e) RETURNING id"
+        ),
+        {"e": email},
+    ).scalar_one()
+    user_id = conn.execute(
+        sa.text(
+            "INSERT INTO users (person_id, email, password_hash, is_active) "
+            "VALUES (:p, :e, 'x', true) RETURNING id"
+        ),
+        {"p": person_id, "e": email},
+    ).scalar_one()
+    for slug in slugs:
+        conn.execute(
+            sa.text(
+                "INSERT INTO user_roles (user_id, role_id) "
+                "SELECT :u, id FROM roles WHERE slug = :s"
+            ),
+            {"u": user_id, "s": slug},
+        )
+    member_id = conn.execute(
+        sa.text(
+            "INSERT INTO members (person_id, user_id, membership_type_id, "
+            "member_number, status, joined_at) "
+            "VALUES (:p, :u, :mt, :n, 'active', :d) RETURNING id"
+        ),
+        {
+            "p": person_id,
+            "u": user_id,
+            "mt": membership_type_id,
+            "n": f"M-{user_id:04d}",
+            "d": date(2026, 1, 1),
+        },
+    ).scalar_one()
+    return member_id
+
+
+@pytest.fixture(scope="module")
+def migrated(scratch_db):
+    """Build the pre-#168 world at the revision before the fix, then upgrade."""
+    _alembic_at(BEFORE)
+
+    with scratch_db.begin() as conn:
+        membership_type_id = conn.execute(
+            sa.text(
+                "INSERT INTO membership_types (name, slug, base_price, billing_frequency) "
+                "VALUES ('Legacy Full', 'legacy-full', 50, 'annual') RETURNING id"
+            )
+        ).scalar_one()
+
+        _account(conn, "super@migration.test", ("super_admin", "member"), membership_type_id)
+        _account(conn, "admin@migration.test", ("admin", "member"), membership_type_id)
+        _account(conn, "member@migration.test", ("member",), membership_type_id)
+
+        billed = _account(
+            conn, "billed-admin@migration.test", ("admin", "member"), membership_type_id
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO receipts (receipt_number, member_id, origin, description, "
+                "base_amount, vat_rate, vat_amount, total_amount, status, emission_date, "
+                "is_batchable, is_active) "
+                "VALUES ('R-0001', :m, 'membership', 'Legacy fee', 100, 0, 0, 100, "
+                "'paid', :d, false, true)"
+            ),
+            {"m": billed, "d": date(2026, 1, 15)},
+        )
+
+    _alembic_at(STAFF_OUT)
+    return scratch_db
+
+
+def _roles(engine, email: str) -> set[str]:
+    with engine.connect() as conn:
+        return {
+            slug
+            for (slug,) in conn.execute(
+                sa.text(
+                    "SELECT r.slug FROM users u "
+                    "JOIN user_roles ur ON ur.user_id = u.id "
+                    "JOIN roles r ON r.id = ur.role_id "
+                    "WHERE u.email = :e"
+                ),
+                {"e": email},
+            ).all()
+        }
+
+
+def _has_member_row(engine, email: str) -> bool:
+    with engine.connect() as conn:
+        return conn.execute(
+            sa.text(
+                "SELECT count(*) FROM members m JOIN users u ON u.id = m.user_id "
+                "WHERE u.email = :e"
+            ),
+            {"e": email},
+        ).scalar_one() > 0
+
+
+class TestStaffLeaveTheRegister:
+    @pytest.mark.parametrize(
+        "email,role",
+        [("super@migration.test", "super_admin"), ("admin@migration.test", "admin")],
+    )
+    def test_the_member_record_and_role_both_go(self, migrated, email, role):
+        assert _has_member_row(migrated, email) is False
+        assert _roles(migrated, email) == {role}
+
+    def test_the_staff_role_survives_so_nothing_holds_no_roles(self, migrated):
+        for email in ("super@migration.test", "admin@migration.test"):
+            assert _roles(migrated, email) != set()
+
+
+class TestWhatItMustNotTouch:
+    def test_a_plain_member_keeps_everything(self, migrated):
+        assert _has_member_row(migrated, "member@migration.test") is True
+        assert _roles(migrated, "member@migration.test") == {"member"}
+
+    def test_a_staff_account_with_billing_is_left_for_a_person_to_sort_out(
+        self, migrated
+    ):
+        """The receipt would make the delete fail outright, and an account with
+        billing history behind it is a decision, not a migration's business.
+        Role and row stay together rather than half-applying."""
+        assert _has_member_row(migrated, "billed-admin@migration.test") is True
+        assert _roles(migrated, "billed-admin@migration.test") == {"admin", "member"}
+
+    def test_the_receipt_still_points_at_its_member(self, migrated):
+        with migrated.connect() as conn:
+            orphans = conn.execute(
+                sa.text(
+                    "SELECT count(*) FROM receipts r "
+                    "LEFT JOIN members m ON m.id = r.member_id WHERE m.id IS NULL"
+                )
+            ).scalar_one()
+
+        assert orphans == 0

--- a/e2e/cypress/e2e/roles/admin-without-member.cy.ts
+++ b/e2e/cypress/e2e/roles/admin-without-member.cy.ts
@@ -1,0 +1,97 @@
+/// <reference types="cypress" />
+
+// An operator account administers the instance without belonging to the club
+// (#168): `super@` and `admin@` are seeded with their staff role and no member
+// record at all.
+//
+// The two halves pull against each other, and the second is the one that would
+// be quietly lost. The member surface has to disappear — but it cannot be hidden
+// by withholding `self.*`, because those keys are the floor on every route staff
+// and members share (`/members/{id}`, the receipt PDFs). A staff role holds all
+// of them and must keep holding them. What the nav hangs off is the member
+// record, which an operator does not have.
+const navLink = (path: string) => `[data-slot="sidebar"] a[href="/en${path}"]`;
+
+describe("An operator account is not a club member", { tags: ["@roles"] }, () => {
+  beforeEach(() => {
+    cy.loginAsSuperAdmin();
+  });
+
+  it("lands on the dashboard and renders it", { tags: ["@smoke"] }, () => {
+    cy.url().should("include", "/dashboard");
+    cy.get("main").should("be.visible");
+  });
+
+  it("has none of the member nav", () => {
+    cy.get(navLink("/my-activities")).should("not.exist");
+    cy.get(navLink("/my-bookings")).should("not.exist");
+    cy.get(navLink("/my-membership")).should("not.exist");
+    cy.get(navLink("/my-receipts")).should("not.exist");
+    cy.get(navLink("/my-card")).should("not.exist");
+  });
+
+  it("keeps the staff nav it administers with", () => {
+    cy.get(navLink("/members")).should("exist");
+    cy.get(navLink("/receipts")).should("exist");
+    cy.get(navLink("/activities")).should("exist");
+    cy.get(navLink("/settings")).should("exist");
+  });
+
+  it("says so on the membership page rather than spinning", () => {
+    // Reachable by URL even with no nav entry. It used to wait on a member that
+    // never arrives and render its skeleton for good.
+    cy.visit("/en/my-membership");
+    cy.contains("not a club member").should("be.visible");
+  });
+
+  it("still has a profile page, without the club facts", () => {
+    // The account has a person even though it has no member: name and email
+    // render, the member number and the status badge do not.
+    cy.visit("/en/profile");
+    cy.contains("super@examplee6e3b1.com").should("be.visible");
+    cy.contains("Member Number").should("not.exist");
+  });
+
+  it("can still open a member and the register", () => {
+    // The regression guard. Both routes are gated on a `self.*` key and widened
+    // by an administrative one, so they break the moment `self.*` stops being
+    // granted to staff — which is the obvious-looking way to hide the member nav.
+    cy.visit("/en/members");
+    cy.get("table tbody tr").should("have.length.greaterThan", 0);
+    cy.get("table tbody tr").first().click();
+    cy.url().should("match", /\/members\/\d+/);
+  });
+});
+
+describe("A club admin is not a club member either", { tags: ["@roles"] }, () => {
+  beforeEach(() => {
+    cy.loginAsAdmin();
+  });
+
+  it("has no member nav but keeps the register", () => {
+    cy.get(navLink("/my-receipts")).should("not.exist");
+    cy.get(navLink("/members")).should("exist");
+  });
+});
+
+describe("A member still has everything", { tags: ["@roles"] }, () => {
+  beforeEach(() => {
+    cy.loginAsMember();
+  });
+
+  it("sees the member nav", () => {
+    cy.get(navLink("/my-activities")).should("exist");
+    cy.get(navLink("/my-receipts")).should("exist");
+    cy.get(navLink("/my-membership")).should("exist");
+  });
+
+  it("sees its plan, not the operator's empty state", () => {
+    cy.visit("/en/my-membership");
+    cy.contains("not a club member").should("not.exist");
+  });
+
+  it("sees its member number on its profile", () => {
+    cy.visit("/en/profile");
+    cy.contains("Member Number").should("be.visible");
+  });
+});

--- a/e2e/cypress/e2e/roles/permission-driven-nav.cy.ts
+++ b/e2e/cypress/e2e/roles/permission-driven-nav.cy.ts
@@ -2,8 +2,9 @@
 
 // The one place the whole chain runs as a single thing: catalog → role →
 // assignment → per-request resolution (no role claim in the JWT) → /auth/me →
-// has(key) → rendered sidebar. treasurer@examplee6e3b1.com holds `billing.*` and the
-// pinned `member` role, and nothing else.
+// has(key) → rendered sidebar. treasurer@examplee6e3b1.com holds `billing.*` and
+// the `member` role, and nothing else — a club officer who is also a member,
+// which is why it keeps its personal nav while the admin accounts do not.
 //
 // Assertions go through hrefs rather than labels: "Receipts" is a substring of
 // "My Receipts", and telling the staff item from the personal one is the whole
@@ -31,7 +32,7 @@ describe("Permission-driven nav", { tags: ["@roles"] }, () => {
     cy.get(navLink("/annual-summary")).should("not.exist");
   });
 
-  it("keeps its personal nav, because `member` is pinned", () => {
+  it("keeps its personal nav, because it is a member as well as an officer", () => {
     // The regression this guards: one administrative permission used to flip
     // the sidebar to the staff shape wholesale and take the self-service items
     // with it, even though the account still held every `self.*` key.
@@ -93,8 +94,15 @@ describe("Permission-driven nav — full admin", { tags: ["@roles"] }, () => {
     cy.get(navLink("/activities")).should("have.length", 1);
   });
 
-  it("also has its own member surface — staff are members too", () => {
-    cy.get(navLink("/my-receipts")).should("exist");
+  it("has no member surface, because an operator is not in the club", () => {
+    // Was the opposite until #168, when `member` was pinned to every account
+    // and an admin carried a member number and a place in the billing run.
+    // The nav hangs off the member record, not off `self.*` — a staff role
+    // holds every `self.*` key and always will, because those are the floor on
+    // the endpoints staff and members share.
+    cy.get(navLink("/my-receipts")).should("not.exist");
+    cy.get(navLink("/my-activities")).should("not.exist");
+    cy.get(navLink("/my-membership")).should("not.exist");
   });
 });
 

--- a/frontend/app/[locale]/(portal)/activities/[id]/page.tsx
+++ b/frontend/app/[locale]/(portal)/activities/[id]/page.tsx
@@ -59,8 +59,11 @@ export default function ActivityDetailPage({
   const canReadRegistrations = has("registrations.read");
 
   const { data: activity, isLoading } = useActivity(activityId);
-  const { data: eligibility } = useEligibility(activityId);
-  const { data: myRegs } = useMyRegistrations();
+  // Both are about *this account's* relationship to the activity, which an
+  // operator account does not have (#168) — the endpoints refuse it.
+  const isMember = user?.member_id != null;
+  const { data: eligibility } = useEligibility(activityId, isMember);
+  const { data: myRegs } = useMyRegistrations({}, isMember);
   const updateMutation = useUpdateActivity();
   const deleteMutation = useDeleteActivity();
   const publishMutation = usePublishActivity();

--- a/frontend/app/[locale]/(portal)/activities/page.tsx
+++ b/frontend/app/[locale]/(portal)/activities/page.tsx
@@ -72,7 +72,10 @@ export default function ActivitiesPage() {
     search: search || undefined,
     status: isAdmin ? statusFilter || undefined : "published",
   });
-  const { data: myRegs } = useMyRegistrations();
+  // Only a member has registrations. An operator account has none (#168) and
+  // the endpoint refuses it, so asking is a guaranteed 403 on a page admins
+  // open constantly.
+  const { data: myRegs } = useMyRegistrations({}, user?.member_id != null);
 
   return (
     <div className="space-y-4">

--- a/frontend/app/[locale]/(portal)/dashboard/page.tsx
+++ b/frontend/app/[locale]/(portal)/dashboard/page.tsx
@@ -374,16 +374,23 @@ export default function DashboardPage() {
   const { data: regStats } = useRegistrationStats(canReadRegistrations);
   const { data: receiptStats } = useReceiptStats(canReadBilling);
 
-  // Member: my registrations + receipts
+  // Member: my registrations + receipts. Gated the same way the staff cards
+  // above are — an operator account has no member record (#168), so these two
+  // would be a pair of guaranteed 403s on every dashboard load.
+  const isMember = user?.member_id != null;
   const { data: myRegistrations } = useMyRegistrations(
-    !isAdmin ? { per_page: 5 } : {}
+    !isAdmin ? { per_page: 5 } : {},
+    !isAdmin && isMember
   );
   const myReceiptsParams = useMemo(() => {
     const p = new URLSearchParams();
     p.set("per_page", "5");
     return p;
   }, []);
-  const { data: myReceipts } = useMyReceipts(!isAdmin ? myReceiptsParams : undefined);
+  const { data: myReceipts } = useMyReceipts(
+    !isAdmin ? myReceiptsParams : undefined,
+    !isAdmin && isMember
+  );
 
   const memberCounters = useMemo<CounterItem[]>(() => [
     { label: t("status.active"), value: activeMembers?.meta.total ?? 0, color: MEMBER_COLORS.active },

--- a/frontend/app/[locale]/(portal)/my-membership/page.tsx
+++ b/frontend/app/[locale]/(portal)/my-membership/page.tsx
@@ -41,6 +41,10 @@ export default function MyMembershipPage() {
   // dialog closes rather than after the receipt list has refetched.
   const [justPurchased, setJustPurchased] = useState<MembershipPurchaseData | null>(null);
 
+  // An operator account has no membership to show (#168). `useMember` is
+  // already inert on 0, so the page has to answer for itself rather than wait
+  // on a member that never arrives.
+  const isMember = user?.member_id != null;
   const { data: member, isLoading: memberLoading } = useMember(user?.member_id || 0);
   const { data: plans, isLoading: plansLoading } = useMembershipTypes();
 
@@ -112,6 +116,17 @@ export default function MyMembershipPage() {
     } catch {
       /* global handler */
     }
+  }
+
+  if (!isMember) {
+    return (
+      <div className="space-y-3">
+        <h1 className="text-2xl font-bold">{t("membership.nav")}</h1>
+        <div className="py-8 text-center text-muted-foreground">
+          {t("membership.notAMember")}
+        </div>
+      </div>
+    );
   }
 
   if (memberLoading || !member) return <FormSkeleton />;

--- a/frontend/app/[locale]/(portal)/profile/page.tsx
+++ b/frontend/app/[locale]/(portal)/profile/page.tsx
@@ -75,6 +75,11 @@ export default function ProfilePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user } = useAuth();
+  // An operator account administers the instance without belonging to the club
+  // (#168), so it has a person but no member record. `useMember` is already
+  // inert on 0, but without this the page waited on a member that never loads
+  // and rendered its skeleton for good.
+  const isMember = user?.member_id != null;
   const { data: member, isLoading } = useMember(user?.member_id || 0);
   const { data: profile, isLoading: profileLoading } = useMyProfile();
   const { data: settings } = useSettings();
@@ -93,11 +98,13 @@ export default function ProfilePage() {
     }
   }, [profile]);
 
-  if (isLoading || profileLoading || !member) {
+  if (profileLoading || (isMember && (isLoading || !member))) {
     return <FormSkeleton fields={5} />;
   }
 
-  const person = member.person;
+  // The club facts come from the member record; the rest of the page is about
+  // the person, which every account has.
+  const person = member?.person;
 
   function handleLocaleChange(newLocale: string) {
     router.replace(pathname, { locale: newLocale as Locale });
@@ -195,7 +202,9 @@ export default function ProfilePage() {
           },
         ]
       : []),
-    { id: "payment", label: t("paymentMethod.title"), content: <MyPaymentMethod /> },
+    ...(isMember
+      ? [{ id: "payment", label: t("paymentMethod.title"), content: <MyPaymentMethod /> }]
+      : []),
   ];
   const tabParam = searchParams.get("tab");
   const defaultTab = tabs.some((tab) => tab.id === tabParam)
@@ -206,7 +215,7 @@ export default function ProfilePage() {
     <div className="space-y-3">
       <div className="flex items-center gap-3">
         <h1 className="text-2xl font-bold">{t("nav.profile")}</h1>
-        <Badge>{t(`status.${member.status}`)}</Badge>
+        {member && <Badge>{t(`status.${member.status}`)}</Badge>}
       </div>
 
       {/* Compact member-info header: photo + read-only facts. */}
@@ -215,20 +224,24 @@ export default function ProfilePage() {
           <div className="grid gap-4 lg:grid-cols-[auto_1fr] lg:items-start lg:gap-8">
             <div className="flex justify-center lg:block">
               <MemberPhotoUpload
-                photoUrl={person.photo_url ?? null}
-                fullName={`${person.first_name} ${person.last_name}`}
+                photoUrl={person?.photo_url ?? user?.photo_url ?? null}
+                fullName={`${person?.first_name ?? user?.first_name ?? ""} ${person?.last_name ?? user?.last_name ?? ""}`}
               />
             </div>
             <dl className="grid content-start gap-x-8 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
-              <Field label={t("profile.firstName")} value={person.first_name} />
-              <Field label={t("profile.lastName")} value={person.last_name} />
-              <Field label={t("profile.email")} value={person.email} />
-              <Field label={t("profile.memberNumber")} value={member.member_number} />
-              <Field label={t("profile.membershipType")} value={member.membership_type_name} />
-              <Field label={t("profile.status")} value={t(`status.${member.status}`)} />
-              <Field label={t("profile.dateOfBirth")} value={person.date_of_birth ? formatDate(person.date_of_birth) : null} />
-              <Field label={t("profile.nationalId")} value={person.national_id} />
-              <Field label={t("profile.joinedAt")} value={formatDate(member.joined_at)} />
+              <Field label={t("profile.firstName")} value={person?.first_name ?? user?.first_name} />
+              <Field label={t("profile.lastName")} value={person?.last_name ?? user?.last_name} />
+              <Field label={t("profile.email")} value={person?.email ?? user?.email} />
+              {member && (
+                <>
+                  <Field label={t("profile.memberNumber")} value={member.member_number} />
+                  <Field label={t("profile.membershipType")} value={member.membership_type_name} />
+                  <Field label={t("profile.status")} value={t(`status.${member.status}`)} />
+                  <Field label={t("profile.dateOfBirth")} value={person?.date_of_birth ? formatDate(person.date_of_birth) : null} />
+                  <Field label={t("profile.nationalId")} value={person?.national_id} />
+                  <Field label={t("profile.joinedAt")} value={formatDate(member.joined_at)} />
+                </>
+              )}
             </dl>
           </div>
         </CardContent>

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -78,13 +78,20 @@ export function AppSidebar({ user }: AppSidebarProps) {
   // narrow custom role sees exactly what it can open. A feature flag and a
   // permission are ANDed: the flag says the club uses the feature at all.
   //
-  // **Additive, not either/or.** `member` is pinned to every account, so staff
-  // hold every `self.*` key too — an account that gains one administrative
-  // permission must not lose its personal nav. The staff groups are appended
-  // when the account is staff; the personal groups always render, gated on the
-  // `self.*` keys. `/activities` and `/dashboard` appear on both sides and are
-  // deduplicated below, first occurrence winning, so the staff catalog (which
-  // shows drafts) beats the member catalog for anyone holding both.
+  // **Additive, not either/or.** An account that gains one administrative
+  // permission must not lose its personal nav, so the staff groups are
+  // appended when the account is staff rather than replacing anything.
+  // `/activities` and `/dashboard` appear on both sides and are deduplicated
+  // below, first occurrence winning, so the staff catalog (which shows drafts)
+  // beats the member catalog for anyone holding both.
+  //
+  // The personal groups hang off `isMember`, not off the `self.*` keys. Those
+  // keys do not answer "is this person in the club": `ADMIN_SEED_KEYS` is the
+  // whole catalogue bar the reserved ones and a super admin resolves to all of
+  // it, so every staff account holds them — they are the floor on the routes
+  // staff and members share, which is why they cannot be taken away (#168).
+  // What separates the two is whether the account has a member record at all.
+  const isMember = user.member_id !== null && user.member_id !== undefined;
   const seenHrefs = new Set<string>();
   const navGroups = [
     [
@@ -115,17 +122,21 @@ export function AppSidebar({ user }: AppSidebarProps) {
           ],
         ]
       : []),
-    [
-      { href: "/activities", label: t("nav.activities"), icon: CalendarDays, show: has("self.activities.read") },
-      { href: "/book", label: t("bookings.navBook"), icon: MapPin, show: bookingsEnabled && has("self.bookings.write") },
-    ],
-    [
-      { href: "/my-activities", label: t("activities.registration.myActivities"), icon: ClipboardList, show: has("self.registrations.read") },
-      { href: "/my-bookings", label: t("bookings.navMyBookings"), icon: ClipboardList, show: bookingsEnabled && has("self.bookings.read") },
-      { href: "/my-membership", label: t("membership.nav"), icon: BadgeEuro, show: has("self.billing.read") },
-      { href: "/my-receipts", label: t("receipts.myReceipts"), icon: Receipt, show: has("self.billing.read") },
-      { href: "/my-card", label: t("nav.myCard"), icon: IdCard, show: cardEnabled && has("self.card.read") },
-    ],
+    ...(isMember
+      ? [
+          [
+            { href: "/activities", label: t("nav.activities"), icon: CalendarDays, show: has("self.activities.read") },
+            { href: "/book", label: t("bookings.navBook"), icon: MapPin, show: bookingsEnabled && has("self.bookings.write") },
+          ],
+          [
+            { href: "/my-activities", label: t("activities.registration.myActivities"), icon: ClipboardList, show: has("self.registrations.read") },
+            { href: "/my-bookings", label: t("bookings.navMyBookings"), icon: ClipboardList, show: bookingsEnabled && has("self.bookings.read") },
+            { href: "/my-membership", label: t("membership.nav"), icon: BadgeEuro, show: has("self.billing.read") },
+            { href: "/my-receipts", label: t("receipts.myReceipts"), icon: Receipt, show: has("self.billing.read") },
+            { href: "/my-card", label: t("nav.myCard"), icon: IdCard, show: cardEnabled && has("self.card.read") },
+          ],
+        ]
+      : []),
     ...(isAdmin
       ? [
           [

--- a/frontend/features/activities/hooks/use-registrations.ts
+++ b/frontend/features/activities/hooks/use-registrations.ts
@@ -15,11 +15,11 @@ import {
   type RegisterParams,
 } from "../services/registrations-api";
 
-export function useEligibility(activityId: number) {
+export function useEligibility(activityId: number, enabled = true) {
   return useQuery({
     queryKey: ["eligibility", activityId],
     queryFn: () => checkEligibility(activityId),
-    enabled: activityId > 0,
+    enabled: enabled && activityId > 0,
   });
 }
 
@@ -90,10 +90,14 @@ export function useRegistrationStats(enabled = true) {
   });
 }
 
-export function useMyRegistrations(params: { page?: number; per_page?: number } = {}) {
+export function useMyRegistrations(
+  params: { page?: number; per_page?: number } = {},
+  enabled = true,
+) {
   return useQuery({
     queryKey: ["my-registrations", params],
     queryFn: () => listMyRegistrations(params),
+    enabled,
   });
 }
 

--- a/frontend/features/receipts/hooks/use-receipts.ts
+++ b/frontend/features/receipts/hooks/use-receipts.ts
@@ -40,10 +40,11 @@ export function useReceiptStats(enabled = true) {
   });
 }
 
-export function useMyReceipts(params?: URLSearchParams) {
+export function useMyReceipts(params?: URLSearchParams, enabled = true) {
   return useQuery({
     queryKey: ["my-receipts", params?.toString()],
     queryFn: () => getMyReceipts(params),
+    enabled,
   });
 }
 

--- a/frontend/locales/ca/membership.json
+++ b/frontend/locales/ca/membership.json
@@ -3,6 +3,7 @@
     "title": "El meu pla de soci",
     "info": "Consulta el teu pla actual i contracta'n un altre. El pla s'activa quan es paga el rebut, no en triar-lo.",
     "nav": "El meu pla",
+    "notAMember": "Aquest compte administra la instància i no és soci del club, així que no té cap pla.",
     "currentPlan": "Pla actual",
     "noPlan": "Sense pla",
     "revertedNotice": "Ets al pla gratuït perquè va quedar una quota sense pagar. En pagar-la recuperaràs «{plan}».",

--- a/frontend/locales/en/membership.json
+++ b/frontend/locales/en/membership.json
@@ -3,6 +3,7 @@
     "title": "My membership plan",
     "info": "See the plan you hold and buy another. A plan activates when its receipt is paid, not when you choose it.",
     "nav": "My plan",
+    "notAMember": "This account administers the instance and is not a club member, so it holds no plan.",
     "currentPlan": "Current plan",
     "noPlan": "No plan",
     "revertedNotice": "You are on the free plan because a fee went unpaid. Paying it puts you back on \"{plan}\".",

--- a/frontend/locales/es/membership.json
+++ b/frontend/locales/es/membership.json
@@ -3,6 +3,7 @@
     "title": "Mi plan de socio",
     "info": "Consulta tu plan actual y contrata otro. El plan se activa cuando se paga el recibo, no al elegirlo.",
     "nav": "Mi plan",
+    "notAMember": "Esta cuenta administra la instancia y no es socia del club, así que no tiene ningún plan.",
     "currentPlan": "Plan actual",
     "noPlan": "Sin plan",
     "revertedNotice": "Estás en el plan gratuito porque quedó una cuota sin pagar. Al pagarla recuperarás «{plan}».",


### PR DESCRIPTION
Closes #168.

`member` was pinned to every account: `assign_roles` added it unconditionally and `replace_user_roles` re-added it to whatever an admin selected, so the role could not be taken off through the UI or the API either. A super admin was therefore a member of the club — a member number, a membership type, and a place in every member count, export and billing run. On a fresh install the register opened with the operator on M-0001 and the club's first actual member started at M-0002.

Four commits, each shippable on its own and each leaving the suite green.

## The correction that shaped the work

The issue's proposed fix said the sidebar needed no change, because it gates on `self.*` and those come from the `member` role. Both halves are wrong, and it matters — it is the difference between a two-line fix and this branch. Recorded in full [in a comment on #168](https://github.com/marcandreuf/memship/issues/168#issuecomment-5644038909):

- `authorization.py:23` — a super admin resolves to `ALL_KEYS`, every `self.*` key included.
- `permissions.py:98` — `ADMIN_SEED_KEYS` is the whole catalogue bar the reserved ones, so the `admin` role is seeded with all twelve `self.*` keys too.

And the obvious follow-up — take `self.*` away from staff — is worse. Those keys are the **floor** on the endpoints staff and members share: `members.py:152` admits the caller on `self.profile.read` and then widens to "any member" on `members.read`; `receipts.py:312` does the same for PDFs. `require_permission` is a dependency, so it runs before the handler. Withholding `self.*` would lock every admin out of the member register, the receipt PDFs, member photos and custom fields.

What actually separates the two is **whether the account has a member record** — already nullable end to end (`schemas.py:56`, `auth.py:357`, `auth-api.ts:26`) and never produced until now.

A dedicated "admin" membership type was considered and rejected: `MembershipType` is a billing tier, and `generate_membership_fees` bills every active member filtered only by frequency, so an admin on an "admin" tier would need explicit exclusions in the member list, the count, the exports, the annual summary and the billing run — and the bug returns with the sixth query that forgets one.

## What changed

**1 — `member` becomes opt-in** (`a5ebc9e`). `assign_roles` and `replace_user_roles` grant exactly what they are named. Self-registration, SSO sign-up and the member seeding paths now say `member` explicitly. Nothing changes observably; only where the decision is made.

**2 — staff are seeded outside the register** (`94fa96a`). `create_staff_user` makes the account and the role and stops. `restore_member_records` no longer hands every surviving super admin a membership after a reset — it still covers the account that was *promoted* rather than created. A migration brings existing installs into line.

**3 — one refusal for "no member record"** (`c838881`). Five routes disagreed: registrations answered 400, membership purchase and `/members/me/receipts` answered 404, the card and booking routes answered 403. `current_member_or_403` replaces all five.

**4 — the nav and the member pages hang off the member record** (`6a246e3`). The sidebar's personal groups gate on `member_id`. The profile page, four hooks, and the e2e specs follow.

`treasurer` deliberately stays a member: it is a club officer whose custom role grants `billing.*` only, so its `self.*` keys come from `member` and nowhere else — removing it would 403 the treasurer out of its own profile. It is also outside the issue's scope, which names super admin and club admin.

## Two changes worth a reviewer's attention

**API contract.** Three routes move from 400/404 to `403 {"code": "not_a_member"}`. The frontend does not branch on status for these — it reads `detail.code`, the pattern already used for `pending_approval` and `role_in_use` — so nothing downstream depended on the old codes.

**The migration deletes data.** It removes the member row and the `member` role assignment from staff accounts, but **leaves a row alone when a receipt or a SEPA mandate points at it**: those are the references that would make the delete fail outright, and an account with billing history is a decision for a person, not a migration. Run against the dev database, which had exactly that shape, it correctly left both staff accounts untouched. Bookings, registrations and announcement recipients cascade with the row.

## Verification

- **Backend: 1765 passed, 0 failures.** New: `test_admin_without_member.py`, `test_staff_member_migration.py` (runs alembic for real against a throwaway database), plus additions to the roles, seed and sign-up suites.
- **E2E: 216 of 217** against a production build (`test:parallel:prod`). The single failure is `bookings-flow.cy.ts` "member sees the booking calendar" — unrelated, predates this branch, and now filed as #182: its slot is created at `today + 2` while the calendar opens on the current week, so it passes Monday to Friday and fails at the weekend. It failed all three attempts on a Saturday.
- **Fresh seed, checked by hand:**

  ```
   id |            email            |      roles       | member_number |     plan
  ----+-----------------------------+------------------+---------------+------------
    1 | super@examplee6e3b1.com     | super_admin      |               |
    2 | admin@examplee6e3b1.com     | admin            |               |
    3 | member@examplee6e3b1.com    | member           | M-0001        | registered
    4 | treasurer@examplee6e3b1.com | member,treasurer | M-0002        | registered
  ```

  24 members in the register rather than 26, and the club's first member back on M-0001.
- **Against the running API**, as the admin-only super admin: login 200, `/auth/me` 200 with null member fields **and all 41 permissions including every `self.*`**, `/members/me/receipts` refused with the new code, `/members/1` and the register 200.

## Still needs a human pass

Two acceptance criteria on #168 are not the kind a test can close:

- a person who is both admin and member running two accounts with two addresses, with no cross-talk;
- clicking through the portal as an admin-only account, rather than trusting `admin-without-member.cy.ts` for it.

Keep or drop the `Closes #168` above depending on whether you want those done before it shuts.

## Note

The e2e suite could not run until `e2e/pnpm-workspace.yaml` was set to `allowBuilds: cypress: true` — pnpm 11 rejects the tracked file. I set it locally to run the suite and **restored the tracked file**; that toolchain decision is its own open thread and is not settled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
